### PR TITLE
Create experience evaluator for resume analysis pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ SkillSphere-AI/
 │   ├── evaluators/                  # AI/ML evaluation logic for resumes, matching, interviews
 │   │   ├── skillEvaluator.js        # Resume vs job skill comparison logic
 │   │   └── keywordEvaluator.js      # JD keyword relevance vs resume text
+│   │   ├── experienceEvaluator.js   # Candidate vs JD experience-level evaluation
+│   │       
 │   ├── resume-analysis/             # Resume scoring and feedback pipelines
 │   ├── jd-matching/                 # Similarity/matching workflows
 │   ├── interview-feedback/          # Interview evaluation logic
@@ -295,6 +297,11 @@ Implemented:
 - Reusable `ai-ml/evaluators/keywordEvaluator.js` for resume vs job description text
 - Keyword relevance analysis with matched keywords, missing keywords, and weighted keyword score (`weight` default `0.2`)
 - Optional `jobDescription` form field on `POST /api/resume/analyze` to run keyword evaluation alongside parsing
+- Reusable `ai-ml/evaluators/experienceEvaluator.js` for resume vs job description experience matching
+- Experience extraction supports years and months (examples: `18 months`, `1 year 6 months`, `2+ years`)
+- Weighted experience scoring with explainable feedback (`score`, `weight`, `candidateExperience`, `requiredExperience`, `experienceGap`)
+- Unit tests for experience evaluator at `ai-ml/evaluators/__tests__/experienceEvaluator.test.js`
+- `/api/resume/analyze` now includes `experienceMatch` in response and MongoDB resume records
 ```
 
 ## For Open-Source Contributors

--- a/ai-ml/evaluators/__tests__/experienceEvaluator.test.js
+++ b/ai-ml/evaluators/__tests__/experienceEvaluator.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  experienceEvaluator,
+  extractExperienceInYears,
+} from "../experienceEvaluator.js";
+
+test("extractExperienceInYears handles years, months, and combined values", () => {
+  assert.equal(extractExperienceInYears("Need 3+ years experience"), 3);
+  assert.equal(extractExperienceInYears("Worked for 18 months"), 1.5);
+  assert.equal(extractExperienceInYears("Total 1 year 6 months"), 1.5);
+  assert.equal(extractExperienceInYears("No experience number"), 0);
+});
+
+test("exact experience match returns 100", () => {
+  const result = experienceEvaluator({
+    candidateExperienceText: "2 years",
+    jobDescription: "Need 2 years of experience",
+  });
+
+  assert.equal(result.score, 100);
+  assert.equal(result.requiredExperience, 2);
+  assert.equal(result.candidateExperience, 2);
+  assert.equal(result.experienceGap, 0);
+});
+
+test("partial match returns ratio-based score", () => {
+  const result = experienceEvaluator({
+    candidateExperienceText: "1 year",
+    jobDescription: "Need 3 years of experience",
+  });
+
+  assert.equal(result.score, 33.33);
+  assert.equal(result.experienceGap, 2);
+  assert.ok(
+    result.feedback.includes(
+      "Candidate experience is significantly below job requirements",
+    ),
+  );
+});
+
+test("months conversion can exceed required years", () => {
+  const result = experienceEvaluator({
+    candidateExperienceText: "18 months",
+    jobDescription: "Need 1 year of experience",
+  });
+
+  assert.equal(result.candidateExperience, 1.5);
+  assert.equal(result.requiredExperience, 1);
+  assert.equal(result.score, 100);
+});
+
+test("combined year and month expression is parsed correctly", () => {
+  const result = experienceEvaluator({
+    candidateExperienceText: "1 year 6 months",
+    jobDescription: "Need 2 years of experience",
+  });
+
+  assert.equal(result.candidateExperience, 1.5);
+  assert.equal(result.requiredExperience, 2);
+  assert.equal(result.score, 75);
+  assert.equal(result.experienceGap, 0.5);
+});
+
+test("missing JD experience returns 0 with guidance feedback", () => {
+  const result = experienceEvaluator({
+    candidateExperienceText: "2 years",
+    jobDescription: "Looking for a React developer",
+  });
+
+  assert.equal(result.score, 0);
+  assert.equal(result.requiredExperience, 0);
+  assert.ok(
+    result.feedback.includes(
+      "Could not detect required experience from the job description",
+    ),
+  );
+});

--- a/ai-ml/evaluators/experienceEvaluator.js
+++ b/ai-ml/evaluators/experienceEvaluator.js
@@ -1,0 +1,97 @@
+const roundToTwo = (value) => Number(value.toFixed(2));
+
+const toNumber = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export const extractExperienceInYears = (text = "") => {
+  const content = `${text}`.toLowerCase();
+  if (!content.trim()) return 0;
+
+  const detectedValues = [];
+
+  // Examples: "1 year 6 months", "2 years and 3 months", "1.5 years 6 months"
+  const combinedPattern =
+    /(\d+(?:\.\d+)?)\s*\+?\s*(?:years?|yrs?)\s*(?:and\s*)?(\d+(?:\.\d+)?)\s*\+?\s*(?:months?|mos?)/gi;
+  for (const match of content.matchAll(combinedPattern)) {
+    const years = toNumber(match[1]);
+    const months = toNumber(match[2]);
+    detectedValues.push(years + months / 12);
+  }
+
+  // Examples: "3 years", "2+ years", "1 yr"
+  const yearsPattern = /(\d+(?:\.\d+)?)\s*\+?\s*(?:years?|yrs?)/gi;
+  for (const match of content.matchAll(yearsPattern)) {
+    detectedValues.push(toNumber(match[1]));
+  }
+
+  // Examples: "18 months", "6+ months", "10 mo"
+  const monthsPattern = /(\d+(?:\.\d+)?)\s*\+?\s*(?:months?|mos?)/gi;
+  for (const match of content.matchAll(monthsPattern)) {
+    detectedValues.push(toNumber(match[1]) / 12);
+  }
+
+  if (detectedValues.length === 0) return 0;
+  return roundToTwo(Math.max(...detectedValues));
+};
+
+export const experienceEvaluator = ({
+  candidateExperienceText = "",
+  jobDescription = "",
+  weight = 0.2,
+} = {}) => {
+  const candidateExperience = extractExperienceInYears(candidateExperienceText);
+  const requiredExperience = extractExperienceInYears(jobDescription);
+
+  if (!requiredExperience) {
+    return {
+      score: 0,
+      weight,
+      feedback: ["Could not detect required experience from the job description"],
+      candidateExperience,
+      requiredExperience: 0,
+      experienceGap: 0,
+    };
+  }
+
+  const gap = Math.max(requiredExperience - candidateExperience, 0);
+  const rawScore =
+    candidateExperience >= requiredExperience
+      ? 100
+      : (candidateExperience / requiredExperience) * 100;
+  const score = roundToTwo(Math.min(rawScore, 100));
+  const experienceGap = roundToTwo(gap);
+
+  let feedback = [];
+  if (candidateExperience >= requiredExperience) {
+    feedback = [
+      "Candidate experience meets or exceeds job requirements",
+      `Required experience: ${requiredExperience} years`,
+      `Candidate experience: ${candidateExperience} years`,
+    ];
+  } else if (score < 40) {
+    feedback = [
+      "Candidate experience is significantly below job requirements",
+      `Required experience: ${requiredExperience} years`,
+      `Candidate experience: ${candidateExperience} years`,
+      `Experience gap: ${experienceGap} years`,
+    ];
+  } else {
+    feedback = [
+      "Candidate experience partially matches job requirements",
+      `Required experience: ${requiredExperience} years`,
+      `Candidate experience: ${candidateExperience} years`,
+      `Experience gap: ${experienceGap} years`,
+    ];
+  }
+
+  return {
+    score,
+    weight,
+    feedback,
+    candidateExperience,
+    requiredExperience,
+    experienceGap,
+  };
+};

--- a/server/src/database/models/Resume.js
+++ b/server/src/database/models/Resume.js
@@ -84,6 +84,14 @@ const resumeSchema = new mongoose.Schema(
       matchedKeywords: [String],
       missingKeywords: [String],
     },
+    experienceMatch: {
+      score: Number,
+      weight: Number,
+      feedback: [String],
+      candidateExperience: Number,
+      requiredExperience: Number,
+      experienceGap: Number,
+    },
   },
   {
     timestamps: true,

--- a/server/src/modules/resumes/controller.js
+++ b/server/src/modules/resumes/controller.js
@@ -2,6 +2,7 @@ import path from "path";
 import { parseResume } from "../../utils/parseResume.js";
 import { skillEvaluator } from "../../../../ai-ml/evaluators/skillEvaluator.js";
 import { keywordEvaluator } from "../../../../ai-ml/evaluators/keywordEvaluator.js";
+import { experienceEvaluator } from "../../../../ai-ml/evaluators/experienceEvaluator.js";
 import Resume from "../../database/models/Resume.js";
 
 const parseSkillArrayString = (input) => {
@@ -105,9 +106,18 @@ export const analyzeResume = async (req, res) => {
           jobDescription: trimmedJobDescription,
         })
       : null;
+    const candidateExperienceText =
+      Array.isArray(parsedData.experience) && parsedData.experience.length > 0
+        ? parsedData.experience.join(" ")
+        : parsedData.resumeText || "";
+    const experienceMatch = experienceEvaluator({
+      candidateExperienceText,
+      jobDescription: trimmedJobDescription,
+    });
 
     const finalSkillMatch = skillMatch || {};
     const finalKeywordMatch = keywordMatch || {};
+    const finalExperienceMatch = experienceMatch || {};
     const fileData = {
       originalName: req.file.originalname,
       storedName: req.file.filename,
@@ -125,14 +135,17 @@ export const analyzeResume = async (req, res) => {
         jobDescription: trimmedJobDescription || null,
         skillMatch: finalSkillMatch,
         keywordMatch: finalKeywordMatch,
+        experienceMatch: finalExperienceMatch,
         file: fileData,
       });
 
       const hasSkillEval = Object.keys(finalSkillMatch).length > 0;
       const hasKeywordEval = Object.keys(finalKeywordMatch).length > 0;
+      const hasExperienceEval = Object.keys(finalExperienceMatch).length > 0;
       const successParts = [];
       if (hasSkillEval) successParts.push("skill match");
       if (hasKeywordEval) successParts.push("keyword relevance");
+      if (hasExperienceEval) successParts.push("experience fit");
       const evalSummary =
         successParts.length > 0
           ? `Resume parsed, ${successParts.join(" and ")} evaluated, and saved successfully`
@@ -147,6 +160,7 @@ export const analyzeResume = async (req, res) => {
         data: resumeFields,
         skillMatch: finalSkillMatch,
         keywordMatch: finalKeywordMatch,
+        experienceMatch: finalExperienceMatch,
         file: fileData,
       });
     } catch (saveError) {


### PR DESCRIPTION
## Summary

This PR adds a reusable experience evaluator for the resume analysis pipeline.

## Changes Made

* Added `ai-ml/evaluators/experienceEvaluator.js`
* Added support for detecting:

  * Years of experience
  * Month-based experience
  * Combined year + month formats
  * `+` patterns such as `2+ years`
* Added conversion logic for month-based values:

  * `6 months` → `0.5 years`
  * `18 months` → `1.5 years`
  * `1 year 6 months` → `1.5 years`
* Added extraction of highest detected experience value from text
* Added weighted experience score generation
* Added structured feedback for:

  * Full match
  * Partial match
  * Low experience match
  * Missing JD experience
* Added `experienceMatch` response in `POST /api/resume/analyze`
* Added MongoDB persistence for `experienceMatch`
* Added test coverage in `ai-ml/evaluators/__tests__/experienceEvaluator.test.js`
* Updated README and project structure documentation

## Example Endpoint

```bash id="x9m2p4"
POST /api/resume/analyze
```

## Example Additional Request Field

```text id="p4q8v2"
jobDescription = Looking for a React developer with 2 years of experience in Node.js and MongoDB
```

## Example Response Addition

```json id="w7m2n5"
"experienceMatch": {
  "score": 100,
  "weight": 0.2,
  "feedback": [
    "Candidate experience meets or exceeds job requirements",
    "Required experience: 2 years",
    "Candidate experience: 2.5 years"
  ],
  "candidateExperience": 2.5,
  "requiredExperience": 2,
  "experienceGap": 0
}
```
<img width="1639" height="735" alt="image" src="https://github.com/user-attachments/assets/b13b4b97-be7e-4b6a-8df3-1105e2dc1740" />


Closes #52
