### PR TITLE
fix: add missing OTP fields to User schema

### DIFF
--- a/server/src/database/models/User.js
+++ b/server/src/database/models/User.js
@@ -25,10 +25,10 @@ const userSchema = new mongoose.Schema(
       type: Boolean,
       default: false
     },
-    verificationToken: String,
-    verificationTokenExpires: Date,
-    resetPasswordToken: String,
-    resetPasswordExpires: Date,
+    verificationToken: { type: String, default: null },
+    verificationTokenExpires: { type: Date, default: null },
+    resetPasswordToken: { type: String, default: null },
+    resetPasswordExpires: { type: Date, default: null },
     otpAttempts: {
       type: Number,
       default: 0


### PR DESCRIPTION
## Summary
I was looking into why email verification and password reset weren't working and traced it back to the User schema. The four OTP-related fields were just defined as bare types like `verificationToken: String` without any default value. Because of Mongoose's strict mode, these never got properly stored in the database, so the OTP check always failed silently.

## Type of Change
- [x] Bug fix


## Related issue

Closes #72
## Changes Made

- Added `default: null` to `verificationToken`, `verificationTokenExpires`, `resetPasswordToken`, and `resetPasswordExpires` fields in the User schema
- These fields are now properly initialized in every new user document so OTP values get saved and matched correctly

## Validation
- [x] Build passes locally

## Screenshots (if UI change)

No UI changes this is a backend schema fix only.
