### PR TITLE
fix: resolve TypeError in handleDuplicateFieldsDB on duplicate email

### DIFF
--- a/server/src/middleware/errorMiddleware.js
+++ b/server/src/middleware/errorMiddleware.js
@@ -6,7 +6,9 @@ const handleCastErrorDB = (err) => {
 };
 
 const handleDuplicateFieldsDB = (err) => {
-  const value = err.errmsg.match(/(["'])(\\?.)*?\1/)[0];
+  const raw = err.errmsg || err.message || "";
+  const match = raw.match(/(["'])(\\?.)*?\1/);
+  const value = match ? match[0] : "unknown";
   const message = `Duplicate field value: ${value}. Please use another value!`;
   return new AppError(message, 400);
 };


### PR DESCRIPTION
## Summary
This PR fixes the server crash that happens when a user tries to register with an already existing email. Mongoose 7+ (MongoDB driver v4+) dropped the `err.errmsg` property, moving the duplicate error message to `err.message`. Because the global error handler was trying to call `.match()` on `undefined`, it caused a `TypeError` and a 500 crash instead of returning a clean 400 response. This PR fixes that by checking both properties.

## Type of Change
- [x] Bug fix

## Related Issue
Closes #74

## Changes Made
- Updated `handleDuplicateFieldsDB` in `errorMiddleware.js` to look for the error string in `err.message` if `err.errmsg` is undefined.
- Added a safe fallback for the regex match (`match ? match[0] : "unknown"`) to completely prevent any chance of a `TypeError` crash in the future.

## Validation
- [x] Build passes locally

## Screenshots (if UI change)
N/A (Backend logic fix)
