### PR TITLE
feat: Integrate Frontend Authentication with Backend (Register & Login)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ lerna-debug.log*
 # Dependency directories
 node_modules/
 
+# Local runtime/cache data
+server/.mongo-data/
+server/.npm-cache/
+
 # Environment files
 .env
 .env.*

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=

--- a/client/src/app/App.jsx
+++ b/client/src/app/App.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Routes, Route } from "react-router-dom";
 import LandingPage from "../modules/landing/LandingPage";
+import DashboardPage from "../modules/dashboard/DashboardPage";
 import ResumeAnalyzerPage from "../modules/resume-analyzer/pages/ResumeAnalyzerPage";
 import ComponentDemo from "../modules/auth/components/ComponentDemo";
 import Login from "../modules/auth/Login";
@@ -23,6 +24,14 @@ function App() {
               <ResumeAnalyzerPage />
             </ProtectedRoute>
           } 
+        />
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute>
+              <DashboardPage />
+            </ProtectedRoute>
+          }
         />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />

--- a/client/src/app/main.jsx
+++ b/client/src/app/main.jsx
@@ -11,13 +11,10 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <Provider store={store}>
       <BrowserRouter>
-        <App />
+        <ToastProvider>
+          <App />
+        </ToastProvider>
       </BrowserRouter>
     </Provider>
-    <ToastProvider>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </ToastProvider>
   </React.StrictMode>
 );

--- a/client/src/features/auth/authSlice.js
+++ b/client/src/features/auth/authSlice.js
@@ -1,51 +1,225 @@
-import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import * as authService from "../../services/authService";
 
-// Async thunk for register
+const TOKEN_KEY = "skillssphere.auth.token";
+const USER_KEY = "skillssphere.auth.user";
+const PENDING_EMAIL_KEY = "skillssphere.auth.pendingEmail";
+
+const canUseStorage = () => typeof window !== "undefined";
+
+const normalizeEmail = (email = "") => email.trim().toLowerCase();
+
+const safeGetItem = (storage, key) => {
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+const safeSetItem = (storage, key, value) => {
+  try {
+    storage.setItem(key, value);
+  } catch {
+    // Auth still works in memory when browser storage is unavailable.
+  }
+};
+
+const safeRemoveItem = (storage, key) => {
+  try {
+    storage.removeItem(key);
+  } catch {
+    // Ignore storage cleanup failures.
+  }
+};
+
+const readStoredUser = (storage) => {
+  const storedUser = safeGetItem(storage, USER_KEY);
+  if (!storedUser) return null;
+
+  try {
+    return JSON.parse(storedUser);
+  } catch {
+    return null;
+  }
+};
+
+const readStoredAuth = () => {
+  if (!canUseStorage()) {
+    return { token: null, user: null };
+  }
+
+  const localToken = safeGetItem(window.localStorage, TOKEN_KEY);
+  const localUser = readStoredUser(window.localStorage);
+
+  if (localToken && localUser) {
+    return { token: localToken, user: localUser };
+  }
+
+  const sessionToken = safeGetItem(window.sessionStorage, TOKEN_KEY);
+  const sessionUser = readStoredUser(window.sessionStorage);
+
+  if (sessionToken && sessionUser) {
+    return { token: sessionToken, user: sessionUser };
+  }
+
+  return { token: null, user: null };
+};
+
+const persistAuth = ({ token, user }, rememberMe) => {
+  if (!canUseStorage()) return;
+
+  clearStoredAuth();
+
+  const storage = rememberMe ? window.localStorage : window.sessionStorage;
+  safeSetItem(storage, TOKEN_KEY, token);
+  safeSetItem(storage, USER_KEY, JSON.stringify(user));
+};
+
+const clearStoredAuth = () => {
+  if (!canUseStorage()) return;
+
+  [window.localStorage, window.sessionStorage].forEach((storage) => {
+    safeRemoveItem(storage, TOKEN_KEY);
+    safeRemoveItem(storage, USER_KEY);
+  });
+};
+
+const readPendingEmail = () => {
+  if (!canUseStorage()) return "";
+  return safeGetItem(window.localStorage, PENDING_EMAIL_KEY) || "";
+};
+
+const persistPendingEmail = (email) => {
+  if (!canUseStorage()) return;
+  safeSetItem(window.localStorage, PENDING_EMAIL_KEY, normalizeEmail(email));
+};
+
+const clearPendingEmail = () => {
+  if (!canUseStorage()) return;
+  safeRemoveItem(window.localStorage, PENDING_EMAIL_KEY);
+};
+
+const toErrorMessage = (error, fallback) =>
+  error?.message || fallback || "Something went wrong. Please try again.";
+
 export const registerUser = createAsyncThunk(
-  'auth/register',
+  "auth/register",
   async (userData, thunkAPI) => {
     try {
-      // Use empty string locally so it falls back to Vite's proxy, bypassing CORS issues!
-      const baseUrl = import.meta.env.VITE_API_URL || '';
-      const response = await fetch(`${baseUrl}/api/auth/register`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(userData),
-      });
+      const payload = {
+        ...userData,
+        email: normalizeEmail(userData.email),
+        name: userData.name.trim(),
+      };
+      const data = await authService.register(payload);
 
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        return thunkAPI.rejectWithValue(errorData.message || 'Registration failed');
-      }
-
-      const data = await response.json();
-      
-      // If the backend returns a token, persist it locally for future authenticated requests
-      if (data.token) {
-        localStorage.setItem('token', data.token);
-      }
-
-      // Handle response structure safely: if { user, token } is returned, return just user.
-      return data.user ? data.user : data;
+      return {
+        ...data,
+        pendingVerificationEmail: payload.email,
+      };
     } catch (error) {
-      return thunkAPI.rejectWithValue(error.message || 'An error occurred during registration');
+      return thunkAPI.rejectWithValue(
+        toErrorMessage(error, "Registration failed"),
+      );
     }
-  }
+  },
 );
 
+export const loginUser = createAsyncThunk(
+  "auth/login",
+  async ({ email, password, rememberMe = true }, thunkAPI) => {
+    try {
+      const data = await authService.login({
+        email: normalizeEmail(email),
+        password,
+      });
+
+      return {
+        ...data,
+        rememberMe,
+      };
+    } catch (error) {
+      return thunkAPI.rejectWithValue(toErrorMessage(error, "Login failed"));
+    }
+  },
+);
+
+export const verifyEmail = createAsyncThunk(
+  "auth/verifyEmail",
+  async ({ email, otp }, thunkAPI) => {
+    try {
+      const normalizedEmail = normalizeEmail(email);
+      const data = await authService.verifyEmail({
+        email: normalizedEmail,
+        otp,
+      });
+
+      return {
+        ...data,
+        email: normalizedEmail,
+      };
+    } catch (error) {
+      return thunkAPI.rejectWithValue(
+        toErrorMessage(error, "Email verification failed"),
+      );
+    }
+  },
+);
+
+export const resendOtp = createAsyncThunk(
+  "auth/resendOtp",
+  async ({ email }, thunkAPI) => {
+    try {
+      const normalizedEmail = normalizeEmail(email);
+      const data = await authService.resendOtp({ email: normalizedEmail });
+
+      return {
+        ...data,
+        email: normalizedEmail,
+      };
+    } catch (error) {
+      return thunkAPI.rejectWithValue(
+        toErrorMessage(error, "Could not resend verification code"),
+      );
+    }
+  },
+);
+
+const storedAuth = readStoredAuth();
+
 const initialState = {
-  user: null,
-  isAuthenticated: false,
+  user: storedAuth.user,
+  token: storedAuth.token,
+  isAuthenticated: Boolean(storedAuth.token && storedAuth.user),
+  pendingVerificationEmail: readPendingEmail(),
+  pendingUser: null,
   loading: false,
+  verificationLoading: false,
+  resendLoading: false,
   error: null,
 };
 
 const authSlice = createSlice({
-  name: 'auth',
+  name: "auth",
   initialState,
-  reducers: {},
+  reducers: {
+    logout: (state) => {
+      clearStoredAuth();
+      state.user = null;
+      state.token = null;
+      state.isAuthenticated = false;
+      state.error = null;
+    },
+    clearAuthError: (state) => {
+      state.error = null;
+    },
+    setPendingVerificationEmail: (state, action) => {
+      const email = normalizeEmail(action.payload);
+      state.pendingVerificationEmail = email;
+      persistPendingEmail(email);
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(registerUser.pending, (state) => {
@@ -53,15 +227,78 @@ const authSlice = createSlice({
         state.error = null;
       })
       .addCase(registerUser.fulfilled, (state, action) => {
+        const email = action.payload.pendingVerificationEmail;
+
+        clearStoredAuth();
+        persistPendingEmail(email);
+
         state.loading = false;
-        state.isAuthenticated = true;
-        state.user = action.payload; // Store user data on success
+        state.error = null;
+        state.user = null;
+        state.token = null;
+        state.isAuthenticated = false;
+        state.pendingUser = action.payload.user || null;
+        state.pendingVerificationEmail = email;
       })
       .addCase(registerUser.rejected, (state, action) => {
         state.loading = false;
         state.error = action.payload;
+      })
+      .addCase(loginUser.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(loginUser.fulfilled, (state, action) => {
+        const { token, user, rememberMe } = action.payload;
+
+        persistAuth({ token, user }, rememberMe);
+        clearPendingEmail();
+
+        state.loading = false;
+        state.error = null;
+        state.user = user;
+        state.token = token;
+        state.isAuthenticated = Boolean(token && user);
+        state.pendingUser = null;
+        state.pendingVerificationEmail = "";
+      })
+      .addCase(loginUser.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload;
+      })
+      .addCase(verifyEmail.pending, (state) => {
+        state.verificationLoading = true;
+        state.error = null;
+      })
+      .addCase(verifyEmail.fulfilled, (state) => {
+        clearPendingEmail();
+        state.verificationLoading = false;
+        state.error = null;
+        state.pendingUser = null;
+        state.pendingVerificationEmail = "";
+      })
+      .addCase(verifyEmail.rejected, (state, action) => {
+        state.verificationLoading = false;
+        state.error = action.payload;
+      })
+      .addCase(resendOtp.pending, (state) => {
+        state.resendLoading = true;
+        state.error = null;
+      })
+      .addCase(resendOtp.fulfilled, (state, action) => {
+        persistPendingEmail(action.payload.email);
+        state.resendLoading = false;
+        state.error = null;
+        state.pendingVerificationEmail = action.payload.email;
+      })
+      .addCase(resendOtp.rejected, (state, action) => {
+        state.resendLoading = false;
+        state.error = action.payload;
       });
   },
 });
+
+export const { clearAuthError, logout, setPendingVerificationEmail } =
+  authSlice.actions;
 
 export default authSlice.reducer;

--- a/client/src/modules/auth/Login.jsx
+++ b/client/src/modules/auth/Login.jsx
@@ -1,16 +1,23 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { loginUser } from "../../features/auth/authSlice";
 import Input from "../../shared/components/Input";
 import Button from "../../shared/components/Button";
 import { useToast } from "../../shared/components";
 
 const Login = () => {
-  const { success, warning } = useToast();
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { loading } = useSelector((state) => state.auth);
+  const { success, warning, error: showError } = useToast();
 
   const [form, setForm] = useState({
     email: "",
     password: "",
   });
+  const [rememberMe, setRememberMe] = useState(true);
 
   const [errors, setErrors] = useState({});
 
@@ -18,12 +25,12 @@ const Login = () => {
     const { id, value } = e.target;
     setForm({ ...form, [id]: value });
     
-    if (errors[id]) {
-      setErrors({ ...errors, [id]: "" });
+    if (errors[id] || errors.form) {
+      setErrors({ ...errors, [id]: "", form: "" });
     }
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     let newErrors = {};
 
@@ -39,10 +46,31 @@ const Login = () => {
       return;
     }
 
-    if (Object.keys(newErrors).length === 0) {
-      console.log(form);
+    const resultAction = await dispatch(
+      loginUser({
+        email: form.email.trim().toLowerCase(),
+        password: form.password,
+        rememberMe,
+      }),
+    );
+
+    if (loginUser.fulfilled.match(resultAction)) {
       success("Logged in successfully.");
+      const fallbackPath = "/dashboard";
+      const redirectTo = location.state?.from?.pathname || fallbackPath;
+      navigate(redirectTo, { replace: true });
+    } else {
+      const message = resultAction.payload || "Login failed";
+      setErrors({ ...errors, form: message });
+      showError(message);
     }
+  };
+
+  const goToVerification = () => {
+    const email = form.email.trim().toLowerCase();
+    navigate(`/verify-email?email=${encodeURIComponent(email)}`, {
+      state: { email },
+    });
   };
 
   return (
@@ -70,6 +98,7 @@ const Login = () => {
               value={form.email}
               onChange={handleChange}
               error={errors.email}
+              disabled={loading}
             />
 
             <Input
@@ -80,6 +109,7 @@ const Login = () => {
               value={form.password}
               onChange={handleChange}
               error={errors.password}
+              disabled={loading}
             />
           </div>
 
@@ -89,6 +119,8 @@ const Login = () => {
               <input
                 id="remember-me"
                 type="checkbox"
+                checked={rememberMe}
+                onChange={(e) => setRememberMe(e.target.checked)}
                 className="accent-blue-500 rounded focus:ring-2 focus:ring-blue-500"
               />
               Remember me
@@ -102,10 +134,27 @@ const Login = () => {
           <Button 
             type="submit"
             fullWidth
+            loading={loading}
+            disabled={loading}
             className="mt-2 rounded-xl bg-gradient-to-r from-blue-500 to-indigo-500 border-none font-bold text-[15px] hover:scale-105 hover:shadow-[0_0_20px_rgba(59,130,246,0.6)] transition-all duration-300"
           >
             Login
           </Button>
+
+          {errors.form && (
+            <div className="mt-3 text-center">
+              <p className="text-red-400 text-sm">{errors.form}</p>
+              {errors.form.toLowerCase().includes("verify") && (
+                <button
+                  type="button"
+                  onClick={goToVerification}
+                  className="mt-2 text-sm text-blue-400 hover:underline bg-transparent border-none cursor-pointer"
+                >
+                  Verify your email
+                </button>
+              )}
+            </div>
+          )}
 
           {/* Footer */}
           <p className="text-center mt-5 text-slate-400 text-[14px]">

--- a/client/src/modules/auth/Register.jsx
+++ b/client/src/modules/auth/Register.jsx
@@ -11,7 +11,7 @@ const Register = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const { loading } = useSelector((state) => state.auth);
-  const { success, warning } = useToast();
+  const { success, warning, error: showError } = useToast();
 
   const [form, setForm] = useState({
     name: "",
@@ -27,14 +27,16 @@ const Register = () => {
     const { id, value } = e.target;
     setForm({ ...form, [id]: value });
 
-    // Clear error for this field when user types
-    if (errors[id]) {
-      setErrors({ ...errors, [id]: "" });
+    if (errors[id] || errors.form) {
+      setErrors({ ...errors, [id]: "", form: "" });
     }
   };
 
   const handleRoleChange = (e) => {
     setForm({ ...form, role: e.target.value });
+    if (errors.role || errors.form) {
+      setErrors({ ...errors, role: "", form: "" });
+    }
   };
 
   const validate = () => {
@@ -72,23 +74,30 @@ const Register = () => {
       return;
     }
 
+    const email = form.email.trim().toLowerCase();
+
     const resultAction = await dispatch(
       registerUser({
-        name: form.name,
-        email: form.email,
+        name: form.name.trim(),
+        email,
         password: form.password,
         role: form.role,
       }),
     );
 
     if (registerUser.fulfilled.match(resultAction)) {
-      success("Account created successfully.");
-      navigate("/resume-analyzer");
+      success("Account created. Check your email for the verification code.");
+      navigate(`/verify-email?email=${encodeURIComponent(email)}`, {
+        state: { email },
+        replace: true,
+      });
     } else {
+      const message = resultAction.payload || "Registration failed";
       setErrors({
         ...errors,
-        form: resultAction.payload || "Registration Failed",
+        form: message,
       });
+      showError(message);
     }
   };
 
@@ -122,6 +131,7 @@ const Register = () => {
               value={form.name}
               onChange={handleChange}
               error={errors.name}
+              disabled={loading}
             />
 
             <Input
@@ -132,6 +142,7 @@ const Register = () => {
               value={form.email}
               onChange={handleChange}
               error={errors.email}
+              disabled={loading}
             />
 
             <Input
@@ -142,6 +153,7 @@ const Register = () => {
               value={form.password}
               onChange={handleChange}
               error={errors.password}
+              disabled={loading}
             />
 
             <Input
@@ -152,6 +164,7 @@ const Register = () => {
               value={form.confirmPassword}
               onChange={handleChange}
               error={errors.confirmPassword}
+              disabled={loading}
             />
 
             <Select
@@ -160,12 +173,14 @@ const Register = () => {
               value={form.role}
               onChange={handleRoleChange}
               options={roleOptions}
+              disabled={loading}
             />
           </div>
 
           <Button
             type="submit"
             fullWidth
+            loading={loading}
             disabled={loading}
             className="mt-2 rounded-xl bg-gradient-to-r from-blue-500 to-indigo-500 border-none font-bold text-[15px] hover:scale-105 hover:shadow-[0_0_20px_rgba(59,130,246,0.6)] transition-all duration-300"
           >

--- a/client/src/modules/auth/VerifyEmail.jsx
+++ b/client/src/modules/auth/VerifyEmail.jsx
@@ -1,47 +1,100 @@
-import React, { useState, useRef, useEffect } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import React, { useEffect, useRef, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Link, useLocation, useNavigate, useSearchParams } from "react-router-dom";
+import {
+  resendOtp,
+  setPendingVerificationEmail,
+  verifyEmail,
+} from "../../features/auth/authSlice";
 import Button from "../../shared/components/Button";
+import Input from "../../shared/components/Input";
+import { useToast } from "../../shared/components";
 import { ShieldCheck, ArrowLeft, CheckCircle } from "lucide-react";
 
 const OTP_LENGTH = 6;
 const COOLDOWN_SECONDS = 60;
 
-const VerifyEmail = () => {
-  const navigate = useNavigate();
+const isValidEmail = (email) => /\S+@\S+\.\S+/.test(email);
 
+const VerifyEmail = () => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const { success: showSuccess, error: showError } = useToast();
+  const {
+    pendingVerificationEmail,
+    verificationLoading,
+    resendLoading,
+  } = useSelector((state) => state.auth);
+
+  const initialEmail =
+    searchParams.get("email") ||
+    location.state?.email ||
+    pendingVerificationEmail ||
+    "";
+
+  const [email, setEmail] = useState(initialEmail);
+  const [emailError, setEmailError] = useState("");
   const [otp, setOtp] = useState(Array(OTP_LENGTH).fill(""));
   const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
   const [countdown, setCountdown] = useState(COOLDOWN_SECONDS);
   const [canResend, setCanResend] = useState(false);
 
   const inputRefs = useRef([]);
 
-  // Countdown timer
+  useEffect(() => {
+    if (initialEmail) {
+      dispatch(setPendingVerificationEmail(initialEmail));
+    }
+  }, [dispatch, initialEmail]);
+
   useEffect(() => {
     if (countdown <= 0) {
       setCanResend(true);
-      return;
+      return undefined;
     }
 
-    const timer = setInterval(() => {
+    const timer = window.setInterval(() => {
       setCountdown((prev) => prev - 1);
     }, 1000);
 
-    return () => clearInterval(timer);
+    return () => window.clearInterval(timer);
   }, [countdown]);
 
-  // Format countdown for display
   const formatTime = (seconds) => {
-    const m = Math.floor(seconds / 60);
-    const s = seconds % 60;
-    return `${m}:${s.toString().padStart(2, "0")}`;
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
   };
 
-  // OTP input handlers
+  const normalizedEmail = email.trim().toLowerCase();
+  const otpValue = otp.join("");
+  const isComplete = otp.every(Boolean) && otpValue.length === OTP_LENGTH;
+
+  const validateEmailField = () => {
+    if (!normalizedEmail) {
+      setEmailError("Email is required");
+      return false;
+    }
+
+    if (!isValidEmail(normalizedEmail)) {
+      setEmailError("Please enter a valid email");
+      return false;
+    }
+
+    setEmailError("");
+    return true;
+  };
+
+  const handleEmailChange = (e) => {
+    setEmail(e.target.value);
+    setEmailError("");
+    setError("");
+  };
+
   const handleOtpChange = (index, value) => {
-    // Allow only single digit
     if (value && !/^\d$/.test(value)) return;
 
     const newOtp = [...otp];
@@ -49,22 +102,20 @@ const VerifyEmail = () => {
     setOtp(newOtp);
     setError("");
 
-    // Auto-advance to next input
     if (value && index < OTP_LENGTH - 1) {
       inputRefs.current[index + 1]?.focus();
     }
   };
 
   const handleKeyDown = (index, e) => {
-    // Move back on Backspace when current field is empty
     if (e.key === "Backspace" && !otp[index] && index > 0) {
       inputRefs.current[index - 1]?.focus();
     }
-    // Move forward on ArrowRight
+
     if (e.key === "ArrowRight" && index < OTP_LENGTH - 1) {
       inputRefs.current[index + 1]?.focus();
     }
-    // Move backward on ArrowLeft
+
     if (e.key === "ArrowLeft" && index > 0) {
       inputRefs.current[index - 1]?.focus();
     }
@@ -72,71 +123,81 @@ const VerifyEmail = () => {
 
   const handlePaste = (e) => {
     e.preventDefault();
-    const pasted = e.clipboardData.getData("text").replace(/\D/g, "").slice(0, OTP_LENGTH);
+    const pasted = e.clipboardData
+      .getData("text")
+      .replace(/\D/g, "")
+      .slice(0, OTP_LENGTH);
 
-    if (pasted.length > 0) {
-      const newOtp = [...otp];
-      for (let i = 0; i < pasted.length; i++) {
-        newOtp[i] = pasted[i];
-      }
-      setOtp(newOtp);
-      setError("");
+    if (!pasted) return;
 
-      // Focus the next empty input or the last one
-      const focusIndex = Math.min(pasted.length, OTP_LENGTH - 1);
-      inputRefs.current[focusIndex]?.focus();
+    const newOtp = Array(OTP_LENGTH).fill("");
+    for (let i = 0; i < pasted.length; i += 1) {
+      newOtp[i] = pasted[i];
     }
+
+    setOtp(newOtp);
+    setError("");
+
+    const focusIndex = Math.min(pasted.length, OTP_LENGTH - 1);
+    inputRefs.current[focusIndex]?.focus();
   };
 
-  // Submit
-  const otpValue = otp.join("");
-  const isComplete = otpValue.length === OTP_LENGTH;
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
 
-  const handleSubmit = (e) => {
-    if (e) e.preventDefault();
+    if (!validateEmailField()) return;
 
     if (!isComplete) {
       setError("Please enter all 6 digits");
       return;
     }
 
-    setLoading(true);
-    // Mock verification — no backend call
-    setTimeout(() => {
-      setLoading(false);
+    const resultAction = await dispatch(
+      verifyEmail({
+        email: normalizedEmail,
+        otp: otpValue,
+      }),
+    );
+
+    if (verifyEmail.fulfilled.match(resultAction)) {
       setSuccess(true);
-      console.log("Verify email OTP:", otpValue);
-    }, 2000);
+      showSuccess("Email verified successfully. You can now log in.");
+    } else {
+      const message = resultAction.payload || "Email verification failed";
+      setError(message);
+      showError(message);
+    }
   };
 
-  // Auto-submit when all digits are filled
-  useEffect(() => {
-    if (isComplete && !loading && !success) {
-      handleSubmit();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isComplete]);
-
-  // Resend OTP
-  const handleResend = () => {
-    if (!canResend) return;
-    setOtp(Array(OTP_LENGTH).fill(""));
+  const handleResend = async () => {
+    if (!canResend || resendLoading) return;
     setError("");
-    setCountdown(COOLDOWN_SECONDS);
-    setCanResend(false);
-    inputRefs.current[0]?.focus();
-    console.log("Resend OTP triggered (mock)");
+
+    if (!validateEmailField()) return;
+
+    const resultAction = await dispatch(resendOtp({ email: normalizedEmail }));
+
+    if (resendOtp.fulfilled.match(resultAction)) {
+      setOtp(Array(OTP_LENGTH).fill(""));
+      setCountdown(COOLDOWN_SECONDS);
+      setCanResend(false);
+      inputRefs.current[0]?.focus();
+      showSuccess("A new verification code has been sent.");
+    } else {
+      const message = resultAction.payload || "Could not resend verification code";
+      setError(message);
+      showError(message);
+    }
   };
 
   return (
     <div className="min-h-screen flex justify-center items-center bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] overflow-hidden relative p-5 box-border">
       <div className="relative z-10 w-full max-w-[420px]">
-        {/* Background glow */}
         <div className="absolute w-[500px] h-[500px] bg-blue-500/40 rounded-full blur-[120px] -top-[150px] -left-[150px] -z-10 animate-pulse"></div>
         <div className="absolute w-[400px] h-[400px] bg-purple-500/40 rounded-full blur-[120px] -bottom-[120px] -right-[120px] -z-10 animate-pulse"></div>
 
         {success ? (
-          /* ── Success State ── */
           <div className="p-6 sm:p-[30px] rounded-[20px] backdrop-blur-[20px] bg-slate-900/70 border border-white/10 shadow-[0_0_40px_rgba(0,0,0,0.6)] animate-[fadeIn_0.8s_ease] text-center">
             <div className="flex justify-center mb-4">
               <div className="w-16 h-16 rounded-full bg-green-500/20 flex items-center justify-center">
@@ -147,25 +208,22 @@ const VerifyEmail = () => {
               Email Verified
             </h2>
             <p className="text-slate-400 text-sm mb-6">
-              Your email has been verified successfully. You can now continue
-              using the platform.
+              Your email has been verified successfully. Log in to continue.
             </p>
             <Button
               fullWidth
               className="rounded-xl bg-gradient-to-r from-blue-500 to-indigo-500 border-none font-bold text-[15px] hover:scale-105 hover:shadow-[0_0_20px_rgba(59,130,246,0.6)] transition-all duration-300"
-              onClick={() => navigate("/login")}
+              onClick={() => navigate("/login", { replace: true })}
             >
               Continue to Login
             </Button>
           </div>
         ) : (
-          /* ── OTP Verification Form ── */
           <form
             className="p-6 sm:p-[30px] rounded-[20px] backdrop-blur-[20px] bg-slate-900/70 border border-white/10 shadow-[0_0_40px_rgba(0,0,0,0.6)] animate-[fadeIn_0.8s_ease]"
             onSubmit={handleSubmit}
             noValidate
           >
-            {/* Header */}
             <div className="flex justify-center mb-4">
               <div className="w-14 h-14 rounded-full bg-blue-500/20 flex items-center justify-center">
                 <ShieldCheck className="w-7 h-7 text-blue-400" />
@@ -174,11 +232,23 @@ const VerifyEmail = () => {
             <h2 className="text-center text-white mb-1 text-2xl font-semibold">
               Verify Your Email
             </h2>
-            <p className="text-center text-slate-400 text-sm mb-8">
-              We've sent a 6-digit verification code to your email
+            <p className="text-center text-slate-400 text-sm mb-6">
+              Enter the email and 6-digit code sent during registration.
             </p>
 
-            {/* Segmented OTP Input */}
+            <div className="mb-5">
+              <Input
+                id="email"
+                type="email"
+                label="Email"
+                placeholder="Enter your registered email"
+                value={email}
+                onChange={handleEmailChange}
+                error={emailError}
+                disabled={verificationLoading || resendLoading}
+              />
+            </div>
+
             <div className="flex justify-center gap-2 sm:gap-3 mb-2" onPaste={handlePaste}>
               {otp.map((digit, index) => (
                 <input
@@ -192,7 +262,7 @@ const VerifyEmail = () => {
                   value={digit}
                   onChange={(e) => handleOtpChange(index, e.target.value)}
                   onKeyDown={(e) => handleKeyDown(index, e)}
-                  disabled={loading}
+                  disabled={verificationLoading}
                   aria-label={`Digit ${index + 1}`}
                   className={`
                     w-11 h-13 sm:w-12 sm:h-14 text-center text-xl font-semibold
@@ -206,13 +276,12 @@ const VerifyEmail = () => {
                         ? "border-blue-500 focus:ring-blue-500 shadow-[0_0_12px_rgba(59,130,246,0.3)]"
                         : "border-slate-600 focus:ring-blue-500 hover:border-slate-500"
                     }
-                    ${loading ? "cursor-not-allowed opacity-60" : ""}
+                    ${verificationLoading ? "cursor-not-allowed opacity-60" : ""}
                   `}
                 />
               ))}
             </div>
 
-            {/* Error message */}
             {error && (
               <p className="text-center text-xs text-red-400 mt-2 flex items-center justify-center gap-1">
                 <svg className="w-3.5 h-3.5 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -222,15 +291,15 @@ const VerifyEmail = () => {
               </p>
             )}
 
-            {/* Countdown & Resend */}
             <div className="text-center mt-6 mb-6">
               {canResend ? (
                 <button
                   type="button"
                   onClick={handleResend}
-                  className="text-blue-400 hover:text-blue-300 text-sm font-medium cursor-pointer bg-transparent border-none hover:underline transition-colors duration-200"
+                  disabled={resendLoading}
+                  className="text-blue-400 hover:text-blue-300 text-sm font-medium cursor-pointer bg-transparent border-none hover:underline transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-60"
                 >
-                  Resend OTP
+                  {resendLoading ? "Sending..." : "Resend OTP"}
                 </button>
               ) : (
                 <p className="text-slate-500 text-sm">
@@ -242,18 +311,16 @@ const VerifyEmail = () => {
               )}
             </div>
 
-            {/* Verify Button */}
             <Button
               type="submit"
               fullWidth
-              loading={loading}
-              disabled={!isComplete}
+              loading={verificationLoading}
+              disabled={!isComplete || verificationLoading}
               className="rounded-xl bg-gradient-to-r from-blue-500 to-indigo-500 border-none font-bold text-[15px] hover:scale-105 hover:shadow-[0_0_20px_rgba(59,130,246,0.6)] transition-all duration-300"
             >
               Verify Email
             </Button>
 
-            {/* Footer */}
             <p className="text-center mt-5 text-slate-400 text-[14px] flex items-center justify-center gap-1">
               <ArrowLeft className="w-4 h-4" />
               <Link to="/login" className="text-blue-400 hover:underline">

--- a/client/src/modules/dashboard/DashboardPage.jsx
+++ b/client/src/modules/dashboard/DashboardPage.jsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Link, useNavigate } from "react-router-dom";
+import { BadgeCheck, FileText, LogOut, Mail, Shield, User } from "lucide-react";
+import { logout } from "../../features/auth/authSlice";
+import Button from "../../shared/components/Button";
+import Navbar from "../../shared/landing/Navbar";
+
+const ROLE_LABELS = {
+  student: "Student",
+  tutor: "Tutor",
+  recruiter: "Recruiter",
+};
+
+const DashboardPage = () => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { user } = useSelector((state) => state.auth);
+
+  const handleLogout = () => {
+    dispatch(logout());
+    navigate("/login", { replace: true });
+  };
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] p-5 pt-28 text-slate-100">
+      <Navbar isAuthenticated user={user} />
+
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 py-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm font-medium text-blue-300">Dashboard</p>
+            <h1 className="mt-1 text-3xl font-bold">
+              Welcome, {user?.name || "Learner"}
+            </h1>
+          </div>
+
+          <Button
+            variant="outline"
+            size="md"
+            onClick={handleLogout}
+            leftIcon={<LogOut size={16} />}
+            className="border-slate-600 bg-slate-900/70 text-slate-100 hover:bg-slate-800"
+          >
+            Logout
+          </Button>
+        </div>
+
+        <section className="grid gap-4 md:grid-cols-3">
+          <div className="rounded-xl border border-white/10 bg-slate-900/70 p-5 shadow-xl backdrop-blur">
+            <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/20 text-blue-300">
+              <User size={20} />
+            </div>
+            <p className="text-sm text-slate-400">Name</p>
+            <p className="mt-1 font-semibold">{user?.name || "Not available"}</p>
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-slate-900/70 p-5 shadow-xl backdrop-blur">
+            <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-500/20 text-emerald-300">
+              <Mail size={20} />
+            </div>
+            <p className="text-sm text-slate-400">Email</p>
+            <p className="mt-1 break-words font-semibold">
+              {user?.email || "Not available"}
+            </p>
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-slate-900/70 p-5 shadow-xl backdrop-blur">
+            <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-violet-500/20 text-violet-300">
+              <Shield size={20} />
+            </div>
+            <p className="text-sm text-slate-400">Role</p>
+            <p className="mt-1 font-semibold">
+              {ROLE_LABELS[user?.role] || user?.role || "Not available"}
+            </p>
+          </div>
+        </section>
+
+        <section className="rounded-xl border border-white/10 bg-slate-900/70 p-5 shadow-xl backdrop-blur">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-sm font-medium text-emerald-300">
+                <BadgeCheck size={15} />
+                Authenticated
+              </div>
+              <h2 className="text-xl font-semibold">Continue your workflow</h2>
+              <p className="mt-1 text-sm text-slate-400">
+                Pick up your career readiness work from here.
+              </p>
+            </div>
+
+            <Link
+              to="/resume-analyzer"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-500"
+            >
+              <FileText size={16} />
+              Resume Analyzer
+            </Link>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+};
+
+export default DashboardPage;

--- a/client/src/modules/landing/LandingPage.jsx
+++ b/client/src/modules/landing/LandingPage.jsx
@@ -1,3 +1,4 @@
+import { useSelector } from "react-redux";
 import Navbar from "../../shared/landing/Navbar.jsx";
 import CTA from "./components/CTA";
 import Features from "./components/Features";
@@ -5,9 +6,11 @@ import Hero from "./components/Hero";
 import TargetUsers from "./components/TargetUsers";
 
 const LandingPage = () => {
+  const { isAuthenticated, user } = useSelector((state) => state.auth);
+
   return (
     <div className="landing-page">
-      <Navbar />
+      <Navbar isAuthenticated={isAuthenticated} user={user} />
       <Hero />
       <Features />
       <TargetUsers />

--- a/client/src/services/apiClient.js
+++ b/client/src/services/apiClient.js
@@ -1,0 +1,61 @@
+const getApiBaseUrl = () => {
+  const rawBaseUrl = import.meta.env.VITE_API_URL || "";
+  return rawBaseUrl.trim().replace(/\/$/, "");
+};
+
+export class ApiError extends Error {
+  constructor(message, status, data) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.data = data;
+  }
+}
+
+const parseResponseBody = async (response) => {
+  const contentType = response.headers.get("content-type") || "";
+
+  if (contentType.includes("application/json")) {
+    return response.json();
+  }
+
+  const text = await response.text();
+  return text ? { message: text } : {};
+};
+
+export const apiRequest = async (
+  path,
+  { method = "GET", body, headers = {}, token } = {},
+) => {
+  const requestHeaders = {
+    Accept: "application/json",
+    ...headers,
+  };
+
+  const requestConfig = {
+    method,
+    headers: requestHeaders,
+  };
+
+  if (body !== undefined) {
+    requestHeaders["Content-Type"] = "application/json";
+    requestConfig.body = JSON.stringify(body);
+  }
+
+  if (token) {
+    requestHeaders.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${getApiBaseUrl()}${path}`, requestConfig);
+  const data = await parseResponseBody(response);
+
+  if (!response.ok || data?.success === false) {
+    throw new ApiError(
+      data?.message || "Something went wrong. Please try again.",
+      response.status,
+      data,
+    );
+  }
+
+  return data;
+};

--- a/client/src/services/authService.js
+++ b/client/src/services/authService.js
@@ -1,0 +1,25 @@
+import { apiRequest } from "./apiClient";
+
+export const register = ({ name, email, password, role }) =>
+  apiRequest("/api/auth/register", {
+    method: "POST",
+    body: { name, email, password, role },
+  });
+
+export const login = ({ email, password }) =>
+  apiRequest("/api/auth/login", {
+    method: "POST",
+    body: { email, password },
+  });
+
+export const verifyEmail = ({ email, otp }) =>
+  apiRequest("/api/auth/verify-email", {
+    method: "POST",
+    body: { email, otp },
+  });
+
+export const resendOtp = ({ email }) =>
+  apiRequest("/api/auth/resend-otp", {
+    method: "POST",
+    body: { email },
+  });

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -17,9 +17,17 @@ Implemented:
 
 - App shell and route configuration in `src/app/App.jsx`
 - Landing page module in `src/modules/landing/`
-- Auth UI modules:
+- Auth UI and API integration:
   - `src/modules/auth/Login.jsx`
+  - `src/modules/auth/Register.jsx`
+  - `src/modules/auth/VerifyEmail.jsx`
   - `src/modules/auth/components/ComponentDemo.jsx`
+- Redux auth state in `src/features/auth/authSlice.js`
+- API client helpers:
+  - `src/services/apiClient.js`
+  - `src/services/authService.js`
+- Protected dashboard route:
+  - `src/modules/dashboard/DashboardPage.jsx`
 - Resume Analyzer UI flow:
   - `src/modules/resume-analyzer/components/DragDropUpload.jsx`
   - `src/modules/resume-analyzer/components/AnalysisResult.jsx`
@@ -36,7 +44,6 @@ Implemented:
 Scaffolded placeholders:
 
 - `classrooms/`
-- `dashboard/`
 - `job-matcher/`
 - `mock-interview/`
 
@@ -89,6 +96,7 @@ Scaffolded placeholders:
 - `POST /api/auth/register`: user registration and initial token issuance
 - `POST /api/auth/login`: credential verification and JWT issuance
 - `POST /api/auth/verify-email`: verify user account via OTP
+- `POST /api/auth/resend-otp`: resend email verification OTP
 - `POST /api/resume/upload`: upload resume file
 - `POST /api/resume/analyze`: parse PDF resume, optional skill match, optional keyword relevance (`jobDescription`)
 - `GET /api/resume/result/:id`: placeholder result retrieval endpoint


### PR DESCRIPTION
## Summary

Closes #89

This PR wires up the full frontend authentication flow — Register, Login, Email Verification, and OTP Resend — against the existing backend auth API endpoints.

---

## What's Changed

### New Files
- client/src/services/apiClient.js — Base fetch wrapper with JSON handling, ApiError class, and VITE_API_URL env support
- client/src/services/authService.js — Auth API calls: egister, login, erifyEmail, esendOtp
- client/.env.example — Documents required VITE_API_URL env variable
- client/src/modules/dashboard/DashboardPage.jsx — Post-login landing stub

### Modified Files
- client/src/features/auth/authSlice.js — Redux Toolkit slice with async thunks for all auth flows, persistent token storage (localStorage / sessionStorage), and ememberMe support
- client/src/modules/auth/Register.jsx — Full registration form with name, email, password, confirm password, role selection, client-side validation, and toast feedback
- client/src/modules/auth/Login.jsx — Login form with rememberMe toggle, redirect-after-login, and a nudge to verify email when the backend returns a 403
- client/src/modules/auth/VerifyEmail.jsx — 6-digit OTP input with paste support, keyboard navigation, 60-second countdown resend timer, and success state
- client/src/app/App.jsx — Auth routes wired up (/register, /login, /verify-email, /reset-password)
- client/src/modules/landing/LandingPage.jsx — CTA buttons linked to /register and /login
- docs/PROJECT_STRUCTURE.md — Updated to reflect new services and features layout

---

## API Endpoints Used

| Method | Endpoint | Used In |
|--------|----------|---------|
| POST | /api/auth/register | Register.jsx |
| POST | /api/auth/login | Login.jsx |
| POST | /api/auth/verify-email | VerifyEmail.jsx |
| POST | /api/auth/resend-otp | VerifyEmail.jsx |

---

## How to Test

1. Copy client/.env.example to client/.env and set VITE_API_URL to your backend URL
2. Start the backend: cd server && npm run dev
3. Start the frontend: cd client && npm run dev
4. Register a new account, check email for OTP, verify, then login
5. Test wrong credentials, unverified login, and OTP resend cooldown

---

## Notes
- Token is stored in localStorage when rememberMe is checked, sessionStorage otherwise
- All API errors surface via toast notifications and inline field errors
- OTP inputs support paste, backspace navigation, and arrow key movement