### PR TITLE
Enhance resume analysis logic and add tests

### DIFF
--- a/ai-ml/pipeline/__tests__/aggregator.test.js
+++ b/ai-ml/pipeline/__tests__/aggregator.test.js
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { aggregateEvaluatorResults } from "../aggregator.js";
+
+const evaluatorResult = (overrides = {}) => ({
+  key: "keywordMatch",
+  label: "Keyword Match",
+  score: 75,
+  weight: 0.2,
+  weightedScore: 15,
+  summary: "",
+  details: {},
+  meta: {},
+  ...overrides,
+});
+
+test("returns correct weighted total rounded to two decimals", () => {
+  const result = aggregateEvaluatorResults([
+    evaluatorResult({
+      key: "skillMatch",
+      label: "Skill Match",
+      weightedScore: 33.335,
+    }),
+    evaluatorResult({
+      key: "experienceMatch",
+      label: "Experience Match",
+      weightedScore: 11.111,
+    }),
+  ]);
+
+  assert.equal(result.score, 44.45);
+});
+
+test("clamps the aggregate score to 100", () => {
+  const result = aggregateEvaluatorResults([
+    evaluatorResult({
+      key: "skillMatch",
+      label: "Skill Match",
+      weightedScore: 80,
+    }),
+    evaluatorResult({
+      key: "experienceMatch",
+      label: "Experience Match",
+      weightedScore: 40,
+    }),
+  ]);
+
+  assert.equal(result.score, 100);
+});
+
+test("returns stable evaluator breakdown and ordered evaluator list", () => {
+  const skill = evaluatorResult({
+    key: "skillMatch",
+    label: "Skill Match",
+    weightedScore: 50,
+  });
+  const keyword = evaluatorResult({
+    key: "keywordMatch",
+    label: "Keyword Match",
+    weightedScore: 15,
+  });
+
+  const result = aggregateEvaluatorResults([skill, keyword]);
+
+  assert.deepEqual(
+    result.evaluators.map((item) => item.key),
+    ["skillMatch", "keywordMatch"],
+  );
+  assert.equal(result.breakdown.skillMatch, result.evaluators[0]);
+  assert.equal(result.breakdown.keywordMatch, result.evaluators[1]);
+});
+
+test("validates evaluator results before aggregation", () => {
+  assert.throws(() =>
+    aggregateEvaluatorResults([
+      evaluatorResult({
+        key: "keywordMatch",
+        score: 200,
+      }),
+    ]),
+  );
+});
+

--- a/ai-ml/pipeline/__tests__/evaluatorContract.test.js
+++ b/ai-ml/pipeline/__tests__/evaluatorContract.test.js
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { validateEvaluatorResult } from "../evaluatorContract.js";
+
+const validResult = (overrides = {}) => ({
+  key: "keywordMatch",
+  label: "Keyword Match",
+  score: 80,
+  weight: 0.2,
+  weightedScore: 16,
+  summary: "Resume contains important job keywords",
+  details: {
+    matchedKeywords: ["JavaScript"],
+    missingKeywords: ["MongoDB"],
+  },
+  meta: {
+    source: "keywordEvaluator",
+  },
+  ...overrides,
+});
+
+test("accepts a valid evaluator result object", () => {
+  const result = validateEvaluatorResult(validResult());
+
+  assert.deepEqual(result, validResult());
+});
+
+test("applies defaults for optional summary, details, and meta fields", () => {
+  const result = validateEvaluatorResult({
+    key: "experienceMatch",
+    label: "Experience Match",
+    score: 100,
+    weight: 0.2,
+    weightedScore: 20,
+  });
+
+  assert.equal(result.summary, "");
+  assert.deepEqual(result.details, {});
+  assert.deepEqual(result.meta, {});
+});
+
+test("rejects an invalid evaluator result object", () => {
+  assert.throws(
+    () =>
+      validateEvaluatorResult({
+        ...validResult({
+          key: "",
+          score: 101,
+          weight: -1,
+        }),
+        unexpectedField: true,
+      }),
+    (error) => {
+      assert.ok(error.issues.some((issue) => issue.path.join(".") === "key"));
+      assert.ok(error.issues.some((issue) => issue.path.join(".") === "score"));
+      assert.ok(error.issues.some((issue) => issue.path.join(".") === "weight"));
+      assert.ok(error.issues.some((issue) => issue.code === "unrecognized_keys"));
+      return true;
+    },
+  );
+});
+

--- a/ai-ml/pipeline/__tests__/runPipeline.test.js
+++ b/ai-ml/pipeline/__tests__/runPipeline.test.js
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runPipeline } from "../runPipeline.js";
+
+const evaluatorResult = (overrides = {}) => ({
+  key: "keywordMatch",
+  label: "Keyword Match",
+  score: 80,
+  weight: 0.2,
+  weightedScore: 16,
+  summary: "",
+  details: {},
+  meta: {},
+  ...overrides,
+});
+
+test("validates evaluator outputs and aggregates successful results", async () => {
+  const calls = [];
+
+  const result = await runPipeline({
+    context: {
+      resumeText: "JavaScript developer",
+    },
+    evaluators: [
+      {
+        key: "keywordMatch",
+        evaluate: async (context) => {
+          calls.push(`keyword:${context.resumeText}`);
+          return evaluatorResult();
+        },
+      },
+      {
+        key: "experienceMatch",
+        evaluate: async () => {
+          calls.push("experience");
+          return evaluatorResult({
+            key: "experienceMatch",
+            label: "Experience Match",
+            score: 100,
+            weight: 0.2,
+            weightedScore: 20,
+          });
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(calls, ["keyword:JavaScript developer", "experience"]);
+  assert.equal(result.score, 36);
+  assert.deepEqual(
+    result.evaluators.map((item) => item.key),
+    ["keywordMatch", "experienceMatch"],
+  );
+});
+
+test("throws on malformed evaluator result with evaluator key and invalid fields", async () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "production";
+
+  try {
+    await assert.rejects(
+      runPipeline({
+        evaluators: [
+          {
+            key: "keywordMatch",
+            evaluate: async () =>
+              evaluatorResult({
+                label: "",
+                score: 101,
+              }),
+          },
+        ],
+      }),
+      /Evaluator "keywordMatch" returned invalid output: .*label: .*score:/,
+    );
+  } finally {
+    process.env.NODE_ENV = previousNodeEnv;
+  }
+});
+
+test("propagates evaluator exceptions", async () => {
+  await assert.rejects(
+    runPipeline({
+      evaluators: [
+        {
+          key: "keywordMatch",
+          evaluate: async () => {
+            throw new Error("keyword evaluator failed");
+          },
+        },
+      ],
+    }),
+    /keyword evaluator failed/,
+  );
+});
+
+test("throws when an invalid evaluator registration is supplied", async () => {
+  await assert.rejects(
+    runPipeline({
+      evaluators: [{ key: "keywordMatch" }],
+    }),
+    /Invalid evaluator supplied to pipeline/,
+  );
+});
+

--- a/ai-ml/pipeline/aggregator.js
+++ b/ai-ml/pipeline/aggregator.js
@@ -1,0 +1,25 @@
+import { validateEvaluatorResult } from "./evaluatorContract.js";
+
+const round = (value) => Math.round(value * 100) / 100;
+
+const clampScore = (value) => Math.min(Math.max(value, 0), 100);
+
+export const aggregateEvaluatorResults = (results = []) => {
+  const evaluators = results.map(validateEvaluatorResult);
+
+  const totalWeightedScore = round(
+    clampScore(evaluators.reduce((sum, item) => sum + item.weightedScore, 0)),
+  );
+
+  const breakdown = evaluators.reduce((acc, item) => {
+    acc[item.key] = item;
+    return acc;
+  }, {});
+
+  return {
+    score: totalWeightedScore,
+    breakdown,
+    evaluators,
+  };
+};
+

--- a/ai-ml/pipeline/evaluatorContract.js
+++ b/ai-ml/pipeline/evaluatorContract.js
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+const flexibleRecordSchema = z.record(z.string(), z.unknown()).default({});
+
+export const evaluatorResultSchema = z
+  .object({
+    key: z.string().trim().min(1),
+    label: z.string().trim().min(1),
+    score: z.number().min(0).max(100),
+    weight: z.number().min(0).max(1),
+    weightedScore: z.number().min(0).max(100),
+    summary: z.string().default(""),
+    details: flexibleRecordSchema,
+    meta: flexibleRecordSchema,
+  })
+  .strict();
+
+export const validateEvaluatorResult = (result) => evaluatorResultSchema.parse(result);
+

--- a/ai-ml/pipeline/runPipeline.js
+++ b/ai-ml/pipeline/runPipeline.js
@@ -1,0 +1,44 @@
+import { aggregateEvaluatorResults } from "./aggregator.js";
+import { validateEvaluatorResult } from "./evaluatorContract.js";
+
+const formatValidationIssues = (error) => {
+  if (!Array.isArray(error?.issues) || error.issues.length === 0) {
+    return error.message;
+  }
+
+  return error.issues
+    .map((issue) => {
+      const field = issue.path.length > 0 ? issue.path.join(".") : "result";
+      return `${field}: ${issue.message}`;
+    })
+    .join("; ");
+};
+
+export const runPipeline = async ({ evaluators = [], context = {} } = {}) => {
+  const results = [];
+
+  for (const evaluator of evaluators) {
+    if (!evaluator || typeof evaluator.evaluate !== "function") {
+      throw new Error("Invalid evaluator supplied to pipeline");
+    }
+
+    const result = await evaluator.evaluate(context);
+    let validated;
+    try {
+      validated = validateEvaluatorResult(result);
+    } catch (error) {
+      if (process.env.NODE_ENV !== "production") {
+        console.error(`Invalid evaluator output from "${evaluator.key || "unknown"}":`, result);
+      }
+
+      throw new Error(
+        `Evaluator "${evaluator.key || "unknown"}" returned invalid output: ${formatValidationIssues(error)}`,
+      );
+    }
+
+    results.push(validated);
+  }
+
+  return aggregateEvaluatorResults(results);
+};
+

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -86,6 +86,10 @@ Implemented:
 
 - Skill evaluator test coverage in `evaluators/__tests__/skillEvaluator.test.js`
 - Keyword evaluator test coverage in `evaluators/__tests__/keywordEvaluator.test.js`
+- Resume analysis pipeline helpers:
+  - `pipeline/evaluatorContract.js`: shared evaluator output schema
+  - `pipeline/runPipeline.js`: unified evaluator execution runner
+  - `pipeline/aggregator.js`: weighted scoring and breakdown aggregation
 
 Scaffolded placeholders:
 

--- a/docs/api/resume-analyze-contract.md
+++ b/docs/api/resume-analyze-contract.md
@@ -1,0 +1,121 @@
+# Resume Analyze API Contract Snapshot
+
+Snapshot date: 2026-04-23
+
+Endpoint: `POST /api/resume/analyze`
+
+Route middleware order:
+
+1. `protect`
+2. `authorizeRoles("student")`
+3. `uploadResumeMiddleware`
+4. `analyzeResume`
+
+Pre-refactor controller flow captured as the baseline safety reference:
+
+1. Rejects when `req.file` is missing.
+2. Rejects when the uploaded original filename extension is not `.pdf`.
+3. Parses the uploaded PDF with `parseResume(req.file.path)`.
+4. Normalizes optional `req.body.jobSkills`.
+5. Runs `skillEvaluator` only when parsed resume skills and normalized job skills are both present; otherwise `skillMatch` is `{}`.
+6. Reads and trims optional `req.body.jobDescription`.
+7. Runs `keywordEvaluator` only when a trimmed job description and parsed resume text are both present; otherwise `keywordMatch` is `{}`.
+8. Builds candidate experience text from parsed experience lines, falling back to full resume text.
+9. Runs `experienceEvaluator`; current behavior returns an object even when no required experience is detected.
+10. Builds response and persistence file metadata from `req.file`.
+11. Removes `resumeText` from parsed data before saving and responding.
+12. Saves a `Resume` MongoDB record with parsed fields, job inputs, evaluator outputs, and file metadata.
+13. Builds a success message from evaluator outputs.
+14. Responds with HTTP `200`.
+
+Success response JSON shape to preserve:
+
+```json
+{
+  "success": true,
+  "message": "Resume parsed, skill match and keyword relevance and experience fit evaluated, and saved successfully",
+  "resumeId": "<MongoDB ObjectId>",
+  "data": {
+    "name": "Candidate Name or Unknown",
+    "email": "candidate@example.com or null",
+    "phone": "phone string or null",
+    "skills": ["JavaScript", "React"],
+    "education": ["education line"],
+    "experience": ["experience line"],
+    "projects": ["project line"],
+    "certifications": ["certification line"],
+    "linkedin": "https://www.linkedin.com/in/example or null",
+    "github": "https://github.com/example or null",
+    "portfolio": "https://example.dev or null",
+    "keywords": ["JavaScript", "React"],
+    "extractedTextLength": 1234
+  },
+  "skillMatch": {
+    "score": 100,
+    "weight": 1,
+    "feedback": ["Great! 2/2 job skills match."],
+    "matchedSkills": ["javascript", "react"],
+    "missingSkills": [],
+    "extraSkills": []
+  },
+  "keywordMatch": {
+    "score": 100,
+    "weight": 0.2,
+    "feedback": ["Resume contains most important job description keywords"],
+    "matchedKeywords": ["JavaScript", "React"],
+    "missingKeywords": []
+  },
+  "experienceMatch": {
+    "score": 100,
+    "weight": 0.2,
+    "feedback": [
+      "Candidate experience meets or exceeds job requirements",
+      "Required experience: 2 years",
+      "Candidate experience: 3 years"
+    ],
+    "candidateExperience": 3,
+    "requiredExperience": 2,
+    "experienceGap": 0
+  },
+  "file": {
+    "originalName": "resume.pdf",
+    "storedName": "generated-upload-name.pdf",
+    "path": "/uploads/generated-upload-name.pdf",
+    "size": "12.34 KB",
+    "mimeType": "application/pdf"
+  },
+  "evaluatorBreakdown": [
+    {
+      "key": "skillMatch",
+      "label": "Skill Match",
+      "score": 100,
+      "weight": 1,
+      "weightedScore": 100,
+      "summary": "Great! 2/2 job skills match.",
+      "details": {
+        "feedback": ["Great! 2/2 job skills match."],
+        "matchedSkills": ["javascript", "react"],
+        "missingSkills": [],
+        "extraSkills": []
+      },
+      "meta": {}
+    }
+  ],
+  "overallScore": 100
+}
+```
+
+Notes for contract tests:
+
+- `data` intentionally excludes `resumeText`.
+- `skillMatch` may be `{}` when no valid `jobSkills` are supplied or the parsed resume has no skills.
+- `keywordMatch` may be `{}` when no non-empty `jobDescription` is supplied or parsed resume text is unavailable.
+- `experienceMatch` is currently always an object from `experienceEvaluator`.
+- `evaluatorBreakdown` and `overallScore` are additive pipeline fields from the refactor; existing top-level fields remain unchanged for backward compatibility.
+- If `jobSkills` starts with `[` but is invalid JSON, the request can still succeed with this message:
+
+```json
+{
+  "message": "Resume parsed and saved, but jobSkills JSON format is invalid"
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "google-auth-library": "^10.6.2"
+        "google-auth-library": "^10.6.2",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/agent-base": {
@@ -296,6 +297,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
+  "type": "module",
   "dependencies": {
-    "google-auth-library": "^10.6.2"
+    "google-auth-library": "^10.6.2",
+    "zod": "^4.3.6"
   }
 }

--- a/server/src/database/models/Resume.js
+++ b/server/src/database/models/Resume.js
@@ -92,6 +92,14 @@ const resumeSchema = new mongoose.Schema(
       requiredExperience: Number,
       experienceGap: Number,
     },
+    evaluatorBreakdown: {
+      type: [mongoose.Schema.Types.Mixed],
+      default: [],
+    },
+    aggregatedScore: {
+      type: Number,
+      default: null,
+    },
   },
   {
     timestamps: true,

--- a/server/src/modules/resumes/__tests__/controller.analyze.test.js
+++ b/server/src/modules/resumes/__tests__/controller.analyze.test.js
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import test, { afterEach } from "node:test";
+import express from "express";
+import globalErrorHandler from "../../../middleware/errorMiddleware.js";
+import {
+  analyzeResume,
+  resetResumeControllerDependencies,
+  setResumeControllerDependencies,
+} from "../controller.js";
+
+const parsedResume = {
+  name: "Ada Lovelace",
+  email: "ada@example.com",
+  phone: "1234567890",
+  skills: ["JavaScript", "React", "Node.js"],
+  education: ["BSc Computer Science"],
+  experience: ["Software Engineer with 3 years experience"],
+  projects: ["Resume analyzer"],
+  certifications: ["AWS Certified"],
+  linkedin: "https://www.linkedin.com/in/ada",
+  github: "https://github.com/ada",
+  portfolio: "https://ada.dev",
+  keywords: ["JavaScript", "React", "Node.js"],
+  extractedTextLength: 128,
+  resumeText:
+    "Ada Lovelace JavaScript React Node.js developer with 3 years experience building APIs.",
+};
+
+afterEach(() => {
+  resetResumeControllerDependencies();
+});
+
+const createApp = () => {
+  const app = express();
+
+  app.use(express.json());
+  app.post(
+    "/api/resume/analyze",
+    (req, res, next) => {
+      req.file = {
+        originalname: "resume.pdf",
+        filename: "test-resume.pdf",
+        path: "uploads/test-resume.pdf",
+        size: 12 * 1024,
+        mimetype: "application/pdf",
+      };
+      next();
+    },
+    analyzeResume,
+  );
+  app.use(globalErrorHandler);
+
+  return app;
+};
+
+const postAnalyze = async (body = {}) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/resume/analyze`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    return {
+      status: response.status,
+      body: await response.json(),
+    };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+};
+
+const stubControllerDependencies = () => {
+  const savedPayloads = [];
+
+  setResumeControllerDependencies({
+    parseResume: async () => parsedResume,
+    createResume: async (payload) => {
+      savedPayloads.push(payload);
+      return {
+        _id: "64f1f77bcf86cd7994390111",
+        ...payload,
+      };
+    },
+  });
+
+  return savedPayloads;
+};
+
+const assertLegacyAnalyzeResponse = (body) => {
+  assert.equal(body.success, true);
+  assert.equal(typeof body.message, "string");
+  assert.equal(body.resumeId, "64f1f77bcf86cd7994390111");
+  assert.ok(body.data);
+  assert.ok(body.skillMatch);
+  assert.ok(body.keywordMatch);
+  assert.ok(body.experienceMatch);
+  assert.deepEqual(body.file, {
+    originalName: "resume.pdf",
+    storedName: "test-resume.pdf",
+    path: "/uploads/test-resume.pdf",
+    size: "12.00 KB",
+    mimeType: "application/pdf",
+  });
+  assert.equal(body.data.resumeText, undefined);
+};
+
+test("analyze with jobDescription preserves legacy fields and includes evaluator breakdown", async () => {
+  const savedPayloads = stubControllerDependencies();
+
+  const { status, body } = await postAnalyze({
+    jobSkills: JSON.stringify(["JavaScript", "Node.js", "MongoDB"]),
+    jobDescription: "Need JavaScript Node.js developer with 2 years experience and MongoDB.",
+  });
+
+  assert.equal(status, 200);
+  assertLegacyAnalyzeResponse(body);
+  assert.equal(body.skillMatch.score, 67);
+  assert.deepEqual(body.skillMatch.matchedSkills, ["javascript", "node.js"]);
+  assert.deepEqual(body.skillMatch.missingSkills, ["mongodb"]);
+  assert.equal(body.keywordMatch.weight, 0.2);
+  assert.ok(body.keywordMatch.matchedKeywords.includes("JavaScript"));
+  assert.ok(body.keywordMatch.missingKeywords.includes("MongoDB"));
+  assert.equal(body.experienceMatch.score, 100);
+  assert.equal(body.experienceMatch.candidateExperience, 3);
+  assert.equal(body.experienceMatch.requiredExperience, 2);
+  assert.equal(body.experienceMatch.experienceGap, 0);
+  assert.deepEqual(
+    body.evaluatorBreakdown.map((item) => item.key),
+    ["skillMatch", "keywordMatch", "experienceMatch"],
+  );
+  assert.equal(typeof body.overallScore, "number");
+  assert.equal(savedPayloads[0].aggregatedScore, body.overallScore);
+  assert.deepEqual(savedPayloads[0].evaluatorBreakdown, body.evaluatorBreakdown);
+});
+
+test("analyze without jobDescription still works with empty optional evaluator fields", async () => {
+  const savedPayloads = stubControllerDependencies();
+
+  const { status, body } = await postAnalyze();
+
+  assert.equal(status, 200);
+  assertLegacyAnalyzeResponse(body);
+  assert.deepEqual(body.skillMatch, {});
+  assert.deepEqual(body.keywordMatch, {});
+  assert.deepEqual(body.experienceMatch, {
+    score: 0,
+    weight: 0.2,
+    feedback: ["Could not detect required experience from the job description"],
+    candidateExperience: 3,
+    requiredExperience: 0,
+    experienceGap: 0,
+  });
+  assert.deepEqual(
+    body.evaluatorBreakdown.map((item) => item.key),
+    ["experienceMatch"],
+  );
+  assert.equal(body.overallScore, 0);
+  assert.equal(savedPayloads[0].aggregatedScore, 0);
+});
+
+test("analyze response shape regression is protected", async () => {
+  stubControllerDependencies();
+
+  const { status, body } = await postAnalyze({
+    jobDescription: "Need JavaScript developer with 2 years experience.",
+  });
+
+  assert.equal(status, 200);
+  assert.deepEqual(Object.keys(body), [
+    "success",
+    "message",
+    "resumeId",
+    "data",
+    "skillMatch",
+    "keywordMatch",
+    "experienceMatch",
+    "file",
+    "evaluatorBreakdown",
+    "overallScore",
+  ]);
+});
+

--- a/server/src/modules/resumes/controller.js
+++ b/server/src/modules/resumes/controller.js
@@ -19,7 +19,7 @@ let controllerDependencies = { ...defaultDependencies };
 
 export const setResumeControllerDependencies = (overrides = {}) => {
   controllerDependencies = {
-    ...controllerDependencies,
+    ...defaultDependencies,
     ...overrides,
   };
 };

--- a/server/src/modules/resumes/controller.js
+++ b/server/src/modules/resumes/controller.js
@@ -1,11 +1,32 @@
 import path from "path";
 import { parseResume } from "../../utils/parseResume.js";
-import { skillEvaluator } from "../../../../ai-ml/evaluators/skillEvaluator.js";
-import { keywordEvaluator } from "../../../../ai-ml/evaluators/keywordEvaluator.js";
-import { experienceEvaluator } from "../../../../ai-ml/evaluators/experienceEvaluator.js";
 import Resume from "../../database/models/Resume.js";
 import asyncHandler from "../../utils/asyncHandler.js";
 import AppError from "../../utils/AppError.js";
+import {
+  experienceMatchEvaluator,
+  keywordMatchEvaluator,
+  skillMatchEvaluator,
+} from "./evaluatorAdapters.js";
+import { runPipeline } from "../../../../ai-ml/pipeline/runPipeline.js";
+
+const defaultDependencies = {
+  parseResume,
+  createResume: (payload) => Resume.create(payload),
+};
+
+let controllerDependencies = { ...defaultDependencies };
+
+export const setResumeControllerDependencies = (overrides = {}) => {
+  controllerDependencies = {
+    ...controllerDependencies,
+    ...overrides,
+  };
+};
+
+export const resetResumeControllerDependencies = () => {
+  controllerDependencies = { ...defaultDependencies };
+};
 
 const parseSkillArrayString = (input) => {
   try {
@@ -50,6 +71,47 @@ const normalizeSkillInput = (skillsInput) => {
   return { skills: [], invalidJson: false };
 };
 
+const toLegacySkillMatch = (pipelineResult) => {
+  const result = pipelineResult.breakdown.skillMatch;
+  if (!result) return {};
+
+  return {
+    score: result.score,
+    weight: result.weight,
+    feedback: result.details.feedback || [],
+    matchedSkills: result.details.matchedSkills || [],
+    missingSkills: result.details.missingSkills || [],
+    extraSkills: result.details.extraSkills || [],
+  };
+};
+
+const toLegacyKeywordMatch = (pipelineResult) => {
+  const result = pipelineResult.breakdown.keywordMatch;
+  if (!result) return {};
+
+  return {
+    score: result.score,
+    weight: result.weight,
+    feedback: result.details.feedback || [],
+    matchedKeywords: result.details.matchedKeywords || [],
+    missingKeywords: result.details.missingKeywords || [],
+  };
+};
+
+const toLegacyExperienceMatch = (pipelineResult) => {
+  const result = pipelineResult.breakdown.experienceMatch;
+  if (!result) return {};
+
+  return {
+    score: result.score,
+    weight: result.weight,
+    feedback: result.details.feedback || [],
+    candidateExperience: result.details.candidateExperience,
+    requiredExperience: result.details.requiredExperience,
+    experienceGap: result.details.experienceGap,
+  };
+};
+
 export const uploadResume = asyncHandler(async (req, res, next) => {
   if (!req.file) {
     return next(new AppError("No file uploaded", 400));
@@ -78,38 +140,43 @@ export const analyzeResume = asyncHandler(async (req, res, next) => {
     return next(new AppError("Only PDF files are supported for resume analysis right now", 400));
   }
 
-  const parsedData = await parseResume(req.file.path).catch((err) => {
+  const parsedData = await controllerDependencies.parseResume(req.file.path).catch((err) => {
     throw new AppError(err.message || "Unable to extract text from resume", 400);
   });
 
   const { skills: jobSkills, invalidJson } = normalizeSkillInput(req.body?.jobSkills);
-  const skillMatch =
-    parsedData.skills?.length && jobSkills.length
-      ? skillEvaluator({
-          resumeSkills: parsedData.skills,
-          jobSkills,
-        })
-      : {};
-
   const jobDescription = typeof req.body?.jobDescription === "string" ? req.body.jobDescription : "";
   const trimmedJobDescription = jobDescription.trim();
-  const keywordMatch =
-    trimmedJobDescription && parsedData.resumeText
-      ? keywordEvaluator({
-          resumeText: parsedData.resumeText,
-          jobDescription: trimmedJobDescription,
-        })
-      : {};
 
   const candidateExperienceText =
     Array.isArray(parsedData.experience) && parsedData.experience.length > 0
       ? parsedData.experience.join(" ")
       : parsedData.resumeText || "";
 
-  const experienceMatch = experienceEvaluator({
-    candidateExperienceText,
-    jobDescription: trimmedJobDescription,
-  }) || {};
+  const evaluators = [];
+  if (parsedData.skills?.length && jobSkills.length) {
+    evaluators.push(skillMatchEvaluator);
+  }
+  if (trimmedJobDescription && parsedData.resumeText) {
+    evaluators.push(keywordMatchEvaluator);
+  }
+  evaluators.push(experienceMatchEvaluator);
+
+  const pipelineResult = await runPipeline({
+    evaluators,
+    context: {
+      parsedResume: parsedData,
+      resumeSkills: parsedData.skills || [],
+      jobSkills,
+      resumeText: parsedData.resumeText || "",
+      jobDescription: trimmedJobDescription,
+      candidateExperienceText,
+    },
+  });
+
+  const skillMatch = toLegacySkillMatch(pipelineResult);
+  const keywordMatch = toLegacyKeywordMatch(pipelineResult);
+  const experienceMatch = toLegacyExperienceMatch(pipelineResult);
 
   const fileData = {
     originalName: req.file.originalname,
@@ -121,13 +188,15 @@ export const analyzeResume = asyncHandler(async (req, res, next) => {
 
   const { resumeText, ...resumeFields } = parsedData;
 
-  const savedResume = await Resume.create({
+  const savedResume = await controllerDependencies.createResume({
     ...resumeFields,
     jobSkills,
     jobDescription: trimmedJobDescription || null,
     skillMatch,
     keywordMatch,
     experienceMatch,
+    evaluatorBreakdown: pipelineResult.evaluators,
+    aggregatedScore: pipelineResult.score,
     file: fileData,
   });
 
@@ -150,6 +219,8 @@ export const analyzeResume = asyncHandler(async (req, res, next) => {
     keywordMatch,
     experienceMatch,
     file: fileData,
+    evaluatorBreakdown: pipelineResult.evaluators,
+    overallScore: pipelineResult.score,
   });
 });
 

--- a/server/src/modules/resumes/evaluatorAdapters.js
+++ b/server/src/modules/resumes/evaluatorAdapters.js
@@ -1,0 +1,98 @@
+import { experienceEvaluator as runExperienceEvaluator } from "../../../../ai-ml/evaluators/experienceEvaluator.js";
+import { keywordEvaluator as runKeywordEvaluator } from "../../../../ai-ml/evaluators/keywordEvaluator.js";
+import { skillEvaluator as runSkillEvaluator } from "../../../../ai-ml/evaluators/skillEvaluator.js";
+
+const round = (value) => Math.round(value * 100) / 100;
+
+const summarizeFeedback = (feedback = []) => {
+  if (Array.isArray(feedback)) return feedback.join(" ");
+  return `${feedback || ""}`;
+};
+
+const weightedScore = ({ score = 0, weight = 0 }) => round(score * weight);
+
+export const skillMatchEvaluator = {
+  key: "skillMatch",
+  evaluate: async (context = {}) => {
+    const result = runSkillEvaluator({
+      resumeSkills: context.resumeSkills || [],
+      jobSkills: context.jobSkills || [],
+    });
+
+    return {
+      key: "skillMatch",
+      label: "Skill Match",
+      score: result.score,
+      weight: result.weight,
+      weightedScore: weightedScore(result),
+      summary: summarizeFeedback(result.feedback),
+      details: {
+        feedback: result.feedback || [],
+        matchedSkills: result.matchedSkills || [],
+        missingSkills: result.missingSkills || [],
+        extraSkills: result.extraSkills || [],
+      },
+      meta: {},
+    };
+  },
+};
+
+export const keywordMatchEvaluator = {
+  key: "keywordMatch",
+  evaluate: async (context = {}) => {
+    const result = runKeywordEvaluator({
+      resumeText: context.resumeText || "",
+      jobDescription: context.jobDescription || "",
+    });
+
+    return {
+      key: "keywordMatch",
+      label: "Keyword Match",
+      score: result.score,
+      weight: result.weight,
+      weightedScore: weightedScore(result),
+      summary: summarizeFeedback(result.feedback),
+      details: {
+        feedback: result.feedback || [],
+        matchedKeywords: result.matchedKeywords || [],
+        missingKeywords: result.missingKeywords || [],
+        extraKeywords: result.extraKeywords || [],
+      },
+      meta: {},
+    };
+  },
+};
+
+export const experienceMatchEvaluator = {
+  key: "experienceMatch",
+  evaluate: async (context = {}) => {
+    const result = runExperienceEvaluator({
+      candidateExperienceText: context.candidateExperienceText || "",
+      jobDescription: context.jobDescription || "",
+      weight: context.experienceWeight,
+    });
+
+    return {
+      key: "experienceMatch",
+      label: "Experience Match",
+      score: result.score,
+      weight: result.weight,
+      weightedScore: weightedScore(result),
+      summary: summarizeFeedback(result.feedback),
+      details: {
+        feedback: result.feedback || [],
+        candidateExperience: result.candidateExperience,
+        requiredExperience: result.requiredExperience,
+        experienceGap: result.experienceGap,
+      },
+      meta: {},
+    };
+  },
+};
+
+export const resumeEvaluatorAdapters = [
+  skillMatchEvaluator,
+  keywordMatchEvaluator,
+  experienceMatchEvaluator,
+];
+


### PR DESCRIPTION
## Summary

Introduces a unified evaluator pipeline for resume analysis so all evaluators follow one strict output contract, are validated consistently, and produce a centralized weighted score with evaluator-wise breakdown. Refactors the resume analysis controller to use the pipeline instead of direct evaluator coupling while preserving the existing /api/resume/analyze response behavior.

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [+] Refactor
- [ +] Documentation
- [ ] Chore

## Related Issue

Closes #93

## Changes Made

-Added a strict evaluator contract and validation flow for all resume evaluators.

-Added a unified pipeline runner and aggregator for consistent execution and scoring.

-Updated the resume analysis controller to use the pipeline instead of direct evaluator calls.

-Documented the pipeline progress in docs/PROJECT_STRUCTURE.md.

## Validation

- [ ] Build passes locally
- [ ] Relevant tests added/updated
- [ +] Documentation updated (if needed)


