### PR TITLE
feat: Build Recruiter Job Posting Pages (UI Shell)

### DIFF
--- a/client/src/app/App.jsx
+++ b/client/src/app/App.jsx
@@ -13,6 +13,8 @@ import OAuthCallback from "../modules/auth/OAuthCallback";
 import ResetPassword from "../modules/auth/ResetPassword";
 import VerifyEmail from "../modules/auth/VerifyEmail";
 import ProfilePage from "../modules/profile/ProfilePage";
+import RecruiterJobsPage from "../modules/recruiter-jobs/pages/RecruiterJobsPage";
+import CreateJobPostingPage from "../modules/recruiter-jobs/pages/CreateJobPostingPage";
 import ProtectedRoute from "../shared/components/ProtectedRoute";
 
 function App() {
@@ -51,6 +53,22 @@ function App() {
         <Route path="/auth/callback" element={<OAuthCallback />} />
         <Route path="/reset-password" element={<ResetPassword />} />
         <Route path="/verify-email" element={<VerifyEmail />} />
+        <Route
+          path="/recruiter/jobs"
+          element={
+            <ProtectedRoute requiredRole="recruiter">
+              <RecruiterJobsPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/recruiter/jobs/new"
+          element={
+            <ProtectedRoute requiredRole="recruiter">
+              <CreateJobPostingPage />
+            </ProtectedRoute>
+          }
+        />
         <Route path="/profile" element={<ProfilePage />} />
       </Routes>
       <ChatWidget />

--- a/client/src/modules/profile/ProfilePage.jsx
+++ b/client/src/modules/profile/ProfilePage.jsx
@@ -19,8 +19,8 @@ import ProfileField from "./components/ProfileField";
 
 // Mock user — no API calls, frontend-only
 const MOCK_USER = {
-  name: "Abhishek Kumar",
-  email: "abhishek@example.com",
+  name: "Candidate One",
+  email: "candidate@example.com",
   role: "student",           // "student" | "tutor" | "recruiter"
   isEmailVerified: true,
   createdAt: "2024-12-01T10:30:00Z",

--- a/client/src/modules/recruiter-jobs/components/JobPostingCard.jsx
+++ b/client/src/modules/recruiter-jobs/components/JobPostingCard.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Button from "../../../shared/components/Button";
+
+const JobPostingCard = ({ job, onViewStats, onEdit }) => {
+  const { title, location, level, createdAt, status } = job;
+
+  const formatDate = (dateString) => {
+    return new Date(dateString).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  };
+
+  return (
+    <div className="bg-slate-900/70 border border-white/10 rounded-xl p-6 shadow-xl backdrop-blur hover:border-blue-500/50 transition-all">
+      <div className="flex justify-between items-start mb-4">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-100">{title}</h3>
+          <div className="flex items-center gap-3 mt-1 text-sm text-slate-400">
+            <span>{location}</span>
+            <span className="w-1 h-1 bg-slate-600 rounded-full"></span>
+            <span>{level}</span>
+          </div>
+        </div>
+        <span className={`px-2.5 py-0.5 rounded-full text-xs font-medium ${
+          status === "active" 
+            ? "bg-emerald-500/20 text-emerald-300 border border-emerald-500/30" 
+            : "bg-slate-800 text-slate-400 border border-slate-700"
+        }`}>
+          {status.charAt(0).toUpperCase() + status.slice(1)}
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between mt-6 pt-4 border-t border-white/5">
+        <span className="text-xs text-slate-500">
+          Posted on {formatDate(createdAt)}
+        </span>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={() => onEdit(job)} className="border-slate-700 text-slate-300 hover:bg-slate-800">
+            Edit
+          </Button>
+          <Button variant="primary" size="sm" onClick={() => onViewStats(job)} className="bg-blue-600 hover:bg-blue-500">
+            View Recommendations
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+JobPostingCard.propTypes = {
+  job: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    location: PropTypes.string.isRequired,
+    level: PropTypes.string.isRequired,
+    createdAt: PropTypes.string.isRequired,
+    status: PropTypes.string.isRequired,
+  }).isRequired,
+  onViewStats: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
+};
+
+export default JobPostingCard;

--- a/client/src/modules/recruiter-jobs/components/JobPostingForm.jsx
+++ b/client/src/modules/recruiter-jobs/components/JobPostingForm.jsx
@@ -1,0 +1,157 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import Input from "../../../shared/components/Input";
+import Select from "../../../shared/components/Select";
+import Button from "../../../shared/components/Button";
+
+const LEVEL_OPTIONS = [
+  { value: "Entry Level", label: "Entry Level" },
+  { value: "Mid Level", label: "Mid Level" },
+  { value: "Senior Level", label: "Senior Level" },
+  { value: "Lead/Manager", label: "Lead/Manager" },
+  { value: "Executive", label: "Executive" },
+];
+
+const JobPostingForm = ({ onSubmit, initialData = {}, isLoading = false }) => {
+  const [formData, setFormData] = useState({
+    title: initialData.title || "",
+    location: initialData.location || "",
+    level: initialData.level || "",
+    description: initialData.description || "",
+    skills: initialData.skills || "",
+    experience: initialData.experience || "",
+  });
+
+  const [errors, setErrors] = useState({});
+
+  const handleChange = (e) => {
+    const { id, value } = e.target;
+    setFormData((prev) => ({ ...prev, [id]: value }));
+    // Clear error when user types
+    if (errors[id]) {
+      setErrors((prev) => ({ ...prev, [id]: null }));
+    }
+  };
+
+  const validate = () => {
+    const newErrors = {};
+    if (!formData.title) newErrors.title = "Job title is required";
+    if (!formData.location) newErrors.location = "Location is required";
+    if (!formData.level) newErrors.level = "Level is required";
+    if (!formData.description) newErrors.description = "Description is required";
+    if (!formData.skills) newErrors.skills = "Required skills are required";
+    if (!formData.experience) newErrors.experience = "Experience details are required";
+    
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (validate()) {
+      onSubmit(formData);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <Input
+          id="title"
+          label="Job Title"
+          placeholder="e.g. Senior Software Engineer"
+          value={formData.title}
+          onChange={handleChange}
+          error={errors.title}
+          required
+        />
+        <Input
+          id="location"
+          label="Location"
+          placeholder="e.g. New York, NY (Remote)"
+          value={formData.location}
+          onChange={handleChange}
+          error={errors.location}
+          required
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <Select
+          id="level"
+          label="Job Level"
+          options={LEVEL_OPTIONS}
+          value={formData.level}
+          onChange={handleChange}
+          error={errors.level}
+          required
+        />
+        <Input
+          id="experience"
+          label="Experience Required"
+          placeholder="e.g. 5+ years in React & Node.js"
+          value={formData.experience}
+          onChange={handleChange}
+          error={errors.experience}
+          required
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="description" className="text-sm font-medium text-gray-300">
+          Job Description <span className="text-red-500">*</span>
+        </label>
+        <textarea
+          id="description"
+          rows={5}
+          className={`w-full rounded-lg border bg-slate-800 px-3.5 py-2.5 text-sm text-white caret-white placeholder:text-gray-500 transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-0 ${
+            errors.description 
+              ? "border-red-400 focus:ring-red-400 focus:border-red-400" 
+              : "border-slate-600 focus:ring-blue-500 focus:border-blue-500 hover:border-slate-500"
+          }`}
+          placeholder="Describe the role, responsibilities, and team..."
+          value={formData.description}
+          onChange={handleChange}
+        />
+        {errors.description && (
+          <p className="text-xs text-red-400 flex items-center gap-1 mt-1">
+            <svg className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M18 10A8 8 0 1 1 2 10a8 8 0 0 1 16 0Zm-8-5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 10 5Zm0 10a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+            </svg>
+            {errors.description}
+          </p>
+        )}
+      </div>
+
+      <Input
+        id="skills"
+        label="Required Skills (Comma separated)"
+        placeholder="e.g. React, TypeScript, Node.js, AWS"
+        value={formData.skills}
+        onChange={handleChange}
+        error={errors.skills}
+        helperText="These skills will be used to match candidates."
+        required
+      />
+
+      <div className="flex justify-end pt-4">
+        <Button
+          type="submit"
+          variant="primary"
+          loading={isLoading}
+          className="px-8 bg-blue-600 hover:bg-blue-500"
+        >
+          {initialData.id ? "Update Job Posting" : "Create Job Posting"}
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+JobPostingForm.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  initialData: PropTypes.object,
+  isLoading: PropTypes.bool,
+};
+
+export default JobPostingForm;

--- a/client/src/modules/recruiter-jobs/pages/CreateJobPostingPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/CreateJobPostingPage.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import { useNavigate, Link } from "react-router-dom";
+import { ArrowLeft, Briefcase } from "lucide-react";
+import Navbar from "../../../shared/landing/Navbar";
+import Button from "../../../shared/components/Button";
+import JobPostingForm from "../components/JobPostingForm";
+import { createJobPosting } from "../services/jobPostingService";
+
+const CreateJobPostingPage = () => {
+  const navigate = useNavigate();
+  const { token } = useSelector((state) => state.auth);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (formData) => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const response = await createJobPosting(formData, token);
+      if (response.success) {
+        navigate("/recruiter/jobs");
+      }
+    } catch (err) {
+      setError(err.message || "Failed to create job posting. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] p-3 sm:p-5 pt-20 sm:pt-28 text-slate-100">
+      <Navbar />
+
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 py-8">
+        <Link 
+          to="/recruiter/jobs" 
+          className="inline-flex items-center gap-2 text-slate-400 hover:text-blue-400 transition-colors w-fit group"
+        >
+          <ArrowLeft size={18} className="group-hover:-translate-x-1 transition-transform" />
+          <span>Back to Jobs</span>
+        </Link>
+
+        <div className="flex flex-col gap-1 mb-2">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-blue-500/10 rounded-lg text-blue-400">
+              <Briefcase size={24} />
+            </div>
+            <h1 className="text-3xl font-bold text-white">Create Job Posting</h1>
+          </div>
+          <p className="text-slate-400 mt-2">
+            Fill in the details below to post a new job. We'll use this information to recommend the best candidates.
+          </p>
+        </div>
+
+        {error && (
+          <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-xl text-red-400 text-sm flex items-start gap-3">
+            <svg className="w-5 h-5 shrink-0 mt-0.5" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M18 10A8 8 0 1 1 2 10a8 8 0 0 1 16 0Zm-8-5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 10 5Zm0 10a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+            </svg>
+            <p>{error}</p>
+          </div>
+        )}
+
+        <div className="bg-slate-900/70 border border-white/10 rounded-2xl p-6 sm:p-8 shadow-2xl backdrop-blur">
+          <JobPostingForm onSubmit={handleSubmit} isLoading={isLoading} />
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default CreateJobPostingPage;

--- a/client/src/modules/recruiter-jobs/pages/RecruiterJobsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterJobsPage.jsx
@@ -1,0 +1,120 @@
+import React, { useState, useEffect } from "react";
+import { useSelector } from "react-redux";
+import { Link, useNavigate } from "react-router-dom";
+import { Plus, Briefcase, Search } from "lucide-react";
+import Navbar from "../../../shared/landing/Navbar";
+import Button from "../../../shared/components/Button";
+import Input from "../../../shared/components/Input";
+import LoadingState from "../../../shared/components/LoadingState";
+import ErrorState from "../../../shared/components/ErrorState";
+import EmptyState from "../../../shared/components/EmptyState";
+import JobPostingCard from "../components/JobPostingCard";
+import { getRecruiterJobs } from "../services/jobPostingService";
+
+const RecruiterJobsPage = () => {
+  const navigate = useNavigate();
+  const { token } = useSelector((state) => state.auth);
+  const [jobs, setJobs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  useEffect(() => {
+    const fetchJobs = async () => {
+      try {
+        setLoading(true);
+        const response = await getRecruiterJobs(token);
+        if (response.success) {
+          setJobs(response.jobs);
+        }
+      } catch (err) {
+        setError("Failed to load job postings. Please try again later.");
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchJobs();
+  }, [token]);
+
+  const filteredJobs = jobs.filter((job) =>
+    job.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    job.location.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  const handleEditJob = (job) => {
+    // navigate(`/recruiter/jobs/edit/${job.id}`);
+    console.log("Edit job", job);
+  };
+
+  const handleViewRecommendations = (job) => {
+    // navigate(`/recruiter/jobs/${job.id}/recommendations`);
+    console.log("View recommendations", job);
+  };
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] p-3 sm:p-5 pt-20 sm:pt-28 text-slate-100">
+      <Navbar />
+
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 py-8">
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-white">Manage Job Postings</h1>
+            <p className="text-slate-400 mt-1">View and manage your active job listings and recommendations.</p>
+          </div>
+          <Link to="/recruiter/jobs/new">
+            <Button variant="primary" leftIcon={<Plus size={18} />} className="bg-blue-600 hover:bg-blue-500">
+              Post New Job
+            </Button>
+          </Link>
+        </div>
+
+        <div className="relative">
+          <Input
+            id="search-jobs"
+            placeholder="Search by title or location..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            leftIcon={<Search size={18} />}
+            className="max-w-md"
+          />
+        </div>
+
+        {loading ? (
+          <div className="py-20">
+            <LoadingState message="Fetching your job postings..." />
+          </div>
+        ) : error ? (
+          <ErrorState message={error} onRetry={() => window.location.reload()} />
+        ) : filteredJobs.length === 0 ? (
+          <EmptyState
+            icon={<Briefcase size={48} className="text-slate-600" />}
+            title={searchTerm ? "No matching jobs found" : "No job postings yet"}
+            description={searchTerm ? "Try adjusting your search filters." : "Get started by creating your first job posting to find the best candidates."}
+            action={!searchTerm && (
+              <Link to="/recruiter/jobs/new">
+                <Button variant="primary" className="bg-blue-600 hover:bg-blue-500 mt-4">
+                  Create First Posting
+                </Button>
+              </Link>
+            )}
+          />
+        ) : (
+          <div className="grid grid-cols-1 gap-4">
+            {filteredJobs.map((job) => (
+              <JobPostingCard
+                key={job.id}
+                job={job}
+                onEdit={handleEditJob}
+                onViewStats={handleViewRecommendations}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+};
+
+export default RecruiterJobsPage;

--- a/client/src/modules/recruiter-jobs/services/jobPostingService.js
+++ b/client/src/modules/recruiter-jobs/services/jobPostingService.js
@@ -1,0 +1,53 @@
+import { apiRequest } from "../../../services/apiClient";
+
+/**
+ * Service for managing recruiter job postings.
+ * Logic is structured to use the apiRequest helper for backend integration.
+ */
+
+export const getRecruiterJobs = async (token) => {
+  // Real API implementation (uncomment when backend is ready)
+  // return apiRequest("/recruiter/jobs", { token });
+  
+  // Current mock implementation for development/demo
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const storedJobs = localStorage.getItem("recruiter_jobs");
+      resolve({
+        success: true,
+        jobs: storedJobs ? JSON.parse(storedJobs) : []
+      });
+    }, 800);
+  });
+};
+
+export const createJobPosting = async (jobData, token) => {
+  // Real API implementation (uncomment when backend is ready)
+  /*
+  return apiRequest("/recruiter/jobs", {
+    method: "POST",
+    body: jobData,
+    token
+  });
+  */
+
+  // Current mock implementation using localStorage for testing
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const storedJobs = JSON.parse(localStorage.getItem("recruiter_jobs") || "[]");
+      const newJob = {
+        id: `job_${Date.now()}`,
+        ...jobData,
+        createdAt: new Date().toISOString(),
+        status: "active"
+      };
+      
+      localStorage.setItem("recruiter_jobs", JSON.stringify([newJob, ...storedJobs]));
+      
+      resolve({
+        success: true,
+        job: newJob
+      });
+    }, 1000);
+  });
+};

--- a/client/src/shared/components/ProtectedRoute.jsx
+++ b/client/src/shared/components/ProtectedRoute.jsx
@@ -3,8 +3,8 @@ import { Navigate, useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
-const ProtectedRoute = ({ children }) => {
-  const { isAuthenticated } = useSelector((state) => state.auth);
+const ProtectedRoute = ({ children, requiredRole }) => {
+  const { isAuthenticated, user } = useSelector((state) => state.auth);
   const location = useLocation();
 
   if (!isAuthenticated) {
@@ -15,11 +15,18 @@ const ProtectedRoute = ({ children }) => {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
+  if (requiredRole && user?.role !== requiredRole) {
+    // If a role is required but the user doesn't have it, redirect to dashboard
+    // or a specialized unauthorized page if one exists.
+    return <Navigate to="/dashboard" replace />;
+  }
+
   return children;
 };
 
 ProtectedRoute.propTypes = {
   children: PropTypes.node.isRequired,
+  requiredRole: PropTypes.string,
 };
 
 export default ProtectedRoute;

--- a/client/src/shared/landing/Navbar.jsx
+++ b/client/src/shared/landing/Navbar.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { Home, FileText, LayoutDashboard, MessageSquare, LogIn, UserPlus, X, Menu, LogOut, User, ChevronDown } from 'lucide-react';
+import { Home, FileText, LayoutDashboard, MessageSquare, LogIn, UserPlus, X, Menu, LogOut, User, ChevronDown, Briefcase } from 'lucide-react';
 import Button from './Button';
 import { logout } from '../../features/auth/authSlice';
 
@@ -38,7 +38,10 @@ const Navbar = () => {
 
   const navLinks = [
     { name: 'Home', path: '/', icon: <Home size={20} /> },
-    { name: 'Resume Analyzer', path: '/resume-analyzer', icon: <FileText size={20} /> },
+    ...(user?.role === 'recruiter' 
+      ? [{ name: 'Manage Jobs', path: '/recruiter/jobs', icon: <Briefcase size={20} /> }]
+      : [{ name: 'Resume Analyzer', path: '/resume-analyzer', icon: <FileText size={20} /> }]
+    ),
     { name: 'Dashboard', path: '/dashboard', icon: <LayoutDashboard size={20} /> },
     { name: 'Mock Interview', path: '/mock-interview', icon: <MessageSquare size={20} /> },
   ];

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -36,6 +36,12 @@ Implemented:
 - User Profile UI:
   - `src/modules/profile/ProfilePage.jsx`
   - `src/modules/profile/components/ProfileField.jsx`
+- Recruiter Job Management:
+  - `src/modules/recruiter-jobs/pages/RecruiterJobsPage.jsx`
+  - `src/modules/recruiter-jobs/pages/CreateJobPostingPage.jsx`
+  - `src/modules/recruiter-jobs/components/JobPostingForm.jsx`
+  - `src/modules/recruiter-jobs/components/JobPostingCard.jsx`
+  - `src/modules/recruiter-jobs/services/jobPostingService.js`
 - Shared UI primitives:
   - `src/shared/components/Button.jsx`
   - `src/shared/components/Input.jsx`

--- a/server/.env.example
+++ b/server/.env.example
@@ -20,4 +20,4 @@ EMAIL_HOST=smtp.mailtrap.io
 EMAIL_PORT=2525
 EMAIL_USER=your_username_here
 EMAIL_PASS=your_password_here
-EMAIL_FROM=SkillsSphere AI <praptiyush2007@gmail.com>
+EMAIL_FROM=SkillsSphere AI <no-reply@skillssphere.ai>


### PR DESCRIPTION
### Summary
Implemented the recruiter-facing UI for managing job postings as part of the initial recruiter module shell. This includes the ability to view a list of job postings and create new ones.

### Key Changes
- **New Pages**: Added RecruiterJobsPage (list view) and CreateJobPostingPage (creation view).
- **Components**: Developed JobPostingForm for input and JobPostingCard for display, utilizing shared UI primitives.
- **Service Layer**: Added jobPostingService with mock logic for development; structured for easy backend integration.
- **Authentication**: Updated ProtectedRoute to support role-based access control (RBAC), ensuring only recruiters can access these routes.
- **Navigation**: Dynamically updated the Navbar to display 'Manage Jobs' for users with the recruiter role.
- **Documentation**: Updated PROJECT_STRUCTURE.md to reflect the new module progress.

<img width="1894" height="1032" alt="Screenshot 2026-04-24 161838" src="https://github.com/user-attachments/assets/532630c0-93d1-4260-891a-e46d639ca088" />
<img width="1891" height="1025" alt="Screenshot 2026-04-24 161931" src="https://github.com/user-attachments/assets/26e0cd56-922d-4614-8417-e2f74a54cdd7" />


### Related Issue
Closes #109