### PR TITLE
fix: enforce user ownership on resume access

### DIFF
--- a/server/src/database/models/Resume.js
+++ b/server/src/database/models/Resume.js
@@ -2,6 +2,11 @@ import mongoose from "mongoose";
 
 const resumeSchema = new mongoose.Schema(
   {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
     name: {
       type: String,
       default: null,

--- a/server/src/modules/resumes/controller.js
+++ b/server/src/modules/resumes/controller.js
@@ -202,6 +202,7 @@ export const analyzeResume = asyncHandler(async (req, res, next) => {
   const { resumeText, ...resumeFields } = parsedData;
 
   const savedResume = await controllerDependencies.createResume({
+    user: req.user._id,
     ...resumeFields,
     jobSkills,
     jobDescription: trimmedJobDescription || null,
@@ -243,6 +244,11 @@ export const getResumeResult = asyncHandler(async (req, res, next) => {
 
   if (!resume) {
     return next(new AppError("Resume not found", 404));
+  }
+
+  // Ensure the user owns this resume
+  if (resume.user.toString() !== req.user._id.toString()) {
+    return next(new AppError("You do not have permission to view this resume", 403));
   }
 
   res.status(200).json({


### PR DESCRIPTION
## Summary

Added a user reference field to the Resume schema to formally associate each resume with its owner. Updated the analyzeResume controller to persist the authenticated user's ID on creation, and added an ownership check in getResumeResult to prevent unauthorized access to other users' resume data.

## Type of Change

- [X] Bug fix

## Related Issue

Closes #119 

## Changes Made

1. Added user field (ObjectId, ref: User, required) to server/src/database/models/Resume.js to link every resume to its owner
2. Updated analyzeResume in server/src/modules/resumes/controller.js to save req.user._id when creating a resume document
3. Added ownership verification in getResumeResult — returns 403 Forbidden if the requesting user does not match resume.user

## Validation

- [X] Build passes locally

## Screenshots 
<img width="1006" height="595" alt="Screenshot 2026-04-26 000121" src="https://github.com/user-attachments/assets/380bd998-c569-42f3-9b5a-ce76a276f6e7" />
