### PR TITLE
feat: implement latest-only resume flow and singleton pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ SkillSphere-AI/
 - `POST /api/auth/logout`
 - `GET /api/auth/me`
 - `POST /api/resume/upload`
-- `POST /api/resume/analyze`
+- `POST /api/resume/analyze` (v2: uses latest-only upsert flow)
+- `GET /api/resume/me/latest`: fetch user's latest parsed resume (no raw resumeText)
 - `GET /api/resume/result/:id`
+
 - `GET /uploads/:filename`
 - `POST /api/jobs`: create a new job (Recruiter only)
 - `GET /api/jobs`: list all published jobs
@@ -178,6 +180,10 @@ Implemented:
 - Weighted experience scoring with explainable feedback (`score`, `weight`, `candidateExperience`, `requiredExperience`, `experienceGap`)
 - Unit tests for experience evaluator at `ai-ml/evaluators/__tests__/experienceEvaluator.test.js`
 - `/api/resume/analyze` now includes `experienceMatch` in response and MongoDB resume records
+- **Latest-Only Resume Flow**: Implemented singleton resume pattern where each user keeps only one stored parsed record, with new uploads replacing the previous one
+- **Resume Service Layer**: Introduced `service.js` in the resumes module to manage upsert and ownership logic
+- **Data Privacy**: Enforced exclusion of `resumeText` from all resume API responses
+
 
 ### Authentication & Security Progress
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -78,7 +78,9 @@ Implemented:
 - Resume upload and analysis flow:
   - `src/modules/resumes/routes.js`
   - `src/modules/resumes/controller.js`
+  - `src/modules/resumes/service.js` (New: Singleton resume logic and ownership enforcement)
   - `src/middleware/uploadResume.js`
+
   - `src/utils/parseResume.js`
 - Evaluator configuration:
   - `src/config/evaluatorConfig.js`
@@ -123,8 +125,10 @@ Scaffolded placeholders:
 - `POST /api/auth/verify-email`: verify user account via OTP
 - `POST /api/auth/resend-otp`: resend email verification OTP
 - `POST /api/resume/upload`: upload resume file
-- `POST /api/resume/analyze`: parse PDF resume, optional skill match, optional keyword relevance (`jobDescription`)
-- `GET /api/resume/result/:id`: placeholder result retrieval endpoint
+- `POST /api/resume/analyze`: parse PDF resume, latest-only upsert flow, optional skill/keyword/experience match
+- `GET /api/resume/me/latest`: fetch user's latest parsed resume (no raw resumeText)
+- `GET /api/resume/result/:id`: fetch stored resume record by ID
+
 - `GET /uploads/:filename`: static file access for uploaded files
 - `POST /api/jobs`: create a new job (Recruiter only)
 - `GET /api/jobs`: list all published jobs

--- a/server/package.json
+++ b/server/package.json
@@ -5,8 +5,10 @@
   "main": "index.js",
   "scripts": {
     "dev": "node index.js",
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node --test"
   },
+
   "dependencies": {
     "bcryptjs": "^3.0.3",
     "cors": "^2.8.6",

--- a/server/src/modules/resumes/__tests__/controller.analyze.test.js
+++ b/server/src/modules/resumes/__tests__/controller.analyze.test.js
@@ -44,8 +44,10 @@ const createApp = () => {
         size: 12 * 1024,
         mimetype: "application/pdf",
       };
+      req.user = { _id: "64f1f77bcf86cd7994390000" };
       next();
     },
+
     analyzeResume,
   );
   app.use(globalErrorHandler);
@@ -79,13 +81,15 @@ const stubControllerDependencies = () => {
 
   setResumeControllerDependencies({
     parseResume: async () => parsedResume,
-    createResume: async (payload) => {
-      savedPayloads.push(payload);
+    upsertResume: async (userId, payload) => {
+      savedPayloads.push({ ...payload, user: userId });
       return {
         _id: "64f1f77bcf86cd7994390111",
         ...payload,
+        user: userId,
       };
     },
+
   });
 
   return savedPayloads;

--- a/server/src/modules/resumes/controller.js
+++ b/server/src/modules/resumes/controller.js
@@ -11,11 +11,14 @@ import {
 } from "./evaluatorAdapters.js";
 import { runPipeline } from "../../../../ai-ml/pipeline/runPipeline.js";
 import { getEvaluatorConfig } from "../../config/evaluatorConfig.js";
+import * as resumeService from "./service.js";
+
 
 const defaultDependencies = {
   parseResume,
-  createResume: (payload) => Resume.create(payload),
+  upsertResume: (userId, payload) => resumeService.upsertResume(userId, payload),
 };
+
 
 let controllerDependencies = { ...defaultDependencies };
 
@@ -201,8 +204,7 @@ export const analyzeResume = asyncHandler(async (req, res, next) => {
 
   const { resumeText, ...resumeFields } = parsedData;
 
-  const savedResume = await controllerDependencies.createResume({
-    user: req.user._id,
+  const savedResume = await controllerDependencies.upsertResume(req.user._id, {
     ...resumeFields,
     jobSkills,
     jobDescription: trimmedJobDescription || null,
@@ -213,6 +215,7 @@ export const analyzeResume = asyncHandler(async (req, res, next) => {
     aggregatedScore: pipelineResult.score,
     file: fileData,
   });
+
 
   const successParts = [];
   if (Object.keys(skillMatch).length > 0) successParts.push("skill match");
@@ -240,7 +243,8 @@ export const analyzeResume = asyncHandler(async (req, res, next) => {
 
 export const getResumeResult = asyncHandler(async (req, res, next) => {
   const { id } = req.params;
-  const resume = await Resume.findById(id).lean();
+  const resume = await Resume.findById(id).select("-resumeText").lean();
+
 
   if (!resume) {
     return next(new AppError("Resume not found", 404));
@@ -257,4 +261,19 @@ export const getResumeResult = asyncHandler(async (req, res, next) => {
     data: resume,
   });
 });
+
+export const getLatestResume = asyncHandler(async (req, res, next) => {
+  const resume = await resumeService.getLatestResume(req.user._id);
+
+  if (!resume) {
+    return next(new AppError("No resume found for this user", 404));
+  }
+
+  res.status(200).json({
+    success: true,
+    message: "Latest resume fetched successfully",
+    data: resume,
+  });
+});
+
 

--- a/server/src/modules/resumes/routes.js
+++ b/server/src/modules/resumes/routes.js
@@ -3,8 +3,10 @@ import { uploadResumeMiddleware } from "../../middleware/uploadResume.js";
 import {
   uploadResume,
   analyzeResume,
-  getResumeResult
+  getResumeResult,
+  getLatestResume
 } from "./controller.js";
+
 
 import { protect, authorizeRoles } from "../../middleware/authMiddleware.js";
 
@@ -13,6 +15,8 @@ const router = express.Router();
 // Only Students can upload and analyze resumes in this example
 router.post("/upload", protect, authorizeRoles("student"), uploadResumeMiddleware, uploadResume);
 router.post("/analyze", protect, authorizeRoles("student"), uploadResumeMiddleware, analyzeResume);
+router.get("/me/latest", protect, getLatestResume);
 router.get("/result/:id", protect, getResumeResult);
+
 
 export default router;

--- a/server/src/modules/resumes/service.js
+++ b/server/src/modules/resumes/service.js
@@ -1,0 +1,39 @@
+import Resume from "../../database/models/Resume.js";
+
+/**
+ * Upsert a resume for a user.
+ * Each user keeps only one stored parsed resume record, 
+ * always replacing the previous one with the most recent upload.
+ * 
+ * @param {string} userId - The ID of the user
+ * @param {Object} resumeData - The parsed resume data to save
+ * @returns {Promise<Object>} The saved resume document
+ */
+export const upsertResume = async (userId, resumeData) => {
+  // Use findOneAndUpdate with upsert: true to ensure only one record per user
+  return await Resume.findOneAndUpdate(
+    { user: userId },
+    { 
+      ...resumeData, 
+      user: userId 
+    },
+    { 
+      new: true, 
+      upsert: true, 
+      runValidators: true 
+    }
+  );
+};
+
+/**
+ * Fetch the user's latest (and only) parsed resume record.
+ * Enforces ownership by filtering by userId and excludes raw resumeText.
+ * 
+ * @param {string} userId - The ID of the user
+ * @returns {Promise<Object|null>} The resume document or null if not found
+ */
+export const getLatestResume = async (userId) => {
+  return await Resume.findOne({ user: userId })
+    .select("-resumeText") // Ensure raw resumeText is excluded if it exists
+    .lean();
+};


### PR DESCRIPTION
## Summary
Implemented a **Singleton Resume Flow** where each user keeps only one stored parsed resume record. New uploads automatically replace previous ones via an upsert mechanism, ensuring a lean database and improved data privacy by excluding raw `resumeText` from all API responses.

## Type of Change
- [x] Feature
- [x] Refactor
- [x] Documentation


## Related Issue
Closes #142 

## Changes Made
- **New Service Layer**: Created `server/src/modules/resumes/service.js` to decouple database logic and manage resume upserts.
- **Singleton Logic**: Updated the `analyzeResume` controller to use `findOneAndUpdate` with `upsert: true`, replacing old records with new uploads.
- **New Endpoint**: Exposed `GET /api/resume/me/latest` to allow users to fetch their current parsed resume securely.
- **Data Privacy**: Enforced strict exclusion of `resumeText` in both the new endpoint and the existing `getResumeResult` endpoint.
- **Documentation**: Updated `README.md` and `docs/PROJECT_STRUCTURE.md` to reflect the new API surface and singleton architecture.
- **Test Suite**: Added a `test` script to `package.json` and updated existing resume tests to pass with the new service-based logic.

## Validation
- [x] Build passes locally
- [x] Relevant tests added/updated
- [x] Documentation updated (if needed)

