### PR TITLE
Stabilize pipeline evaluation and support mixed experience formats

### DIFF
--- a/ai-ml/pipeline/runPipeline.js
+++ b/ai-ml/pipeline/runPipeline.js
@@ -8,6 +8,33 @@ export async function runPipeline({
   jobSkills = [],
   jobDescription = "",
 }) {
+    // ADD — safe wrapper for all evaluator calls
+  function safeEval(name, fn, fallback = { score: 0, error: true }) {
+    try {
+      return fn();
+    } catch (err) {
+      console.error(`[runPipeline] Evaluator "${name}" failed:`, err);
+      return fallback;
+    }
+  }
+
+  // ADD — handles both string and object experience entries
+  function parseExperience(experience = []) {
+    return experience.map((entry) => {
+      if (typeof entry === "string") return entry;
+      if (typeof entry === "object" && entry !== null) {
+        return [
+          entry.title,
+          entry.company,
+          entry.duration,
+          entry.description,
+        ]
+          .filter(Boolean)
+          .join(" ");
+      }
+      return "";
+    }).join("\n");
+  }
   const evaluations = [];
 
   // 🟢 Skill Match

--- a/ai-ml/pipeline/runPipeline.js
+++ b/ai-ml/pipeline/runPipeline.js
@@ -38,24 +38,30 @@ export async function runPipeline({
   const evaluations = [];
 
   // 🟢 Skill Match
-  const skillMatch = skillEvaluator({
+  const skillMatch = safeEval("skillMatch", () =>
+  skillEvaluator({
     resumeSkills: resumeData.skills || [],
     jobSkills,
-  });
+  })
+);
   evaluations.push({ ...skillMatch, name: "skillMatch" });
 
   // 🟡 Keyword Match
-  const keywordMatch = keywordEvaluator({
+  const keywordMatch = safeEval("keywordMatch", () =>
+  keywordEvaluator({
     resumeText: resumeData.resumeText || "",
     jobDescription,
-  });
+  })
+);
   evaluations.push({ ...keywordMatch, name: "keywordMatch" });
 
   // 🔵 Experience Match
-  const experienceMatch = experienceEvaluator({
-    candidateExperienceText: (resumeData.experience || []).join(" "),
+  const experienceMatch = safeEval("experienceMatch", () =>
+  experienceEvaluator({
+    candidateExperienceText: parseExperience(resumeData.experience),
     jobDescription,
-  });
+  })
+);
   evaluations.push({ ...experienceMatch, name: "experienceMatch" });
 
   // 🧠 Aggregate

--- a/ai-ml/pipeline/runPipeline.js
+++ b/ai-ml/pipeline/runPipeline.js
@@ -65,7 +65,9 @@ export async function runPipeline({
   evaluations.push({ ...experienceMatch, name: "experienceMatch" });
 
   // 🧠 Aggregate
-  const { score, breakdown } = aggregateResults(evaluations);
+  const result = aggregateResults(evaluations);
+  if (!result) throw new Error("[runPipeline] aggregateResults returned empty");
+  const { score, breakdown } = result;
 
   return {
     score,


### PR DESCRIPTION
## Summary

Fixes runtime instability in the evaluation pipeline by adding a safe execution wrapper for evaluators and improving experience parsing. The pipeline now correctly handles both string-based and object-based experience entries, preventing crashes and ensuring consistent data processing. Also adds a guard for aggregation output to avoid silent failures.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #160 

## Changes Made

- Added `safeEval` helper to wrap all evaluator calls and prevent pipeline crashes on failure
- Implemented `parseExperience` utility to correctly parse both object-like and string-like experience structures
- Replaced unsafe `.join(" ")` with structured parsing logic that supports mixed formats
- Wrapped `skillEvaluator`, `keywordEvaluator`, and `experienceEvaluator` with `safeEval`
- Added guard for `aggregateResults` to throw an explicit error if it returns an empty result


