### PR TITLE
Add Resume Strength Classification Based on Analysis Results

### DIFF
--- a/ai-ml/pipeline/runPipeline.js
+++ b/ai-ml/pipeline/runPipeline.js
@@ -2,6 +2,7 @@ import { aggregateResults } from "./aggregator.js";
 import { skillEvaluator } from "../evaluators/skillEvaluator.js";
 import { keywordEvaluator } from "../evaluators/keywordEvaluator.js";
 import { experienceEvaluator } from "../evaluators/experienceEvaluator.js";
+import { classifyResume } from "../utils/resumeClassifier.js";
 
 export async function runPipeline({
   resumeData,
@@ -69,11 +70,19 @@ export async function runPipeline({
   if (!result) throw new Error("[runPipeline] aggregateResults returned empty");
   const { score, breakdown } = result;
 
+  // 🔥 Classification
+  const classification = classifyResume({
+    score,
+    skillMatch,
+    experienceMatch,
+  });
+
   return {
     score,
     breakdown,
     skillMatch,
     keywordMatch,
     experienceMatch,
+    classification,
   };
 }

--- a/ai-ml/utils/resumeClassifier.js
+++ b/ai-ml/utils/resumeClassifier.js
@@ -1,0 +1,29 @@
+export function classifyResume({ score, skillMatch, experienceMatch }) {
+  let level = "";
+  let label = "";
+  let color = "";
+
+  if (score < 40) {
+    level = "Beginner";
+    label = "Low Profile Strength";
+    color = "red";
+  } else if (score < 70) {
+    level = "Intermediate";
+    label = "Moderate Profile Strength";
+    color = "yellow";
+  } else if (score < 85) {
+    level = "Advanced";
+    label = "Strong Profile";
+    color = "blue";
+  } else {
+    level = "Strong Match";
+    label = "Highly Suitable Candidate";
+    color = "green";
+  }
+
+  return {
+    level,
+    label,
+    color,
+  };
+}

--- a/client/src/modules/resume-analyzer/components/AnalysisResult.jsx
+++ b/client/src/modules/resume-analyzer/components/AnalysisResult.jsx
@@ -20,10 +20,17 @@ const AnalysisResult = ({ result, file, onReset }) => {
     ...(result.experienceMatch?.feedback || [])
   ];
 
-  const missing_keywords = result.missing_keywords ?? [
+  const rawMissing = [
     ...(result.keywordMatch?.missingKeywords || []),
     ...(result.skillMatch?.missingSkills || [])
   ];
+
+  // Deduplicate case-insensitively
+  const missing_keywords = result.missing_keywords ?? rawMissing.filter(
+    (keyword, index, self) =>
+      index === self.findIndex((k) => k.toLowerCase() === keyword.toLowerCase())
+  );
+  
   const [previewUrl, setPreviewUrl] = useState(null);
 
   useEffect(() => {
@@ -38,8 +45,15 @@ const AnalysisResult = ({ result, file, onReset }) => {
     }
   }, [file]);
 
-  // Determine score color/gradient class
+  // Determine score color/gradient class (sync with classification)
   const getScoreStyles = (s) => {
+    const classificationColor = result?.classification?.color;
+    if (classificationColor === "red") return "text-red-400";
+    if (classificationColor === "yellow") return "text-yellow-400";
+    if (classificationColor === "blue") return "text-blue-400";
+    if (classificationColor === "green") return "text-secondary";
+
+    // Fallback if classification is missing
     if (s >= 80) return "text-secondary"; // Emerald
     if (s >= 60) return "text-yellow-400";
     return "text-red-400";
@@ -53,6 +67,16 @@ const AnalysisResult = ({ result, file, onReset }) => {
     if (file?.name.endsWith(".docx")) return "DOCX";
     if (file?.name.endsWith(".pdf")) return "PDF";
     return file?.type?.split("/")[1]?.toUpperCase() || "FILE";
+  };
+
+  const getLevelColor = (color) => {
+    switch (color) {
+      case "red": return "text-red-400";
+      case "yellow": return "text-yellow-400";
+      case "blue": return "text-blue-400";
+      case "green": return "text-secondary";
+      default: return "text-primary";
+    }
   };
 
   return (
@@ -76,11 +100,11 @@ const AnalysisResult = ({ result, file, onReset }) => {
             <Sparkles className="w-10 h-10 animate-pulse" />
           </div>
           <div>
-            <h2 className="text-2xl font-heading font-bold text-text-main">
-              Global Insight Analysis
+            <h2 className={`text-2xl font-heading font-bold ${result?.classification?.color ? getLevelColor(result.classification.color) : 'text-text-main'}`}>
+              {result?.classification?.level || "Global Insight Analysis"}
             </h2>
-            <p className="text-text-muted text-sm mt-1">
-              AI-driven evaluation across 50+ industry parameters.
+            <p className="text-text-muted text-sm mt-1 font-medium">
+              {result?.classification?.label || "AI-driven evaluation across 50+ industry parameters."}
             </p>
           </div>
         </div>

--- a/server/src/database/models/Resume.js
+++ b/server/src/database/models/Resume.js
@@ -110,6 +110,10 @@ const resumeSchema = new mongoose.Schema(
       type: Number,
       default: null,
     },
+    classification: {
+      type: mongoose.Schema.Types.Mixed,
+      default: null,
+    },
   },
   {
     timestamps: true,

--- a/server/src/utils/normalizeResumeResponse.js
+++ b/server/src/utils/normalizeResumeResponse.js
@@ -42,5 +42,9 @@ export function normalizePipelineResult(result = {}) {
       result.experienceMatch && typeof result.experienceMatch === "object"
         ? result.experienceMatch
         : {},
+    classification:
+      result.classification && typeof result.classification === "object"
+        ? result.classification
+        : null,
   };
 }


### PR DESCRIPTION
###  Problem

The current resume analysis system provides detailed metrics such as skillMatch, keywordMatch, experienceMatch, and Trust Score, but lacks a clear high-level summary of the candidate’s overall profile strength.

Users are required to interpret multiple values, making it harder to quickly understand their standing.

---

###  Solution

Implemented a resume classification layer that categorizes candidates into:

* Beginner (< 40)
* Intermediate (40–70)
* Advanced (70–85)
* Strong Match (85+)

---

### Implementation Details

#### 1. Classification Utility

* Created `ai-ml/utils/resumeClassifier.js`
* Converts numeric score into meaningful categories with:

  * level
  * label
  * color

#### 2. Pipeline Integration

* Integrated classification at the end of `runPipeline.js`
* Ensures clean separation from aggregation logic
* Automatically included in API response via existing controller spread

#### 3. Frontend Integration

* Integrated classification into `AnalysisResult.jsx`
* Dynamically replaces the "Global Insight Analysis" title
* Applies Tailwind-based color styling for visual clarity

---

### Result

* Users now get an instant understanding of their profile strength
* Improved readability and usability of analysis results
* Adds a “smart summary” layer to the system

---

###  Testing

Tested across all score ranges:

* < 40 → Beginner
* 40–70 → Intermediate
* 70–85 → Advanced
* 85+ → Strong Match

Verified:

* API response includes classification object
* UI updates dynamically based on score
* No regression in existing features


###  Related Issue

Closes #171 
