### PR TITLE
Fix: NaN score and inconsistent extraSkills in skillEvaluator

### DIFF
--- a/ai-ml/evaluators/skillEvaluator.js
+++ b/ai-ml/evaluators/skillEvaluator.js
@@ -13,7 +13,7 @@ export const skillEvaluator = ({ resumeSkills = [], jobSkills = [] }) => {
       feedback: ["No job skills provided for comparison"],
       matchedSkills: [],
       missingSkills: [],
-      extraSkills: resumeSkills,
+      extraSkills: normResume,
     };
   }
 

--- a/ai-ml/evaluators/skillEvaluator.js
+++ b/ai-ml/evaluators/skillEvaluator.js
@@ -6,7 +6,7 @@ export const skillEvaluator = ({ resumeSkills = [], jobSkills = [] }) => {
   const normResume = normalize(resumeSkills);
   const normJob = normalize(jobSkills);
 
-  if (jobSkills.length === 0) {
+  if (jobSkills.length === 0 || normJob.length === 0) {
     return {
       score: 0,
       weight: 1.0,

--- a/ai-ml/evaluators/skillEvaluator.js
+++ b/ai-ml/evaluators/skillEvaluator.js
@@ -1,4 +1,11 @@
 export const skillEvaluator = ({ resumeSkills = [], jobSkills = [] }) => {
+  // Normalize: lowercase, trim, unique
+  const normalize = (skills) => 
+    [...new Set(skills.map(s => s.toLowerCase().trim()).filter(Boolean))];
+
+  const normResume = normalize(resumeSkills);
+  const normJob = normalize(jobSkills);
+
   if (jobSkills.length === 0) {
     return {
       score: 0,
@@ -9,13 +16,6 @@ export const skillEvaluator = ({ resumeSkills = [], jobSkills = [] }) => {
       extraSkills: resumeSkills,
     };
   }
-
-  // Normalize: lowercase, trim, unique
-  const normalize = (skills) => 
-    [...new Set(skills.map(s => s.toLowerCase().trim()).filter(Boolean))];
-
-  const normResume = normalize(resumeSkills);
-  const normJob = normalize(jobSkills);
 
   // Matched: intersection
   const matched = normJob.filter(s => normResume.includes(s));


### PR DESCRIPTION
## Summary

Moves `normalize`, `normResume`, and `normJob` above the early-return block so they are available at the point of the guard check. Updates the guard condition to also catch cases where all job skills normalize to empty, preventing a `NaN` score. Fixes `extraSkills` in the early return to use the normalized array for consistency.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #185 

## Changes Made

- Moved `normalize` function and `normJob`/`normResume` declarations above the early-return block
- Added `|| normJob.length === 0` to the early-return guard to handle blank/whitespace-only job skill inputs
- Replaced `extraSkills: resumeSkills` with `extraSkills: normResume` in the early return for consistent normalized output


