### PR TITLE
Integrated skill/experience match parameters into the classifier and …

### DIFF
--- a/ai-ml/utils/resumeClassifier.js
+++ b/ai-ml/utils/resumeClassifier.js
@@ -1,8 +1,12 @@
 export function classifyResume({ score, skillMatch, experienceMatch }) {
+  const sScore = skillMatch?.score;
+  const eScore = experienceMatch?.score;
+
   let level = "";
   let label = "";
   let color = "";
 
+  // Base classification based on overall weighted score
   if (score < 40) {
     level = "Beginner";
     label = "Low Profile Strength";
@@ -21,9 +25,31 @@ export function classifyResume({ score, skillMatch, experienceMatch }) {
     color = "green";
   }
 
+  // Incorporate skillMatch and experienceMatch for contextual refinement
+  const highlights = [];
+
+  // Only add insights if they are available (numeric scores)
+  if (typeof sScore === "number") {
+    if (sScore >= 90) highlights.push("Exceptional Skills");
+    else if (sScore >= 70) highlights.push("Solid Skill Match");
+    else if (sScore < 30) highlights.push("Skill Gaps Noted");
+  }
+
+  if (typeof eScore === "number") {
+    if (eScore >= 90) highlights.push("Deep Experience");
+    else if (eScore >= 70) highlights.push("Relevant Background");
+    else if (eScore < 30) highlights.push("Experience Mismatch");
+  }
+
+  // Update label with highlights if any exist to provide more context
+  if (highlights.length > 0) {
+    label = `${label} (${highlights.join(" • ")})`;
+  }
+
   return {
     level,
     label,
     color,
   };
 }
+

--- a/client/src/modules/resume-analyzer/components/AnalysisResult.jsx
+++ b/client/src/modules/resume-analyzer/components/AnalysisResult.jsx
@@ -76,9 +76,23 @@ const AnalysisResult = ({ result, file, onReset }) => {
             <div className={`text-7xl font-black tracking-tighter ${getScoreColor(score)}`}>
               {score}%
             </div>
+            
+            {/* Classification Level and Insights */}
+            {result.classification && (
+              <div className="mt-4 space-y-2">
+                <div className={`inline-block px-4 py-1.5 rounded-xl text-[10px] font-black uppercase tracking-widest bg-dark-bg border border-border shadow-sm ${getScoreColor(score)}`}>
+                  {result.classification.level}
+                </div>
+                <p className="text-[10px] text-text-muted font-bold px-2 leading-relaxed italic">
+                  {result.classification.label}
+                </p>
+              </div>
+            )}
+
             <p className="text-xs text-text-muted mt-4 font-bold max-w-[150px]">
               {isJDProvided ? "Optimized for Job Description" : "General Quality Baseline"}
             </p>
+
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Improved the resume classification logic by incorporating previously unused `skillMatch` and `experienceMatch` parameters. This allows for more contextual analysis results (e.g., "Exceptional Skills" or "Experience Mismatch"), which are now rendered as a badge and descriptive label in the UI's Trust Score card.

## Type of Change
- [x] Feature
- [x] Refactor


## Related Issue
Closes #198 198

## Changes Made
- **Backend (AI/ML):** Updated `ai-ml/utils/resumeClassifier.js` to utilize `skillMatch.score` and `experienceMatch.score` to refine the classification label.
- **Frontend (UI):** Modified `client/src/modules/resume-analyzer/components/AnalysisResult.jsx` to render the classification `level` and `label` right under the Trust Score.
- **Dead Code Removal:** Successfully resolved the issue where match parameters were passed to the function but never used.

## Validation
- [x] Build passes locally
- [x] Relevant tests added/updated (Verified logic with manual test script)


## Screenshots 
The classification now appears as a badge below the Trust Score:
- **Strong Match** (Exceptional Skills • Deep Experience)
- **Intermediate** (Skill Gaps Noted • Experience Mismatch)

<img width="334" height="508" alt="Screenshot 2026-05-04 021556" src="https://github.com/user-attachments/assets/2d0084f5-649f-428e-ad24-2bfceca3fd80" />