### PR TITLE
fix: add regex fallback and placeholder detection in atsOptimizationEvaluator to prevent incorrect contact field penalties

### DIFF
--- a/ai-ml/evaluators/atsOptimizationEvaluator.js
+++ b/ai-ml/evaluators/atsOptimizationEvaluator.js
@@ -12,6 +12,8 @@ export const atsOptimizationEvaluator = ({ resumeData, weight = 0.15 }) => {
     email,
     phone,
     linkedin,
+    github,
+    portfolio,
     resumeText = ""
   } = resumeData;
 
@@ -24,10 +26,23 @@ export const atsOptimizationEvaluator = ({ resumeData, weight = 0.15 }) => {
     summary: /summary|profile|objective|about me/gi.test(resumeText),
   };
 
-  const contactResults = {
-    email: !!email,
-    phone: !!phone,
-    linkedin: !!linkedin,
+  // Fallback to regex detection from resumeText when structured fields are missing
+  const emailFromText = /[\w.+-]+@[\w-]+\.[a-z]{2,}/i.test(resumeText); 
+  const phoneFromText = /(\+\d{1,3}[\s-]?)?\d[\d\s-]{7,}/.test(resumeText); 
+  const portfolioFromText = /(portfolio|https?:\/\/(www\.)?[\w-]+\.[a-z]{2,}[^\s]*)/i.test(resumeText);
+  const linkedinUrlDetected = /linkedin\.com\/in\/[\w-]+|linkedin\.com\/company\/[\w-]+/i.test(resumeText);
+  const githubUrlDetected = /github\.com\/[\w-]+/i.test(resumeText);
+  const hasLinkedinPlaceholder = /\blinkedin\b/i.test(resumeText) && !linkedinUrlDetected;
+  const hasGithubPlaceholder = /\bgithub\b/i.test(resumeText) && !githubUrlDetected;
+  const linkedinFromText = linkedinUrlDetected || hasLinkedinPlaceholder;
+  const githubFromText = githubUrlDetected || hasGithubPlaceholder;
+
+  const contactResults = { 
+    email: !!email || emailFromText,
+    phone: !!phone || phoneFromText,
+    linkedin: !!linkedin || linkedinFromText, 
+    github: !!github || githubFromText,
+    portfolio: !!portfolio || portfolioFromText,
   };
 
   // Scoring
@@ -55,6 +70,16 @@ export const atsOptimizationEvaluator = ({ resumeData, weight = 0.15 }) => {
     feedback.push(`Missing contact info: ${missingContact.join(", ")}.`);
     suggestions.push(`Ensure your ${missingContact.join(" and ")} are visible at the top.`);
   }
+
+  if (hasLinkedinPlaceholder || hasGithubPlaceholder) {
+  feedback.push(
+    "Embedded hyperlinks detected. Some ATS systems may not extract hidden profile URLs correctly."
+  );
+
+  suggestions.push(
+    "Use visible LinkedIn/GitHub URLs instead of embedded hyperlinks for better ATS compatibility."
+  );
+}
 
   // Formatting Hygiene (Bonus/Penalty)
   const hasTables = /<table|\[table\]/gi.test(resumeText);
@@ -87,4 +112,3 @@ export const atsOptimizationEvaluator = ({ resumeData, weight = 0.15 }) => {
     }
   };
 };
-


### PR DESCRIPTION
Closes #229

## What I did
- Added regex fallback detection from `resumeText` for email, phone, LinkedIn, GitHub and portfolio when structured fields are missing
- Separated URL detection and placeholder text detection for LinkedIn and GitHub to handle cases like `| GitHub | LinkedIn |` in parsed PDFs
- Replaced hard penalty with ATS guidance warning when only placeholder text is detected instead of a raw URL
- Added `github` and `portfolio` to destructuring and `contactResults`

## What I didn't implement
Looked into the pdf.js hyperlink annotation extraction (point 4) but it's a bigger change, leaving it for a separate issue.

## Testing

Tested locally with a temporary test block simulating a PDF with only placeholder text and no raw URLs:

```js
const testResume = {
  experience: [{ title: "Engineer" }],
  education: [{ degree: "BTech" }],
  skills: ["JavaScript"],
  email: undefined,
  phone: undefined,
  linkedin: undefined,
  github: undefined,
  portfolio: undefined,
  resumeText: "| GitHub | LinkedIn | Portfolio |"
};

console.log(
  atsOptimizationEvaluator({ resumeData: testResume }).details
);
```

Output:

<img width="1115" height="581" alt="Screenshot 2026-05-09 011519" src="https://github.com/user-attachments/assets/79e7a22c-67c2-4a8d-a85f-9fdfa1cfe39f" />

LinkedIn and GitHub correctly detected via placeholder text, ATS warning generated, no false score penalties. Test block removed before pushing.