### PR TITLE
Fix/integrate semantic evaluator

### DIFF
--- a/ai-ml/evaluators/readabilityEvaluator.js
+++ b/ai-ml/evaluators/readabilityEvaluator.js
@@ -10,7 +10,7 @@ export default function readabilityEvaluator({ resumeText = "", weight = 0.1 }) 
   // Clean bullet point prefixes from sentence start (fixes #230)
   // Handles common bullet characters from PDF extraction: •, –, *, en-dash, em-dash
   function cleanSentenceStart(sentence) {
-    return sentence.replace(/^[\s\u2022-*\u2013\u2014•]+/, '').trim();
+    return sentence.replace(/^[\s\u2022\*\u2013\u2014•\-]+/, '').trim();
   }
 
   const sentences = resumeText

--- a/ai-ml/pipeline/aggregator.js
+++ b/ai-ml/pipeline/aggregator.js
@@ -6,8 +6,9 @@ export function aggregateResults(evaluations, isJDProvided = true) {
   // Dynamic Weights Map
   const weights = isJDProvided 
     ? {
-        skillMatch: 0.3,
-        keywordMatch: 0.2,
+        skillMatch: 0.15,
+        semanticMatch: 0.20,
+        keywordMatch: 0.15,
         experienceMatch: 0.1,
         impactMatch: 0.15,
         atsOptimization: 0.1,

--- a/ai-ml/pipeline/runPipeline.js
+++ b/ai-ml/pipeline/runPipeline.js
@@ -6,6 +6,7 @@ import { keywordEvaluator } from "../evaluators/keywordEvaluator.js";
 import readabilityEvaluator from "../evaluators/readabilityEvaluator.js";
 import { skillEvaluator } from "../evaluators/skillEvaluator.js";
 import { techStandardEvaluator } from "../evaluators/techStandardEvaluator.js";
+import { semanticEvaluator } from "../evaluators/semanticEvaluator.js";
 import gapAnalyzer from "../utils/gapAnalyzer.js";
 import { classifyResume } from "../utils/resumeClassifier.js";
 import { aggregateResults } from "./aggregator.js";
@@ -114,6 +115,39 @@ export async function runPipeline({
 
   evaluations.push(experienceMatch);
 
+  // 🌀 Semantic Match
+  const hasOpenAIKey = !!process.env.OPENAI_API_KEY;
+  let semanticMatch;
+
+  if (!isJDProvided) {
+    semanticMatch = {
+      score: null,
+      name: "semanticMatch",
+      message: "No job description provided",
+    };
+  } else if (!hasOpenAIKey) {
+    semanticMatch = {
+      score: 0,
+      name: "semanticMatch",
+      key: "semanticMatch",
+      label: "Semantic Match",
+      weight: 0,
+      weightedScore: 0,
+      summary: "Semantic evaluation skipped — no API key",
+      details: {},
+      meta: {},
+    };
+  } else {
+    semanticMatch = await safeEval("semanticMatch", () =>
+      semanticEvaluator({
+        resumeText,
+        jobDescription,
+      }),
+    );
+  }
+
+  evaluations.push(semanticMatch);
+
   // 🟣 Consistency Match
   const consistencyMatch = await safeEval("consistencyMatch", () =>
     consistencyEvaluator({
@@ -192,6 +226,7 @@ export async function runPipeline({
     skillMatch,
     keywordMatch,
     experienceMatch,
+    semanticMatch,
     consistencyMatch,
     readabilityMatch,
     impactMatch,


### PR DESCRIPTION
## Summary

semanticEvaluator.js was fully implemented but never imported or called in runPipeline.js. This PR integrates it into the pipeline with a conditional check for OPENAI_API_KEY and a graceful fallback when the key is absent.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #228

## Changes Made

- Imported `semanticEvaluator` in `ai-ml/pipeline/runPipeline.js`
- Added `semanticMatch` evaluation block that runs only when a job 
  description is provided AND `OPENAI_API_KEY` exists
- When API key is missing, returns `score: 0` with 
  `summary: "Semantic evaluation skipped — no API key"` instead of crashing
- Included `semanticMatch` in the pipeline return object
- Added `semanticMatch: 0.20` to the JD-mode weight map in `aggregator.js`
- Reduced `skillMatch` (0.30 → 0.15) and `keywordMatch` (0.20 → 0.15) 
  to keep total weights at 1.0

## Validation

- [x] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)

N/A — backend pipeline change only.

### 🐛 Additional Fix (Test Suite)
While testing the pipeline, I noticed the entire test suite was failing due to a `SyntaxError: Invalid regular expression` in `readabilityEvaluator.js` (line 13). 

The regex `^[\s\u2022-*\u2013\u2014•]+` was creating an invalid character range because of the unescaped hyphen. I fixed this by moving the hyphen to the end of the character class `^[\s\u2022\*\u2013\u2014•\-]+` so the automated CI tests can pass successfully!
