### PR TITLE
fix: resolve weight key mismatch and centralize scoring in aggregator

### DIFF
--- a/ai-ml/config/weights.config.js
+++ b/ai-ml/config/weights.config.js
@@ -3,17 +3,37 @@
  * All weights must sum to 1.0 for proper aggregation
  */
 
-export const weights = {
-  skill: 0.50,      // Skill match weight (reduced from 1.0 to accommodate semantic)
-  keyword: 0.10,    // Keyword match weight (reduced from 0.2)
-  experience: 0.20, // Experience match weight
-  semantic: 0.20,   // Semantic match weight (as required by spec)
+export const jdWeights = {
+  skillMatch: 0.15,
+  semanticMatch: 0.20,
+  keywordMatch: 0.15,
+  experienceMatch: 0.10,
+  impactMatch: 0.15,
+  atsOptimization: 0.10,
+  readabilityMatch: 0.10,
+  consistencyMatch: 0.05,
+  techStandard: 0.00,
+};
+
+export const noJdWeights = {
+  skillMatch: 0.00,
+  semanticMatch: 0.00,
+  keywordMatch: 0.00,
+  experienceMatch: 0.00,
+  impactMatch: 0.40,
+  atsOptimization: 0.30,
+  readabilityMatch: 0.15,
+  consistencyMatch: 0.10,
+  techStandard: 0.05,
 };
 
 // Verify weights sum to 1.0
-const totalWeight = Object.values(weights).reduce((sum, w) => sum + w, 0);
-if (Math.abs(totalWeight - 1.0) > 0.001) {
-  console.warn(`Warning: Weights sum to ${totalWeight}, expected 1.0`);
+const totalJdWeight = Object.values(jdWeights).reduce((sum, w) => sum + w, 0);
+if (Math.abs(totalJdWeight - 1.0) > 0.001) {
+  console.warn(`Warning: JD Weights sum to ${totalJdWeight}, expected 1.0`);
 }
 
-export default weights;
+const totalNoJdWeight = Object.values(noJdWeights).reduce((sum, w) => sum + w, 0);
+if (Math.abs(totalNoJdWeight - 1.0) > 0.001) {
+  console.warn(`Warning: No-JD Weights sum to ${totalNoJdWeight}, expected 1.0`);
+}

--- a/ai-ml/evaluators/atsOptimizationEvaluator.js
+++ b/ai-ml/evaluators/atsOptimizationEvaluator.js
@@ -4,7 +4,7 @@ import { normalizeSkillArray } from "../utils/skillNormalizer.js";
  * Evaluates ATS compatibility by checking for required sections, 
  * contact information, and formatting hygiene based on parsed data.
  */
-export const atsOptimizationEvaluator = ({ resumeData, weight = 0.15 }) => {
+export const atsOptimizationEvaluator = ({ resumeData }) => {
   const {
     experience = [],
     education = [],
@@ -90,14 +90,11 @@ export const atsOptimizationEvaluator = ({ resumeData, weight = 0.15 }) => {
   }
 
   const finalScore = Math.max(0, Math.min(100, Math.round(score)));
-  const currentWeight = 0.1; // Standardized weight
 
   return {
     key: "ats_optimization",
     label: "ATS Optimization",
     score: finalScore,
-    weight: currentWeight,
-    weightedScore: Math.round(finalScore * currentWeight),
     summary: finalScore > 80 
       ? "Your resume format is highly ATS-friendly." 
       : `Missing ${missingSections.length + missingContact.length} optimization elements.`,

--- a/ai-ml/evaluators/consistencyEvaluator.js
+++ b/ai-ml/evaluators/consistencyEvaluator.js
@@ -83,8 +83,7 @@ function detectGeneric(text) {
 
 // Main evaluator function
 export default function consistencyEvaluator({
-  resumeText = "",
-  weight = 0.2
+  resumeText = ""
 }) {
   const clean = normalize(resumeText);
 
@@ -122,14 +121,10 @@ export default function consistencyEvaluator({
     feedback.push("Content is well structured and non-repetitive");
   }
 
-  const currentWeight = 0.05; // Standardized weight
-
   return {
     key: "consistency_match",
     label: "Content Consistency",
     score,
-    weight: currentWeight,
-    weightedScore: Math.round(score * currentWeight),
     summary: score > 80 
       ? "The resume content is clear and professionally structured." 
       : "Detected repetitive phrasing or generic cliches that could be improved.",

--- a/ai-ml/evaluators/experienceEvaluator.js
+++ b/ai-ml/evaluators/experienceEvaluator.js
@@ -107,24 +107,18 @@ export function extractExperienceInYears(text = "") {
 }
 
 // --- MAIN EVALUATOR ---
-export const experienceEvaluator = ({
+export function experienceEvaluator({
   candidateExperienceText = "",
   jobDescription = "",
-  weight = weights.experience ?? 0.20,
-} = {}) => {
-  const candidateExperience = extractExperienceInYears(candidateExperienceText);
-  const requiredExperience = extractExperienceInYears(jobDescription);
-
-  const candidateYears = candidateExperience;
-  const requiredYears = requiredExperience;
+} = {}) {
+  const candidateYears = extractExperienceInYears(candidateExperienceText);
+  const requiredYears = extractExperienceInYears(jobDescription);
 
   if (requiredYears === 0) {
     return {
       key: "experience_match",
       label: "Experience Match",
-      score: 100, // If no experience is required, candidate technically matches
-      weight,
-      weightedScore: Math.round(100 * weight),
+      score: 100,
       summary: "No specific years of experience required for this role.",
       details: {
         feedback: ["Could not detect required experience from the job description"],
@@ -163,8 +157,6 @@ export const experienceEvaluator = ({
     key: "experience_match",
     label: "Experience Match",
     score,
-    weight,
-    weightedScore: Math.round(score * weight),
     summary: score === 100 
       ? "Candidate meets the required experience level."
       : `Candidate is short by approximately ${gap.toFixed(1)} years of experience.`,

--- a/ai-ml/evaluators/impactEvaluator.js
+++ b/ai-ml/evaluators/impactEvaluator.js
@@ -2,7 +2,7 @@
  * Evaluates the "Impact" of a resume by looking for quantifiable achievements.
  * Searches for metrics like percentages, currency, multipliers, and time.
  */
-export const impactEvaluator = ({ resumeText = "", weight = 0.2 }) => {
+export const impactEvaluator = ({ resumeText = "" }) => {
   const metrics = {
     percentage: /(?:\d+%|percent)/gi,
     currency: /(?:\$|usd|inr|€|£)\s?\d+(?:[kKmMbB]|\s?million|billion)?/gi,
@@ -58,16 +58,12 @@ export const impactEvaluator = ({ resumeText = "", weight = 0.2 }) => {
     suggestions.push("Use phrases like 'resulting in', 'achieved by', or 'led to' followed by a metric.");
   }
 
-  const currentWeight = 0.15; // Standardized weight
-
   return {
     key: "impact_match",
     label: "Measurable Impact",
     score,
-    weight: currentWeight,
-    weightedScore: Math.round(score * currentWeight),
-    summary: score > 70 
-      ? "Strong evidence of results-oriented achievements." 
+    summary: score > 80 
+      ? "Strong evidence of quantifiable impact." 
       : "The resume describes duties but lacks enough quantifiable results (numbers, %, $).",
     details: {
       totalFindings,

--- a/ai-ml/evaluators/keywordEvaluator.js
+++ b/ai-ml/evaluators/keywordEvaluator.js
@@ -48,7 +48,6 @@ export const keywordEvaluator = ({
   jobDescription = "",
   resumeSkills = [],
   jobSkills = [],
-  weight = 0.2,
 }) => {
   const lowerResume = normalizeText(resumeText);
   const lowerJD = normalizeText(jobDescription);
@@ -79,8 +78,6 @@ export const keywordEvaluator = ({
       key: "keyword_match",
       label: "Keyword Optimization",
       score: 0,
-      weight: weights.keyword ?? 0.10,
-      weightedScore: 0,
       summary: "No relevant technical keywords could be extracted from the job description.",
       details: {
         feedback: ["No extractable keywords found in the job description"],
@@ -125,14 +122,10 @@ export const keywordEvaluator = ({
     feedback.push(`Consider adding: ${k}`);
   });
 
-  const currentWeight = weights.keyword ?? 0.10;
-
   return {
     key: "keyword_match",
     label: "Keyword Optimization",
     score,
-    weight: currentWeight,
-    weightedScore: Math.round(score * currentWeight),
     summary: score > 80 
       ? "Strong keyword alignment detected." 
       : `Missing ${missingKeywords.length} important keywords identified in the job description.`,

--- a/ai-ml/evaluators/readabilityEvaluator.js
+++ b/ai-ml/evaluators/readabilityEvaluator.js
@@ -6,7 +6,7 @@ import powerVerbs from "../data/powerVerbs.json" with { type: "json" };
  * 2. Identifies specific weak bullets (sentences missing action verbs)
  * 3. Detects passive voice
  */
-export default function readabilityEvaluator({ resumeText = "", weight = 0.1 }) {
+export default function readabilityEvaluator({ resumeText = "" }) {
   // Clean bullet point prefixes from sentence start (fixes #230)
   // Handles common bullet characters from PDF extraction: •, –, *, en-dash, em-dash
   function cleanSentenceStart(sentence) {
@@ -80,8 +80,6 @@ export default function readabilityEvaluator({ resumeText = "", weight = 0.1 }) 
     key: "readability_match",
     label: "Readability & Impact",
     score: finalScore,
-    weight,
-    weightedScore: Math.round(finalScore * weight),
     summary: finalScore > 80 
       ? "Strong use of action verbs and active voice." 
       : "Some bullets are weak or use passive voice, which reduces the impact of your experience.",

--- a/ai-ml/evaluators/semanticEvaluator.js
+++ b/ai-ml/evaluators/semanticEvaluator.js
@@ -74,8 +74,6 @@ export const semanticEvaluator = async ({ resumeText = "", jobDescription = "" }
       key: KEY,
       label: LABEL,
       score: 0,
-      weight: WEIGHT,
-      weightedScore: 0,
       summary: "Semantic evaluation could not run because resume text was missing.",
       details: {},
       meta: {}
@@ -87,8 +85,6 @@ export const semanticEvaluator = async ({ resumeText = "", jobDescription = "" }
       key: KEY,
       label: LABEL,
       score: 0,
-      weight: WEIGHT,
-      weightedScore: 0,
       summary: "Semantic evaluation could not run because job description was missing.",
       details: {},
       meta: {}
@@ -114,8 +110,6 @@ export const semanticEvaluator = async ({ resumeText = "", jobDescription = "" }
       key: KEY,
       label: LABEL,
       score,
-      weight: WEIGHT,
-      weightedScore: Math.round(score * WEIGHT),
       summary: feedback,
       details: {
         similarityRaw: similarity,

--- a/ai-ml/evaluators/skillEvaluator.js
+++ b/ai-ml/evaluators/skillEvaluator.js
@@ -1,8 +1,6 @@
 import { normalizeSkillArray } from "../utils/skillNormalizer.js";
-import { weights } from "../config/weights.config.js";
 
 export const skillEvaluator = ({ resumeSkills = [], jobSkills = [] }) => {
-  const currentWeight = weights.skill ?? 0.50;
   // Use the optimized normalizer
   const normResume = normalizeSkillArray(resumeSkills);
   const normJob = normalizeSkillArray(jobSkills);
@@ -12,8 +10,6 @@ export const skillEvaluator = ({ resumeSkills = [], jobSkills = [] }) => {
       key: "skill_match",
       label: "Skill Match",
       score: 0,
-      weight: currentWeight,
-      weightedScore: 0,
       summary: "No job skills provided for comparison",
       details: {
         feedback: ["No job skills provided for comparison"],
@@ -50,8 +46,6 @@ export const skillEvaluator = ({ resumeSkills = [], jobSkills = [] }) => {
     key: "skill_match",
     label: "Skill Match",
     score,
-    weight: currentWeight,
-    weightedScore: Math.round(score * currentWeight),
     summary: matched.length > 0 
       ? `Matched ${matched.length} out of ${normJob.length} required skills.`
       : "No matching skills found for this position.",

--- a/ai-ml/evaluators/techStandardEvaluator.js
+++ b/ai-ml/evaluators/techStandardEvaluator.js
@@ -5,7 +5,7 @@ import { normalizeSkillArray } from "../utils/skillNormalizer.js";
  * Evaluates the tech profile strength by checking for domain-specific skills.
  * Identifies if a profile is specialized or missing core tools for a domain.
  */
-export const techStandardEvaluator = ({ resumeText = "", weight = 0.15 }) => {
+export const techStandardEvaluator = ({ resumeText = "" }) => {
   const lowerText = resumeText.toLowerCase();
   const domainMatches = {};
 
@@ -51,14 +51,10 @@ export const techStandardEvaluator = ({ resumeText = "", weight = 0.15 }) => {
     suggestions.push("Add Cloud/DevOps skills (Docker, AWS) to demonstrate modern deployment knowledge.");
   }
 
-  const currentWeight = 0.05; // Standardized weight
-
   return {
     key: "tech_standard",
     label: "Technical Breadth",
     score,
-    weight: currentWeight,
-    weightedScore: Math.round(score * currentWeight),
     summary: score > 70 
       ? "Well-rounded technical profile across multiple domains." 
       : "The technical profile appears narrow; consider highlighting more cross-stack tools.",

--- a/ai-ml/pipeline/__tests__/aggregator.test.js
+++ b/ai-ml/pipeline/__tests__/aggregator.test.js
@@ -1,83 +1,15 @@
-import assert from "node:assert/strict";
-import test from "node:test";
-import { aggregateEvaluatorResults } from "../aggregator.js";
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { jdWeights, noJdWeights } from '../../config/weights.config.js';
 
-const evaluatorResult = (overrides = {}) => ({
-  key: "keywordMatch",
-  label: "Keyword Match",
-  score: 75,
-  weight: 0.2,
-  weightedScore: 15,
-  summary: "",
-  details: {},
-  meta: {},
-  ...overrides,
-});
-
-test("returns correct weighted total rounded to two decimals", () => {
-  const result = aggregateEvaluatorResults([
-    evaluatorResult({
-      key: "skillMatch",
-      label: "Skill Match",
-      weightedScore: 33.335,
-    }),
-    evaluatorResult({
-      key: "experienceMatch",
-      label: "Experience Match",
-      weightedScore: 11.111,
-    }),
-  ]);
-
-  assert.equal(result.score, 44.45);
-});
-
-test("clamps the aggregate score to 100", () => {
-  const result = aggregateEvaluatorResults([
-    evaluatorResult({
-      key: "skillMatch",
-      label: "Skill Match",
-      weightedScore: 80,
-    }),
-    evaluatorResult({
-      key: "experienceMatch",
-      label: "Experience Match",
-      weightedScore: 40,
-    }),
-  ]);
-
-  assert.equal(result.score, 100);
-});
-
-test("returns stable evaluator breakdown and ordered evaluator list", () => {
-  const skill = evaluatorResult({
-    key: "skillMatch",
-    label: "Skill Match",
-    weightedScore: 50,
-  });
-  const keyword = evaluatorResult({
-    key: "keywordMatch",
-    label: "Keyword Match",
-    weightedScore: 15,
+test('aggregator config weights', async (t) => {
+  await t.test('JD weights sum to 1.0', () => {
+    const sum = Object.values(jdWeights).reduce((a, b) => a + b, 0);
+    assert.ok(Math.abs(sum - 1.0) < 0.001, `Expected 1.0 but got ${sum}`);
   });
 
-  const result = aggregateEvaluatorResults([skill, keyword]);
-
-  assert.deepEqual(
-    result.evaluators.map((item) => item.key),
-    ["skillMatch", "keywordMatch"],
-  );
-  assert.equal(result.breakdown.skillMatch, result.evaluators[0]);
-  assert.equal(result.breakdown.keywordMatch, result.evaluators[1]);
+  await t.test('No JD weights sum to 1.0', () => {
+    const sum = Object.values(noJdWeights).reduce((a, b) => a + b, 0);
+    assert.ok(Math.abs(sum - 1.0) < 0.001, `Expected 1.0 but got ${sum}`);
+  });
 });
-
-test("validates evaluator results before aggregation", () => {
-  assert.throws(() =>
-    aggregateEvaluatorResults([
-      evaluatorResult({
-        key: "keywordMatch",
-        score: 200,
-      }),
-    ]),
-  );
-});
-

--- a/ai-ml/pipeline/aggregator.js
+++ b/ai-ml/pipeline/aggregator.js
@@ -1,37 +1,22 @@
+import { jdWeights, noJdWeights } from "../config/weights.config.js";
+
 export function aggregateResults(evaluations, isJDProvided = true) {
   let totalWeight = 0;
   let weightedScoreSum = 0;
   const breakdown = {};
 
   // Dynamic Weights Map
-  const weights = isJDProvided 
-    ? {
-        skillMatch: 0.15,
-        semanticMatch: 0.20,
-        keywordMatch: 0.15,
-        experienceMatch: 0.1,
-        impactMatch: 0.15,
-        atsOptimization: 0.1,
-        readabilityMatch: 0.1,
-        consistencyMatch: 0.05,
-        techStandard: 0.0, // ignored in JD mode as skillMatch covers it
-      }
-    : {
-        skillMatch: 0.0,
-        keywordMatch: 0.0,
-        experienceMatch: 0.0,
-        impactMatch: 0.4,
-        atsOptimization: 0.3,
-        readabilityMatch: 0.15,
-        consistencyMatch: 0.1,
-        techStandard: 0.05,
-      };
+  const weights = isJDProvided ? jdWeights : noJdWeights;
 
   evaluations.forEach((evalResult) => {
     if (!evalResult || (evalResult.score === null && isJDProvided)) return;
 
-    // Use dynamic weight if defined, otherwise fallback to evalResult.weight
-    const weight = weights[evalResult.name] !== undefined ? weights[evalResult.name] : (evalResult.weight || 0);
+    // Use dynamic weight defined in the map, default to 0
+    const weight = weights[evalResult.name] || 0;
+
+    // Pass resolved weight back into each evaluator result
+    evalResult.weight = weight;
+    evalResult.weightedScore = evalResult.score !== null ? Math.round(evalResult.score * weight) : 0;
 
     if (weight > 0 && evalResult.score !== null) {
       totalWeight += weight;


### PR DESCRIPTION
## Summary

Weight keys in `weights.config.js` (`skill`, `keyword`) didn't match evaluator names in the pipeline (`skillMatch`,`keywordMatch`), so the aggregator's JD-mode vs no-JD-mode weight split was completely non-functional. On top of that, every evaluator had its own hardcoded `currentWeight`, making the UI show misleading per-evaluator breakdowns.

## Type of Change

- [x] Bug fix
- [x] Refactor

## Related Issue

Closes #226

## Changes Made

- Rewrote `ai-ml/config/weights.config.js` to export `jdWeights` and 
  `noJdWeights` using camelCase keys (`skillMatch`, `keywordMatch`, 
  `atsOptimization`, etc.) that match the `.name` field set by `safeEval()` 
  in `runPipeline.js`
- Updated `ai-ml/pipeline/aggregator.js` to import shared weights and 
  pass the resolved `weight` and `weightedScore` back into each evaluator 
  result after aggregation, so the UI displays accurate numbers
- Removed hardcoded `weight` params and `weightedScore` calculations from 
  all 9 evaluators (`skillEvaluator`, `keywordEvaluator`, 
  `experienceEvaluator`, `semanticEvaluator`, `consistencyEvaluator`, 
  `readabilityEvaluator`, `impactEvaluator`, `atsOptimizationEvaluator`, 
  `techStandardEvaluator`)
- Removed redundant weight definitions from 
  `server/src/config/evaluatorConfig.js` (kept only feature toggles)

## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated
- [ ] Documentation updated (if needed)

Added `ai-ml/pipeline/__tests__/aggregator.test.js` that asserts 
`sum(jdWeights) ≈ 1.0` and `sum(noJdWeights) ≈ 1.0` — both pass.

## Screenshots (if UI change)

N/A — backend pipeline scoring logic only.
