### PR TITLE
fix: pass resumeText and isJDProvided to gapAnalyzer to restore contextual suggestions

### DIFF
--- a/ai-ml/pipeline/runPipeline.js
+++ b/ai-ml/pipeline/runPipeline.js
@@ -209,6 +209,8 @@ export async function runPipeline({
     impactMatch,
     atsOptimization,
     techStandard,
+    resumeText,
+    isJDProvided,
   });
 
   // 🔥 Classification

--- a/ai-ml/utils/gapAnalyzer.js
+++ b/ai-ml/utils/gapAnalyzer.js
@@ -6,7 +6,9 @@ export default function gapAnalyzer({
   readabilityMatch = {},
   impactMatch = {},
   atsOptimization = {},
-  techStandard = {}
+  techStandard = {},
+  resumeText = "",
+  isJDProvided = false
 }) {
   const categorizedSuggestions = {
     critical: [],
@@ -34,7 +36,7 @@ export default function gapAnalyzer({
   }
 
   // 2. 🎯 Strategic: Skills & Keywords (Only if JD provided)
-  if (skillMatch?.score !== null && skillMatch?.score < 70) {
+  if (isJDProvided && skillMatch?.score !== null && skillMatch?.score < 70) {
     const missingSkills = skillMatch.details?.missingSkills || skillMatch.missingSkills || [];
     const prioritySkills = missingSkills.slice(0, 3);
     if (prioritySkills.length > 0) {
@@ -42,7 +44,7 @@ export default function gapAnalyzer({
     }
   }
 
-  if (keywordMatch?.score !== null && keywordMatch?.score < 60) {
+  if (isJDProvided && keywordMatch?.score !== null && keywordMatch?.score < 60) {
     const missingKeywords = keywordMatch.details?.missingKeywords || keywordMatch.missingKeywords || [];
     const topKeywords = missingKeywords.slice(0, 3);
     if (topKeywords.length > 0) {
@@ -76,7 +78,7 @@ export default function gapAnalyzer({
 
   // If still too few, add highly contextual polish tips
   if (allSuggestions.length < 4) {
-    const wordCount = (atsOptimization?.meta?.resumeText || atsOptimization?.resumeText || "").split(/\s+/).length;
+    const wordCount = resumeText.split(/\s+/).filter(Boolean).length;
     if (wordCount > 1000) {
       allSuggestions.push({ priority: "Polish", text: "Your resume is quite long (~3+ pages). Aim for a concise 1-2 page format for maximum engagement.", icon: "CheckCircle2" });
     } else if (wordCount > 0 && wordCount < 200) {


### PR DESCRIPTION
Closes #227

## What I did
- Passed `resumeText` and `isJDProvided` from `runPipeline.js` to `gapAnalyzer`
- Updated `gapAnalyzer` signature to accept and use both params
- Fixed word count logic to use `resumeText` directly instead of incorrectly reading from `atsOptimization.meta`
- Added `isJDProvided` guard to skill and keyword suggestion branches so they only fire when a JD is actually provided

## Why
`gapAnalyzer` was receiving `resumeText` and `isJDProvided` as `undefined` always, so word count was 0 and all contextual polish suggestions were dead code.

No other changes.