### PR TITLE
feat: expand ATS checklist to 9 checks and show missing tech keywords

### DIFF
--- a/ai-ml/evaluators/techStandardEvaluator.js
+++ b/ai-ml/evaluators/techStandardEvaluator.js
@@ -8,6 +8,7 @@ import { normalizeSkillArray } from "../utils/skillNormalizer.js";
 export const techStandardEvaluator = ({ resumeText = "" }) => {
   const lowerText = resumeText.toLowerCase();
   const domainMatches = {};
+  const domainMissing = {};
 
   Object.keys(techKeywords).forEach(domain => {
     // Normalize domain keywords to match our canonical forms
@@ -19,6 +20,7 @@ export const techStandardEvaluator = ({ resumeText = "" }) => {
       (skill === 'csharp' && lowerText.includes('c#'))
     );
     domainMatches[domain] = matches;
+    domainMissing[domain] = normDomainKeywords.filter(skill => !matches.includes(skill));
   });
 
   const feedback = [];
@@ -60,6 +62,7 @@ export const techStandardEvaluator = ({ resumeText = "" }) => {
       : "The technical profile appears narrow; consider highlighting more cross-stack tools.",
     details: {
       domainMatches,
+      domainMissing,
       feedback,
       suggestions
     },

--- a/ai-ml/utils/gapAnalyzer.js
+++ b/ai-ml/utils/gapAnalyzer.js
@@ -71,7 +71,18 @@ export default function gapAnalyzer({
     categorizedSuggestions.optimization.push(`Convert passive phrases into active ones using power verbs like ${verbs.slice(0, 2).join(" or ")}.`);
   }
 
-  // 4. 🏛️ Domain Specialization
+  // 4. 🏛️ Domain Specialization — always surface missing tech keywords
+  const domainMissing = techStandard?.details?.domainMissing || {};
+  const topMissingKeywords = Object.values(domainMissing)
+    .flat()
+    .slice(0, 5);
+
+  if (topMissingKeywords.length > 0) {
+    categorizedSuggestions.strategic.push(
+      `Strengthen your technical breadth by adding keywords like: ${topMissingKeywords.join(", ")} to your resume.`
+    );
+  }
+
   if (techStandard?.score < 60) {
     const techSuggestions = techStandard.details?.suggestions || techStandard.suggestions || [];
     techSuggestions.forEach(s => categorizedSuggestions.strategic.push(s));

--- a/client/src/modules/resume-analyzer/components/AnalysisResult.jsx
+++ b/client/src/modules/resume-analyzer/components/AnalysisResult.jsx
@@ -144,43 +144,20 @@ const AnalysisResult = ({ result, file, onReset }) => {
             </div>
             <h3 className="font-bold text-text-main">ATS Readiness</h3>
           </div>
-          <div className="grid grid-cols-1 gap-3">
+          <div className="grid grid-cols-2 gap-x-6 gap-y-3">
             {checklist.map((item, i) => (
-              <div key={i} className="flex flex-col p-3 bg-dark-bg/40 rounded-xl border border-border/50">
-                <div className="flex items-center justify-between">
-                  <span className="text-xs font-bold text-text-muted">{item.label}</span>
-                  {item.status ? (
-                    <CheckCircle2 className="w-4 h-4 text-secondary" />
-                  ) : (
-                    <AlertCircle className="w-4 h-4 text-red-400" />
-                  )}
-                </div>
-                {!item.status && (
-                  <span className="text-[10px] text-red-400 mt-1.5">{item.reason}</span>
+              <div key={i} className="flex items-center gap-2">
+                {item.status ? (
+                  <CheckCircle2 className="w-4 h-4 text-secondary flex-shrink-0" />
+                ) : (
+                  <AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0" />
                 )}
+                <span className={`text-xs font-medium ${item.status ? "text-text-muted" : "text-red-400"}`}>
+                  {item.label}
+                </span>
               </div>
             ))}
           </div>
-
-          {/* Missing Tech Keywords */}
-          {missingTechKeywords.length > 0 && (
-            <div className="mt-4 pt-4 border-t border-border/50">
-              <p className="text-[10px] font-black uppercase tracking-widest text-text-muted mb-2">
-                Add These Keywords to Boost Score
-              </p>
-              <div className="flex flex-wrap gap-1.5">
-                {missingTechKeywords.map((item, i) => (
-                  <span
-                    key={i}
-                    className="px-2 py-0.5 bg-yellow-400/5 border border-yellow-400/20 text-yellow-400 text-[10px] font-bold rounded-md capitalize"
-                    title={item.domain}
-                  >
-                    {item.keyword}
-                  </span>
-                ))}
-              </div>
-            </div>
-          )}
         </div>
       </div>
 
@@ -278,6 +255,26 @@ const AnalysisResult = ({ result, file, onReset }) => {
                   </div>
                 )}
               </div>
+
+              {/* Missing Tech Standard Keywords */}
+              {missingTechKeywords.length > 0 && (
+                <div className="mt-4 pt-4 border-t border-border/50">
+                  <p className="text-[10px] font-black uppercase tracking-widest text-text-muted mb-2">
+                    Add These Keywords to Boost Score
+                  </p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {missingTechKeywords.map((item, i) => (
+                      <span
+                        key={i}
+                        className="px-2.5 py-1 bg-yellow-400/5 border border-yellow-400/20 text-yellow-400 text-[10px] font-bold rounded-lg capitalize transition-colors hover:bg-yellow-400/10"
+                        title={item.domain}
+                      >
+                        {item.keyword}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
            </div>
 
            {/* Preview */}

--- a/client/src/modules/resume-analyzer/components/AnalysisResult.jsx
+++ b/client/src/modules/resume-analyzer/components/AnalysisResult.jsx
@@ -43,10 +43,24 @@ const AnalysisResult = ({ result, file, onReset }) => {
   const atsData = result.atsOptimization || {};
   const checklist = [
     { label: "Experience Section", status: atsData.details?.sectionResults?.experience, reason: "Missing clear experience headers or work history" },
+    { label: "Education Section", status: atsData.details?.sectionResults?.education, reason: "Missing education section or degree information" },
     { label: "Skills Section", status: atsData.details?.sectionResults?.skills, reason: "No extractable skills section found" },
+    { label: "Summary / Objective", status: atsData.details?.sectionResults?.summary, reason: "Missing summary, profile, or objective section" },
     { label: "Contact: Email", status: atsData.details?.contactResults?.email, reason: "Missing valid email address" },
+    { label: "Contact: Phone", status: atsData.details?.contactResults?.phone, reason: "Missing phone number" },
     { label: "Contact: LinkedIn", status: atsData.details?.contactResults?.linkedin, reason: "Missing LinkedIn profile link" },
+    { label: "Contact: GitHub", status: atsData.details?.contactResults?.github, reason: "Missing GitHub profile link" },
+    { label: "Portfolio Link", status: atsData.details?.contactResults?.portfolio, reason: "Missing portfolio or personal website link" },
   ];
+
+  // --- Missing Tech Keywords (from techStandard evaluator) ---
+  const techData = result.techStandard?.details?.domainMissing || {};
+  const missingTechKeywords = Object.entries(techData)
+    .filter(([, keywords]) => keywords.length > 0)
+    .flatMap(([domain, keywords]) =>
+      keywords.slice(0, 3).map(kw => ({ keyword: kw, domain }))
+    )
+    .slice(0, 12);
 
   // --- Action Words ---
   const actionWords = result.readabilityMatch?.relevantVerbs || ["Spearheaded", "Orchestrated", "Transformed", "Optimized", "Architected", "Launched", "Pioneered", "Revitalized"];
@@ -147,6 +161,26 @@ const AnalysisResult = ({ result, file, onReset }) => {
               </div>
             ))}
           </div>
+
+          {/* Missing Tech Keywords */}
+          {missingTechKeywords.length > 0 && (
+            <div className="mt-4 pt-4 border-t border-border/50">
+              <p className="text-[10px] font-black uppercase tracking-widest text-text-muted mb-2">
+                Add These Keywords to Boost Score
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {missingTechKeywords.map((item, i) => (
+                  <span
+                    key={i}
+                    className="px-2 py-0.5 bg-yellow-400/5 border border-yellow-400/20 text-yellow-400 text-[10px] font-bold rounded-md capitalize"
+                    title={item.domain}
+                  >
+                    {item.keyword}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Expands the ATS Readiness checklist from 4 items to all 9 checks already computed by the backend. Also surfaces missing tech standard keywords directly in the ATS widget so users know exactly which terms to add to improve their score.

## Type of Change

- [x] Feature

## Related Issue

Closes #249 

## Changes Made

- `ai-ml/evaluators/techStandardEvaluator.js` — added `domainMissing` computation alongside existing `domainMatches`, returning unmatched tech keywords per domain in the evaluator details
- `client/src/modules/resume-analyzer/components/AnalysisResult.jsx` — expanded ATS checklist from 4 to 9 items (experience, education, skills, summary, email, phone, linkedin, github, portfolio); added "Add These Keywords to Boost Score" section showing missing tech keywords as yellow badges

## Validation

- [x] Build passes locally
- [ ] Relevant tests added/updated
- [x] Documentation updated (if needed)

## Screenshots

<!-- Add your screenshot here showing the expanded 9-item checklist and missing keywords section -->
<img width="1907" height="775" alt="Screenshot from 2026-05-10 18-05-16" src="https://github.com/user-attachments/assets/6ff09b24-9512-4ae7-9c4d-628b241013b8" />
<img width="1907" height="775" alt="Screenshot from 2026-05-10 18-05-22" src="https://github.com/user-attachments/assets/e13233a3-6dce-4bcf-a232-f8b91b15abb3" />
<img width="1907" height="775" alt="Screenshot from 2026-05-10 18-05-29" src="https://github.com/user-attachments/assets/244b0e2b-c6a1-4592-a792-e589c0bca31f" />


