### PR TITLE
feat: add resumeLink field to JobApplication and update apply API (#248)

### DIFF
--- a/server/src/database/models/JobApplication.js
+++ b/server/src/database/models/JobApplication.js
@@ -28,6 +28,25 @@ const jobApplicationSchema = new mongoose.Schema(
       default: "pending",
     },
 
+    resumeLink: {
+      type: String,
+      trim: true,
+      maxlength: [2048, "Resume link cannot exceed 2048 characters"],
+      default: null,
+      validate: {
+        validator: function (v) {
+          if (!v) return true; // allow null/empty
+          try {
+            const url = new URL(v);
+            return url.protocol === "http:" || url.protocol === "https:";
+          } catch {
+            return false;
+          }
+        },
+        message: "Resume link must be a valid HTTP or HTTPS URL",
+      },
+    },
+
     coverNote: {
       type: String,
       trim: true,

--- a/server/src/modules/jobs/controller.js
+++ b/server/src/modules/jobs/controller.js
@@ -179,12 +179,12 @@ export const getRecruiterAnalytics = asyncHandler(async (req, res) => {
  * @access  Private (Students only)
  */
 export const applyToJobPosting = asyncHandler(async (req, res) => {
-  const { resumeId, coverNote } = req.body;
+  const { resumeId, resumeLink, coverNote } = req.body;
 
   const application = await applyToJobService(
     req.params.id,
     req.user._id,
-    { resumeId, coverNote }
+    { resumeId, resumeLink, coverNote }
   );
 
   res.status(201).json({

--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -283,7 +283,7 @@ export const getRecruiterAnalytics = async (recruiterId) => {
  * Apply to a job posting (for students)
  * @param {string} jobId - ID of the job
  * @param {string} applicantId - ID of the student
- * @param {Object} options - Optional fields (resumeId, coverNote)
+ * @param {Object} options - Optional fields (resumeId, resumeLink, coverNote)
  * @returns {Promise<Object>} - Created application
  */
 export const applyToJob = async (jobId, applicantId, options = {}) => {
@@ -296,6 +296,11 @@ export const applyToJob = async (jobId, applicantId, options = {}) => {
     throw new AppError("This job is not accepting applications", 400);
   }
 
+  // resumeLink is required for student applications
+  if (!options.resumeLink || !options.resumeLink.trim()) {
+    throw new AppError("A shareable resume link is required to apply", 400);
+  }
+
   // Check for duplicate application
   const existing = await JobApplication.findOne({ job: jobId, applicant: applicantId });
   if (existing) {
@@ -306,7 +311,8 @@ export const applyToJob = async (jobId, applicantId, options = {}) => {
     job: jobId,
     applicant: applicantId,
     resume: options.resumeId || null,
-    coverNote: options.coverNote || "",
+    resumeLink: options.resumeLink.trim(),
+    coverNote: options.coverNote?.trim() || "",
   });
 
   return application;


### PR DESCRIPTION
## Summary
Adds a `resumeLink` field to the JobApplication schema with URL validation. Updates the apply API to require a shareable resume link and returns it in recruiter application responses. Backend-only changes for issue #248.
## Type of Change
- [x] Feature
## Related Issue
Closes #248
## Changes Made
- `server/src/database/models/JobApplication.js` — added `resumeLink` field with `trim`, `maxlength: 2048`, and HTTP/HTTPS URL validation; existing `resume` ObjectId kept optional for backward compatibility
- `server/src/modules/jobs/service.js` — `applyToJob` now requires `resumeLink` (returns 400 if empty/missing), persists `resumeLink` and trims `coverNote`; duplicate apply still returns 409
- `server/src/modules/jobs/controller.js` — destructures `resumeLink` from `req.body` and passes it to service
## Validation
- [x] Build passes locally
- [ ] Relevant tests added/updated
- [x] Documentation updated (if needed)
## Screenshots (if UI change)
N/A — backend only change (frontend will follow in a separate PR)