### PR TITLE
feat: extract hidden hyperlink annotations during PDF parsing

### DIFF
--- a/server/src/utils/parseResume.js
+++ b/server/src/utils/parseResume.js
@@ -92,7 +92,7 @@ export const parseResume = async (filePath) => {
     const fileBuffer = await fs.readFile(filePath);
     const parser = new PDFParse({ data: fileBuffer });
     try {
-      const parsed = await parser.getText();
+      const parsed = await parser.getText({ parseHyperlinks: true });
       text = normalizeWhitespace(parsed.text || "");
     } finally {
       await parser.destroy();


### PR DESCRIPTION



###  Description
This PR enhances the `parseResume.js` utility to automatically extract hidden hyperlink annotations from uploaded PDF resumes.

By passing the `{ parseHyperlinks: true }` parameter to our `pdf-parse` implementation, the library now leverages `pdf.js` to convert embedded PDF links (e.g., a clickable "Portfolio" or "GitHub" word) into markdown-style inline links (e.g., `[GitHub](https://github.com/praptii21)`). 

closes issue #253 

Because our existing `urlRegex` successfully targets the `http(s)://` strings within these markdown structures, these hidden URLs are now automatically identified and pushed into the AI evaluator pipeline without any additional regex modifications.

### Why is this needed?
Previously, standard text extraction would only scrape plain text. If a candidate hyperlinked the word "GitHub" instead of typing out the full URL, the AI would lose their profile link entirely. This update ensures no critical candidate portfolio or repository URLs are lost during the initial parsing phase.

###  How was this tested?
- Created mock PDF resumes containing embedded hyperlinks behind standard text.
- Processed the PDFs through `parseResume.js`.
- Verified that previously "hidden" URLs are successfully extracted into the `github`, `linkedin`, and `portfolio` JSON keys.
- Confirmed that this does not break parsing for legacy resumes or plain-text URLs.

<img width="860" height="305" alt="Screenshot 2026-05-10 184110" src="https://github.com/user-attachments/assets/d20f333d-a16d-410c-b081-011248da2f01" />