### PR TITLE
feat: ensure strategic improvements display for high-scoring resumes

### DIFF
--- a/ai-ml/utils/gapAnalyzer.js
+++ b/ai-ml/utils/gapAnalyzer.js
@@ -31,8 +31,14 @@ export default function gapAnalyzer({
     const missingContact = Object.keys(contactResults)
       .filter(k => !contactResults[k]);
     if (missingContact.length > 0) {
-      categorizedSuggestions.critical.push(`Ensure your ${missingContact.join(" and ")} are visible at the top of the document.`);
+      const verb = missingContact.length === 1 ? "is" : "are";
+      const items = missingContact.length > 2 
+        ? missingContact.slice(0, -1).join(", ") + ", and " + missingContact[missingContact.length - 1]
+        : missingContact.join(" and ");
+      categorizedSuggestions.critical.push(`Ensure your ${items} ${verb} visible at the top of the document.`);
     }
+  } else if (atsOptimization?.score < 100) {
+    categorizedSuggestions.optimization.push("Your ATS structure is excellent. Ensure you use standard, non-serif fonts to guarantee 100% parseability by legacy ATS systems.");
   }
 
   // 2. 🎯 Strategic: Skills & Keywords (Only if JD provided)
@@ -63,18 +69,24 @@ export default function gapAnalyzer({
   // 3. 📈 Optimization: Impact & Readability
   if (impactMatch?.score < 50) {
     categorizedSuggestions.optimization.push("Transform task-based descriptions into result-oriented bullet points using the XYZ formula (Accomplished [X] as measured by [Y], by doing [Z]).");
+  } else {
+    categorizedSuggestions.optimization.push("Your impact metrics are strong. Consider adding specific financial figures or time-saved percentages to make your top achievements stand out even more.");
   }
 
   const readabilityDetails = readabilityMatch?.details || {};
   if ((readabilityDetails.passiveVoiceCount || 0) > 2) {
     const verbs = readabilityDetails.relevantVerbs || [];
     categorizedSuggestions.optimization.push(`Convert passive phrases into active ones using power verbs like ${verbs.slice(0, 2).join(" or ")}.`);
+  } else {
+    categorizedSuggestions.optimization.push("Readability is highly active. Maintain this by keeping bullet points strictly under two lines each for maximum scannability.");
   }
 
   // 4. 🏛️ Domain Specialization
   if (techStandard?.score < 60) {
     const techSuggestions = techStandard.details?.suggestions || techStandard.suggestions || [];
     techSuggestions.forEach(s => categorizedSuggestions.strategic.push(s));
+  } else {
+    categorizedSuggestions.strategic.push("You have a solid technical foundation. Consider linking open-source contributions or live deployments to provide proof-of-work for your top skills.");
   }
 
   // Flatten and prioritize
@@ -91,6 +103,8 @@ export default function gapAnalyzer({
       allSuggestions.push({ priority: "Polish", text: "Your resume is quite long (~3+ pages). Aim for a concise 1-2 page format for maximum engagement.", icon: "CheckCircle2" });
     } else if (wordCount > 0 && wordCount < 200) {
       allSuggestions.push({ priority: "Polish", text: "Your resume is very brief. Consider detailing your projects or certifications to show more depth.", icon: "CheckCircle2" });
+    } else {
+      allSuggestions.push({ priority: "Polish", text: "Your resume is in the top percentile! To maintain this competitive edge, ensure you update your metrics every 3-6 months.", icon: "CheckCircle2" });
     }
   }
 


### PR DESCRIPTION
## Summary

This PR fixes a behavioral bug where highly optimized resumes were failing to populate the "Strategic Improvements" UI. Previously, the analyzer only generated suggestions if specific sub-scores fell below a threshold. This update adds conditional logic to ensure advanced, high-level optimization tips are always provided to top-scoring candidates.

## Type of Change

- [x] Feature

## Related Issue

Closes #256 

## Changes Made

- Updated `ai-ml/utils/gapAnalyzer.js` to add `else` branches across all major evaluation logic blocks (ATS, Impact, Readability, Tech Standard).
- Introduced new, advanced fallback suggestions targeting high-performing resumes (e.g., maintaining metrics, using non-serif fonts for legacy ATS, linking live deployments).
- Fixed a minor grammatical quirk in the critical ATS suggestion logic to correctly use "is" vs. "are" depending on the number of missing contact fields.

## Validation

- [x] Build passes locally


## Screenshots
<img width="535" height="636" alt="Screenshot 2026-05-10 190859" src="https://github.com/user-attachments/assets/91418a4f-64d1-4747-b730-35972aeef6b0" />