### PR TITLE
feat: add Applied Jobs page accessible from student profile

### DIFF
--- a/client/src/app/App.jsx
+++ b/client/src/app/App.jsx
@@ -19,6 +19,7 @@ import RecruiterJobsPage from "../modules/recruiter-jobs/pages/RecruiterJobsPage
 import RecruiterAnalyticsPage from "../modules/recruiter-jobs/pages/RecruiterAnalyticsPage";
 import CreateJobPostingPage from "../modules/recruiter-jobs/pages/CreateJobPostingPage";
 import JobBoardPage from "../modules/student-jobs/pages/JobBoardPage";
+import MyApplicationsPage from "../modules/student-jobs/pages/MyApplicationsPage";
 import ClassroomsDashboard from "../modules/classrooms/pages/ClassroomsDashboard";
 import ClassroomRoom from "../modules/classrooms/pages/ClassroomRoom";
 import ProtectedRoute from "../shared/components/ProtectedRoute";
@@ -45,6 +46,14 @@ function App() {
               <JobMatcherPage />
             </ProtectedRoute>
           } 
+        />
+        <Route
+          path="/my-applications"
+          element={
+            <ProtectedRoute requiredRole="student">
+              <MyApplicationsPage />
+            </ProtectedRoute>
+          }
         />
         {import.meta.env.DEV && <Route path="/demo" element={<ComponentDemo />} />}
         <Route 

--- a/client/src/modules/dashboard/DashboardPage.jsx
+++ b/client/src/modules/dashboard/DashboardPage.jsx
@@ -667,6 +667,17 @@ const DashboardPage = () => {
                       </div>
                       <ArrowRight size={16} className="text-emerald-300 group-hover/link:translate-x-1 transition-transform" />
                     </Link>
+
+                    <Link
+                      to="/my-applications"
+                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-white/10 hover:bg-white/20 transition-all"
+                    >
+                      <div className="flex items-center gap-3">
+                        <Briefcase size={18} className="text-violet-300" />
+                        <span className="font-semibold text-sm">Applied Jobs</span>
+                      </div>
+                      <ArrowRight size={16} className="text-violet-300 group-hover/link:translate-x-1 transition-transform" />
+                    </Link>
                   </>
                 ) : (
                   <>

--- a/client/src/modules/student-jobs/pages/MyApplicationsPage.jsx
+++ b/client/src/modules/student-jobs/pages/MyApplicationsPage.jsx
@@ -1,0 +1,211 @@
+import React, { useState, useEffect } from "react";
+import { useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
+import {
+  Briefcase,
+  Calendar,
+  MapPin,
+  ExternalLink,
+  Clock,
+  AlertCircle,
+} from "lucide-react";
+import Navbar from "../../../shared/landing/Navbar";
+import LoadingState from "../../../shared/components/LoadingState";
+import { getMyApplicationsDetailed } from "../services/jobService";
+
+const statusConfig = {
+  pending: { label: "Pending", bg: "bg-yellow-500/15", text: "text-yellow-300", border: "border-yellow-500/25" },
+  reviewed: { label: "Reviewed", bg: "bg-blue-500/15", text: "text-blue-300", border: "border-blue-500/25" },
+  shortlisted: { label: "Shortlisted", bg: "bg-emerald-500/15", text: "text-emerald-300", border: "border-emerald-500/25" },
+  rejected: { label: "Rejected", bg: "bg-red-500/15", text: "text-red-300", border: "border-red-500/25" },
+  withdrawn: { label: "Withdrawn", bg: "bg-slate-500/15", text: "text-slate-400", border: "border-slate-500/25" },
+};
+
+const MyApplicationsPage = () => {
+  const { token } = useSelector((state) => state.auth);
+  const navigate = useNavigate();
+  const [applications, setApplications] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchApplications = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await getMyApplicationsDetailed(token);
+        setApplications(data.applications || []);
+      } catch (err) {
+        setError(err.message || "Failed to load applications.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchApplications();
+  }, [token]);
+
+  const formatDate = (dateStr) => {
+    return new Date(dateStr).toLocaleDateString("en-IN", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+  };
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] text-slate-100 flex flex-col">
+      <Navbar />
+
+      {/* Spacer for fixed navbar */}
+      <div className="h-32 md:h-40 shrink-0"></div>
+
+      <div className="container mx-auto px-4 pb-12 flex-1 max-w-4xl">
+        {/* Header */}
+        <div className="mb-10 text-center">
+          <h1 className="text-4xl md:text-5xl font-black mb-4 tracking-tight">
+            <span className="text-gradient">My</span> Applications
+          </h1>
+          <p className="text-slate-400 text-lg">
+            Track all the jobs you&apos;ve applied to
+          </p>
+        </div>
+
+        {/* Content */}
+        {loading ? (
+          <div className="min-h-[400px] flex items-center justify-center bg-slate-900/30 rounded-2xl border border-white/5">
+            <LoadingState message="Loading your applications..." />
+          </div>
+        ) : error ? (
+          <div className="text-center p-10 bg-slate-900/50 rounded-2xl border border-red-500/20">
+            <AlertCircle size={48} className="text-red-400 mx-auto mb-4" />
+            <p className="text-red-300 font-medium mb-6">{error}</p>
+            <button
+              onClick={() => window.location.reload()}
+              className="px-6 py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-bold rounded-xl transition-colors"
+            >
+              Try Again
+            </button>
+          </div>
+        ) : applications.length === 0 ? (
+          /* Empty state */
+          <div className="text-center p-12 bg-slate-900/50 rounded-2xl border border-white/5">
+            <div className="inline-flex p-4 bg-slate-700/30 rounded-2xl mb-6">
+              <Briefcase size={48} className="text-slate-500" />
+            </div>
+            <h2 className="text-2xl font-bold text-white mb-3">
+              No Applications Yet
+            </h2>
+            <p className="text-slate-400 mb-8">
+              You haven&apos;t applied to any jobs yet. Head to the Job Board to find opportunities!
+            </p>
+            <button
+              onClick={() => navigate("/jobs")}
+              className="px-8 py-3 bg-blue-600 hover:bg-blue-500 text-white font-bold rounded-xl transition-colors"
+            >
+              Browse Job Board
+            </button>
+          </div>
+        ) : (
+          /* Applications list */
+          <div className="space-y-4">
+            <p className="text-sm text-slate-500 mb-2">
+              {applications.length} application{applications.length !== 1 ? "s" : ""}
+            </p>
+
+            {applications.map((app) => {
+              const job = app.job;
+              const status = statusConfig[app.status] || statusConfig.pending;
+
+              return (
+                <div
+                  key={app._id}
+                  className="p-5 bg-slate-900/50 rounded-2xl border border-white/5 hover:border-white/10 transition-colors"
+                >
+                  <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4">
+                    {/* Job info */}
+                    <div className="flex-1 min-w-0">
+                      <h3 className="text-lg font-bold text-white truncate">
+                        {job?.title || "Job no longer available"}
+                      </h3>
+
+                      <div className="flex flex-wrap items-center gap-3 mt-2 text-sm text-slate-400">
+                        {job?.location && (
+                          <span className="flex items-center gap-1">
+                            <MapPin size={14} />
+                            {job.location.city}
+                            {job.location.remote && ", Remote"}
+                          </span>
+                        )}
+                        {job?.jobLevel && (
+                          <span className="px-2 py-0.5 bg-slate-800 rounded text-xs">
+                            {job.jobLevel}
+                          </span>
+                        )}
+                      </div>
+
+                      {/* Skills */}
+                      {job?.skills?.length > 0 && (
+                        <div className="flex flex-wrap gap-1.5 mt-3">
+                          {job.skills.slice(0, 5).map((skill) => (
+                            <span
+                              key={skill}
+                              className="px-2 py-0.5 bg-blue-500/10 text-blue-300 text-xs rounded-md border border-blue-500/20"
+                            >
+                              {skill}
+                            </span>
+                          ))}
+                          {job.skills.length > 5 && (
+                            <span className="text-xs text-slate-500">
+                              +{job.skills.length - 5} more
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Status + Date */}
+                    <div className="flex flex-col items-end gap-2 shrink-0">
+                      <span
+                        className={`px-3 py-1 text-xs font-bold rounded-full ${status.bg} ${status.text} border ${status.border}`}
+                      >
+                        {status.label}
+                      </span>
+                      <span className="flex items-center gap-1 text-xs text-slate-500">
+                        <Calendar size={12} />
+                        {formatDate(app.createdAt)}
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* Resume link + Cover note */}
+                  <div className="mt-4 pt-3 border-t border-white/5 flex flex-wrap items-center gap-4 text-sm">
+                    {app.resumeLink && (
+                      <a
+                        href={app.resumeLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-1.5 text-blue-400 hover:text-blue-300 transition-colors"
+                      >
+                        <ExternalLink size={14} />
+                        Resume Link
+                      </a>
+                    )}
+                    {app.coverNote && (
+                      <span className="flex items-center gap-1.5 text-slate-500">
+                        <Clock size={14} />
+                        Cover note submitted
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+};
+
+export default MyApplicationsPage;

--- a/client/src/modules/student-jobs/services/jobService.js
+++ b/client/src/modules/student-jobs/services/jobService.js
@@ -43,3 +43,12 @@ export const applyToJob = async (jobId, token, options = {}) => {
 export const getMyAppliedJobIds = async (token) => {
   return apiRequest("/api/jobs/my-applications", { token });
 };
+
+/**
+ * Get current student's applied jobs with full details
+ * @param {string} token - Auth token
+ * @returns {Promise<Object>} - API response with applications array
+ */
+export const getMyApplicationsDetailed = async (token) => {
+  return apiRequest("/api/jobs/my-applications/details", { token });
+};

--- a/client/src/shared/landing/Navbar.jsx
+++ b/client/src/shared/landing/Navbar.jsx
@@ -138,6 +138,16 @@ const Navbar = () => {
                     <LayoutDashboard size={18} />
                     Dashboard
                   </Link>
+                  {user?.role === 'student' && (
+                    <Link 
+                      to="/my-applications" 
+                      className="flex items-center gap-3 px-4 py-2.5 text-sm text-[var(--text-muted)] hover:text-[var(--text-main)] hover:bg-[var(--surface-hover)] transition-colors"
+                      onClick={() => setIsProfileOpen(false)}
+                    >
+                      <Briefcase size={18} />
+                      Applied Jobs
+                    </Link>
+                  )}
                   <button 
                     onClick={handleLogout}
                     className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-red-500 hover:text-red-400 hover:bg-red-400/10 transition-colors mt-1 border-t border-[var(--border)] pt-3"

--- a/server/src/modules/jobs/controller.js
+++ b/server/src/modules/jobs/controller.js
@@ -7,6 +7,7 @@ import {
   getJobApplications as getJobAppsService,
   getApplicantAnalytics as getApplicantAnalyticsData,
   getMyAppliedJobIds as getMyAppliedJobIdsService,
+  getMyApplicationsWithDetails as getMyAppsDetailedService,
 } from "./service.js";
 import AppError from "../../utils/AppError.js";
 import asyncHandler from "../../utils/asyncHandler.js";
@@ -221,5 +222,20 @@ export const getMyApplications = asyncHandler(async (req, res) => {
   res.status(200).json({
     success: true,
     appliedJobIds: jobIds,
+  });
+});
+
+/**
+ * @desc    Get current student's applied jobs with full details
+ * @route   GET /api/jobs/my-applications/details
+ * @access  Private (Students only)
+ */
+export const getMyApplicationsDetailed = asyncHandler(async (req, res) => {
+  const applications = await getMyAppsDetailedService(req.user._id);
+
+  res.status(200).json({
+    success: true,
+    count: applications.length,
+    applications,
   });
 });

--- a/server/src/modules/jobs/routes.js
+++ b/server/src/modules/jobs/routes.js
@@ -10,6 +10,7 @@ import {
   applyToJobPosting,
   getApplications,
   getMyApplications,
+  getMyApplicationsDetailed,
 } from "./controller.js";
 
 const router = express.Router();
@@ -28,6 +29,7 @@ router.post("/", authorizeRoles("recruiter"), createJobPosting);
 
 // Student application routes (must be before /:id to avoid route conflict)
 router.get("/my-applications", authorizeRoles("student"), getMyApplications);
+router.get("/my-applications/details", authorizeRoles("student"), getMyApplicationsDetailed);
 
 // Job-specific routes
 router

--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -422,3 +422,17 @@ export const getMyAppliedJobIds = async (applicantId) => {
 
   return applications.map((app) => app.job.toString());
 };
+
+/**
+ * Get all applications with full job details for the current student
+ * @param {string} applicantId - ID of the student
+ * @returns {Promise<Object[]>} - Array of application objects with populated job data
+ */
+export const getMyApplicationsWithDetails = async (applicantId) => {
+  const applications = await JobApplication.find({ applicant: applicantId })
+    .populate("job", "title skills location status salary jobLevel description")
+    .sort({ createdAt: -1 })
+    .lean();
+
+  return applications;
+};


### PR DESCRIPTION
## Summary

Implements the feature requested by maintainer after PR #260 — when a student clicks on their profile, 
they can now see an **"Applied Jobs"** option that shows all jobs they've applied to with full details.

This required changes across both backend (new detailed endpoint) and frontend (new page, navigation links).

## Type of Change

- [x] Feature

## Related Issue

Closes #262 

## What This PR Does

### Problem
Students could apply to jobs but had **no way to view their application history** anywhere in the app. 
The existing `GET /api/jobs/my-applications` endpoint only returned job IDs (used internally for the 
"Applied" badge on the Job Board), not the full application details needed for a dedicated page.

### Solution

#### 1. New Backend Endpoint
Created `GET /api/jobs/my-applications/details` that returns **full application records** with 
populated job data. The existing `/my-applications` endpoint remains untouched since it's used 
by the Job Board and Job Matcher for lightweight applied-status checks.

**Flow:**
Student hits /my-applications/details → controller calls getMyApplicationsWithDetails(userId) → service queries JobApplication.find({ applicant: userId }) → .populate("job", "title skills location status salary jobLevel description") → .sort({ createdAt: -1 }) → returns full application objects with nested job data


#### 2. New Frontend Page (`/my-applications`)
Created `MyApplicationsPage.jsx` that displays:
- **Job title, location, level** from populated job data
- **Status badge** with color coding:
  - 🟡 Pending (yellow)
  - 🔵 Reviewed (blue)
  - 🟢 Shortlisted (green)
  - 🔴 Rejected (red)
  - ⚪ Withdrawn (gray)
- **Applied date** formatted as "10 May 2026"
- **Skills tags** (up to 5 shown, rest collapsed as "+N more")
- **Resume link** (opens in new tab)
- **Cover note indicator** if submitted
- **Empty state** with link to Job Board when no applications exist

#### 3. Navigation — Accessible from 3 Places
- **Profile dropdown** → "Applied Jobs" link (only visible for students, not recruiters)
- **Dashboard** → "Improve Profile" quick actions → "Applied Jobs"
- **Direct URL** → `/my-applications` (protected route, students only)

## Files Changed

| File | Type | What Changed |
|------|------|-------------|
| `server/src/modules/jobs/service.js` | Backend | Added `getMyApplicationsWithDetails()` — queries with `.populate()` and `.sort()` |
| `server/src/modules/jobs/controller.js` | Backend | Added `getMyApplicationsDetailed` controller handler |
| `server/src/modules/jobs/routes.js` | Backend | Added `GET /my-applications/details` route before `/:id` |
| `client/src/modules/student-jobs/pages/MyApplicationsPage.jsx` | Frontend (new) | Full page with cards, status badges, empty state |
| `client/src/modules/student-jobs/services/jobService.js` | Frontend | Added `getMyApplicationsDetailed()` API call |
| `client/src/app/App.jsx` | Frontend | Added `/my-applications` protected route |
| `client/src/shared/landing/Navbar.jsx` | Frontend | Added "Applied Jobs" in profile dropdown (students only) |
| `client/src/modules/dashboard/DashboardPage.jsx` | Frontend | Added "Applied Jobs" quick action link |

## Design Decisions

1. **Separate endpoint instead of extending existing one** — The existing `/my-applications` returns 
   only IDs and is called on every Job Board/Matcher page load. Keeping it lightweight avoids 
   unnecessary `.populate()` calls. The new `/details` endpoint is only called when the student 
   explicitly visits the Applied Jobs page.

2. **Route placement** — `/my-applications/details` is placed before `/:id` in `routes.js` to 
   avoid Express treating "my-applications" as a dynamic `:id` parameter (same pattern used in PR #257).

3. **Student-only visibility** — The "Applied Jobs" link in the profile dropdown is conditionally 
   rendered with `user?.role === 'student'` so recruiters don't see it.

## Validation

- [x] Build passes locally
- [x] Page renders correctly with applied jobs
- [x] Empty state renders when no applications exist
- [x] Status badges display correct colors
- [x] Navigation works from profile dropdown, dashboard, and direct URL
- [x] Route is protected — redirects unauthenticated users

## Screenshots 

<img width="1907" height="788" alt="Screenshot from 2026-05-10 21-43-22" src="https://github.com/user-attachments/assets/1afcb53c-f397-47f9-8a66-dd04a61f8d74" />
<img width="1907" height="788" alt="Screenshot from 2026-05-10 21-43-14" src="https://github.com/user-attachments/assets/979e24e3-1837-4482-9f7b-3a33aa683784" />
