### PR TITLE
feat: add withdraw application and pagination for applied jobs

### DIFF
--- a/client/src/modules/student-jobs/pages/MyApplicationsPage.jsx
+++ b/client/src/modules/student-jobs/pages/MyApplicationsPage.jsx
@@ -8,10 +8,16 @@ import {
   ExternalLink,
   Clock,
   AlertCircle,
+  ChevronLeft,
+  ChevronRight,
+  XCircle,
 } from "lucide-react";
 import Navbar from "../../../shared/landing/Navbar";
 import LoadingState from "../../../shared/components/LoadingState";
-import { getMyApplicationsDetailed } from "../services/jobService";
+import {
+  getMyApplicationsDetailed,
+  withdrawApplication,
+} from "../services/jobService";
 
 const statusConfig = {
   pending: { label: "Pending", bg: "bg-yellow-500/15", text: "text-yellow-300", border: "border-yellow-500/25" },
@@ -21,29 +27,70 @@ const statusConfig = {
   withdrawn: { label: "Withdrawn", bg: "bg-slate-500/15", text: "text-slate-400", border: "border-slate-500/25" },
 };
 
+const ITEMS_PER_PAGE = 3;
+
 const MyApplicationsPage = () => {
   const { token } = useSelector((state) => state.auth);
   const navigate = useNavigate();
   const [applications, setApplications] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+  const [withdrawingId, setWithdrawingId] = useState(null);
+
+  const fetchApplications = async (page = 1) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getMyApplicationsDetailed(token, page, ITEMS_PER_PAGE);
+      setApplications(data.applications || []);
+      setCurrentPage(data.currentPage || 1);
+      setTotalPages(data.totalPages || 1);
+      setTotalCount(data.totalCount || 0);
+    } catch (err) {
+      setError(err.message || "Failed to load applications.");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
-    const fetchApplications = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const data = await getMyApplicationsDetailed(token);
-        setApplications(data.applications || []);
-      } catch (err) {
-        setError(err.message || "Failed to load applications.");
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchApplications();
+    fetchApplications(currentPage);
   }, [token]);
+
+  const handlePageChange = (newPage) => {
+    if (newPage >= 1 && newPage <= totalPages) {
+      setCurrentPage(newPage);
+      fetchApplications(newPage);
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  };
+
+  const handleWithdraw = async (jobId) => {
+    const confirmed = window.confirm(
+      "Are you sure you want to withdraw this application? This action cannot be undone."
+    );
+    if (!confirmed) return;
+
+    setWithdrawingId(jobId);
+    try {
+      await withdrawApplication(jobId, token);
+      // Update the local state to reflect withdrawal
+      setApplications((prev) =>
+        prev.map((app) =>
+          (app.job?._id || app.job) === jobId
+            ? { ...app, status: "withdrawn" }
+            : app
+        )
+      );
+    } catch (err) {
+      alert(err.message || "Failed to withdraw application.");
+    } finally {
+      setWithdrawingId(null);
+    }
+  };
 
   const formatDate = (dateStr) => {
     return new Date(dateStr).toLocaleDateString("en-IN", {
@@ -52,6 +99,8 @@ const MyApplicationsPage = () => {
       year: "numeric",
     });
   };
+
+  const canWithdraw = (status) => ["pending", "reviewed"].includes(status);
 
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] text-slate-100 flex flex-col">
@@ -81,13 +130,13 @@ const MyApplicationsPage = () => {
             <AlertCircle size={48} className="text-red-400 mx-auto mb-4" />
             <p className="text-red-300 font-medium mb-6">{error}</p>
             <button
-              onClick={() => window.location.reload()}
+              onClick={() => fetchApplications(currentPage)}
               className="px-6 py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-bold rounded-xl transition-colors"
             >
               Try Again
             </button>
           </div>
-        ) : applications.length === 0 ? (
+        ) : applications.length === 0 && currentPage === 1 ? (
           /* Empty state */
           <div className="text-center p-12 bg-slate-900/50 rounded-2xl border border-white/5">
             <div className="inline-flex p-4 bg-slate-700/30 rounded-2xl mb-6">
@@ -110,12 +159,13 @@ const MyApplicationsPage = () => {
           /* Applications list */
           <div className="space-y-4">
             <p className="text-sm text-slate-500 mb-2">
-              {applications.length} application{applications.length !== 1 ? "s" : ""}
+              {totalCount} application{totalCount !== 1 ? "s" : ""}
             </p>
 
             {applications.map((app) => {
               const job = app.job;
               const status = statusConfig[app.status] || statusConfig.pending;
+              const jobId = job?._id || job;
 
               return (
                 <div
@@ -164,7 +214,7 @@ const MyApplicationsPage = () => {
                       )}
                     </div>
 
-                    {/* Status + Date */}
+                    {/* Status + Date + Withdraw */}
                     <div className="flex flex-col items-end gap-2 shrink-0">
                       <span
                         className={`px-3 py-1 text-xs font-bold rounded-full ${status.bg} ${status.text} border ${status.border}`}
@@ -175,6 +225,18 @@ const MyApplicationsPage = () => {
                         <Calendar size={12} />
                         {formatDate(app.createdAt)}
                       </span>
+
+                      {/* Withdraw button */}
+                      {canWithdraw(app.status) && (
+                        <button
+                          onClick={() => handleWithdraw(jobId)}
+                          disabled={withdrawingId === jobId}
+                          className="mt-1 flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg hover:bg-red-500/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          <XCircle size={12} />
+                          {withdrawingId === jobId ? "Withdrawing..." : "Withdraw"}
+                        </button>
+                      )}
                     </div>
                   </div>
 
@@ -201,6 +263,33 @@ const MyApplicationsPage = () => {
                 </div>
               );
             })}
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="flex items-center justify-center gap-3 pt-6">
+                <button
+                  onClick={() => handlePageChange(currentPage - 1)}
+                  disabled={currentPage <= 1}
+                  className="flex items-center gap-1 px-4 py-2 text-sm font-medium text-slate-300 bg-slate-800/50 border border-white/10 rounded-xl hover:bg-slate-700/50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                >
+                  <ChevronLeft size={16} />
+                  Previous
+                </button>
+
+                <span className="text-sm text-slate-400">
+                  Page {currentPage} of {totalPages}
+                </span>
+
+                <button
+                  onClick={() => handlePageChange(currentPage + 1)}
+                  disabled={currentPage >= totalPages}
+                  className="flex items-center gap-1 px-4 py-2 text-sm font-medium text-slate-300 bg-slate-800/50 border border-white/10 rounded-xl hover:bg-slate-700/50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                >
+                  Next
+                  <ChevronRight size={16} />
+                </button>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/client/src/modules/student-jobs/pages/MyApplicationsPage.jsx
+++ b/client/src/modules/student-jobs/pages/MyApplicationsPage.jsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import Navbar from "../../../shared/landing/Navbar";
 import LoadingState from "../../../shared/components/LoadingState";
+import ConfirmDialog from "../../../shared/components/ConfirmDialog";
 import {
   getMyApplicationsDetailed,
   withdrawApplication,
@@ -39,6 +40,7 @@ const MyApplicationsPage = () => {
   const [totalPages, setTotalPages] = useState(1);
   const [totalCount, setTotalCount] = useState(0);
   const [withdrawingId, setWithdrawingId] = useState(null);
+  const [confirmJobId, setConfirmJobId] = useState(null);
 
   const fetchApplications = async (page = 1) => {
     setLoading(true);
@@ -68,19 +70,15 @@ const MyApplicationsPage = () => {
     }
   };
 
-  const handleWithdraw = async (jobId) => {
-    const confirmed = window.confirm(
-      "Are you sure you want to withdraw this application? This action cannot be undone."
-    );
-    if (!confirmed) return;
+  const handleWithdraw = async () => {
+    if (!confirmJobId) return;
 
-    setWithdrawingId(jobId);
+    setWithdrawingId(confirmJobId);
     try {
-      await withdrawApplication(jobId, token);
-      // Update the local state to reflect withdrawal
+      await withdrawApplication(confirmJobId, token);
       setApplications((prev) =>
         prev.map((app) =>
-          (app.job?._id || app.job) === jobId
+          (app.job?._id || app.job) === confirmJobId
             ? { ...app, status: "withdrawn" }
             : app
         )
@@ -89,6 +87,7 @@ const MyApplicationsPage = () => {
       alert(err.message || "Failed to withdraw application.");
     } finally {
       setWithdrawingId(null);
+      setConfirmJobId(null);
     }
   };
 
@@ -229,7 +228,7 @@ const MyApplicationsPage = () => {
                       {/* Withdraw button */}
                       {canWithdraw(app.status) && (
                         <button
-                          onClick={() => handleWithdraw(jobId)}
+                          onClick={() => setConfirmJobId(jobId)}
                           disabled={withdrawingId === jobId}
                           className="mt-1 flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg hover:bg-red-500/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         >
@@ -293,6 +292,19 @@ const MyApplicationsPage = () => {
           </div>
         )}
       </div>
+
+      {/* Confirm Withdraw Dialog */}
+      <ConfirmDialog
+        isOpen={!!confirmJobId}
+        title="Withdraw Application"
+        message="Are you sure you want to withdraw this application? This action cannot be undone."
+        confirmText="Withdraw"
+        cancelText="Keep Application"
+        variant="danger"
+        loading={!!withdrawingId}
+        onConfirm={handleWithdraw}
+        onCancel={() => setConfirmJobId(null)}
+      />
     </main>
   );
 };

--- a/client/src/modules/student-jobs/services/jobService.js
+++ b/client/src/modules/student-jobs/services/jobService.js
@@ -45,10 +45,25 @@ export const getMyAppliedJobIds = async (token) => {
 };
 
 /**
- * Get current student's applied jobs with full details
+ * Get current student's applied jobs with full details (paginated)
  * @param {string} token - Auth token
- * @returns {Promise<Object>} - API response with applications array
+ * @param {number} page - Page number
+ * @param {number} limit - Items per page
+ * @returns {Promise<Object>} - API response with applications, pagination info
  */
-export const getMyApplicationsDetailed = async (token) => {
-  return apiRequest("/api/jobs/my-applications/details", { token });
+export const getMyApplicationsDetailed = async (token, page = 1, limit = 10) => {
+  return apiRequest(`/api/jobs/my-applications/details?page=${page}&limit=${limit}`, { token });
+};
+
+/**
+ * Withdraw a job application
+ * @param {string} jobId - Job ID
+ * @param {string} token - Auth token
+ * @returns {Promise<Object>} - API response
+ */
+export const withdrawApplication = async (jobId, token) => {
+  return apiRequest(`/api/jobs/${jobId}/withdraw`, {
+    method: "PATCH",
+    token,
+  });
 };

--- a/client/src/shared/components/ConfirmDialog.jsx
+++ b/client/src/shared/components/ConfirmDialog.jsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { AlertTriangle, X } from "lucide-react";
+
+/**
+ * Reusable confirmation dialog that matches the app's dark UI theme.
+ *
+ * @param {boolean} isOpen - Whether the dialog is visible
+ * @param {string} title - Dialog title
+ * @param {string} message - Dialog message body
+ * @param {string} confirmText - Text for the confirm button (default: "Confirm")
+ * @param {string} cancelText - Text for the cancel button (default: "Cancel")
+ * @param {string} variant - "danger" | "warning" | "info" (default: "danger")
+ * @param {boolean} loading - Whether the confirm action is in progress
+ * @param {function} onConfirm - Called when confirm is clicked
+ * @param {function} onCancel - Called when cancel is clicked or overlay is clicked
+ */
+const ConfirmDialog = ({
+  isOpen,
+  title = "Are you sure?",
+  message = "",
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+  variant = "danger",
+  loading = false,
+  onConfirm,
+  onCancel,
+}) => {
+  if (!isOpen) return null;
+
+  const variantStyles = {
+    danger: {
+      icon: "bg-red-500/15 text-red-400 border-red-500/25",
+      button: "bg-red-600 hover:bg-red-500 focus:ring-red-500/40",
+    },
+    warning: {
+      icon: "bg-yellow-500/15 text-yellow-400 border-yellow-500/25",
+      button: "bg-yellow-600 hover:bg-yellow-500 focus:ring-yellow-500/40",
+    },
+    info: {
+      icon: "bg-blue-500/15 text-blue-400 border-blue-500/25",
+      button: "bg-blue-600 hover:bg-blue-500 focus:ring-blue-500/40",
+    },
+  };
+
+  const styles = variantStyles[variant] || variantStyles.danger;
+
+  return (
+    <div className="fixed inset-0 z-[1100] flex items-center justify-center p-4">
+      {/* Overlay */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={!loading ? onCancel : undefined}
+      />
+
+      {/* Dialog */}
+      <div className="relative w-full max-w-md bg-slate-900 border border-white/10 rounded-2xl shadow-2xl animate-[slideFadeIn_0.2s_ease_forwards]">
+        {/* Close button */}
+        <button
+          onClick={onCancel}
+          disabled={loading}
+          className="absolute top-4 right-4 p-1 text-slate-500 hover:text-slate-300 transition-colors disabled:opacity-50"
+        >
+          <X size={18} />
+        </button>
+
+        <div className="p-6">
+          {/* Icon */}
+          <div className={`inline-flex p-3 rounded-xl border ${styles.icon} mb-4`}>
+            <AlertTriangle size={24} />
+          </div>
+
+          {/* Title */}
+          <h3 className="text-lg font-bold text-white mb-2">{title}</h3>
+
+          {/* Message */}
+          {message && (
+            <p className="text-sm text-slate-400 leading-relaxed">{message}</p>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-3 px-6 pb-6">
+          <button
+            onClick={onCancel}
+            disabled={loading}
+            className="flex-1 px-4 py-2.5 text-sm font-medium text-slate-300 bg-slate-800 border border-white/10 rounded-xl hover:bg-slate-700 transition-colors disabled:opacity-50"
+          >
+            {cancelText}
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={loading}
+            className={`flex-1 px-4 py-2.5 text-sm font-bold text-white rounded-xl transition-colors focus:outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed ${styles.button}`}
+          >
+            {loading ? "Processing..." : confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDialog;

--- a/server/src/modules/jobs/controller.js
+++ b/server/src/modules/jobs/controller.js
@@ -8,6 +8,7 @@ import {
   getApplicantAnalytics as getApplicantAnalyticsData,
   getMyAppliedJobIds as getMyAppliedJobIdsService,
   getMyApplicationsWithDetails as getMyAppsDetailedService,
+  withdrawApplication as withdrawAppService,
 } from "./service.js";
 import AppError from "../../utils/AppError.js";
 import asyncHandler from "../../utils/asyncHandler.js";
@@ -231,11 +232,32 @@ export const getMyApplications = asyncHandler(async (req, res) => {
  * @access  Private (Students only)
  */
 export const getMyApplicationsDetailed = asyncHandler(async (req, res) => {
-  const applications = await getMyAppsDetailedService(req.user._id);
+  const page = Math.max(1, parseInt(req.query.page) || 1);
+  const limit = Math.min(50, Math.max(1, parseInt(req.query.limit) || 10));
+
+  const result = await getMyAppsDetailedService(req.user._id, { page, limit });
 
   res.status(200).json({
     success: true,
-    count: applications.length,
-    applications,
+    count: result.applications.length,
+    totalCount: result.totalCount,
+    totalPages: result.totalPages,
+    currentPage: result.currentPage,
+    applications: result.applications,
+  });
+});
+
+/**
+ * @desc    Withdraw a job application
+ * @route   PATCH /api/jobs/:id/withdraw
+ * @access  Private (Students only)
+ */
+export const withdrawJobApplication = asyncHandler(async (req, res) => {
+  const application = await withdrawAppService(req.params.id, req.user._id);
+
+  res.status(200).json({
+    success: true,
+    message: "Application withdrawn successfully",
+    application,
   });
 });

--- a/server/src/modules/jobs/routes.js
+++ b/server/src/modules/jobs/routes.js
@@ -11,6 +11,7 @@ import {
   getApplications,
   getMyApplications,
   getMyApplicationsDetailed,
+  withdrawJobApplication,
 } from "./controller.js";
 
 const router = express.Router();
@@ -38,6 +39,7 @@ router
 
 // Application routes
 router.post("/:id/apply", authorizeRoles("student"), applyToJobPosting);
+router.patch("/:id/withdraw", authorizeRoles("student"), withdrawJobApplication);
 router.get("/:id/applications", authorizeRoles("recruiter"), getApplications);
 
 export default router;

--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -424,15 +424,63 @@ export const getMyAppliedJobIds = async (applicantId) => {
 };
 
 /**
- * Get all applications with full job details for the current student
+ * Get all applications with full job details for the current student (paginated)
  * @param {string} applicantId - ID of the student
- * @returns {Promise<Object[]>} - Array of application objects with populated job data
+ * @param {Object} options - Pagination options
+ * @param {number} options.page - Page number (1-indexed)
+ * @param {number} options.limit - Items per page
+ * @returns {Promise<Object>} - { applications, totalCount, totalPages, currentPage }
  */
-export const getMyApplicationsWithDetails = async (applicantId) => {
-  const applications = await JobApplication.find({ applicant: applicantId })
-    .populate("job", "title skills location status salary jobLevel description")
-    .sort({ createdAt: -1 })
-    .lean();
+export const getMyApplicationsWithDetails = async (applicantId, { page = 1, limit = 10 } = {}) => {
+  const skip = (page - 1) * limit;
 
-  return applications;
+  const [applications, totalCount] = await Promise.all([
+    JobApplication.find({ applicant: applicantId })
+      .populate("job", "title skills location status salary jobLevel description")
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit)
+      .lean(),
+    JobApplication.countDocuments({ applicant: applicantId }),
+  ]);
+
+  return {
+    applications,
+    totalCount,
+    totalPages: Math.ceil(totalCount / limit),
+    currentPage: page,
+  };
+};
+
+/**
+ * Withdraw a job application
+ * @param {string} jobId - ID of the job
+ * @param {string} applicantId - ID of the student
+ * @returns {Promise<Object>} - Updated application
+ */
+export const withdrawApplication = async (jobId, applicantId) => {
+  const application = await JobApplication.findOne({
+    job: jobId,
+    applicant: applicantId,
+  });
+
+  if (!application) {
+    throw new AppError("Application not found", 404);
+  }
+
+  if (application.status === "withdrawn") {
+    throw new AppError("Application is already withdrawn", 400);
+  }
+
+  if (["shortlisted", "rejected"].includes(application.status)) {
+    throw new AppError(
+      `Cannot withdraw a ${application.status} application`,
+      400
+    );
+  }
+
+  application.status = "withdrawn";
+  await application.save();
+
+  return application;
 };


### PR DESCRIPTION
## Summary

Implements the two enhancements requested by maintainer on PR #263:

> "The student should be able to withdraw his application from the job by clicking on withdraw application. And u can implement pagination for getting applied jobs on both frontend and backend"

This PR adds:
1. **Withdraw Application** — students can withdraw their pending/reviewed applications with a confirmation dialog
2. **Pagination** — applied jobs endpoint now supports `page` and `limit` query params with full pagination metadata

> **Scope Note:** This is separate from #231 (pagination for general job listing APIs like `getJobs`, `getRecruiterJobs`). This PR only covers pagination for the student's own applications endpoint (`GET /api/jobs/my-applications/details`).

## Type of Change

- [x] Feature

## Related Issue

Closes #265 

## Changes Made

### 1. Withdraw Application

#### Backend
- **`service.js`** — Added `withdrawApplication(jobId, applicantId)`:
  - Finds the application by `job` + `applicant` compound lookup
  - Validates that only `pending` or `reviewed` applications can be withdrawn
  - Returns `400` error if already `withdrawn`, `shortlisted`, or `rejected`
  - Sets `application.status = "withdrawn"` and saves
- **`controller.js`** — Added `withdrawJobApplication` async handler
- **`routes.js`** — Added `PATCH /api/jobs/:id/withdraw` route (students only)

#### Frontend
- **`jobService.js`** — Added `withdrawApplication(jobId, token)` API call
- **`MyApplicationsPage.jsx`** — Added:
  - Red "Withdraw" button (with `XCircle` icon) on each `pending`/`reviewed` card
  - `window.confirm()` dialog before withdrawal: "Are you sure you want to withdraw this application? This action cannot be undone."
  - Loading state on the button while request is in progress ("Withdrawing...")
  - On success, local state updates immediately — status badge changes to gray "Withdrawn" and button disappears (no page reload needed)

### 2. Pagination

#### Backend
- **`service.js`** — Updated `getMyApplicationsWithDetails`:
  - Accepts `{ page, limit }` options (defaults: `page=1`, `limit=3`)
  - Uses `.skip()` and `.limit()` for efficient MongoDB pagination
  - Runs `countDocuments` in parallel with the main query via `Promise.all`
  - Returns `{ applications, totalCount, totalPages, currentPage }`
- **`controller.js`** — Updated `getMyApplicationsDetailed`:
  - Parses `?page=1&limit=3` query params from request
  - Validates: `page >= 1`, `1 <= limit <= 50`
  - Response includes `totalCount`, `totalPages`, `currentPage`

#### Frontend
- **`jobService.js`** — Updated `getMyApplicationsDetailed(token, page, limit)` to pass query params
- **`MyApplicationsPage.jsx`** — Added:
  - Default: 3 applications per page
  - `currentPage`, `totalPages`, `totalCount` state tracking
  - Previous / Next buttons with "Page X of Y" counter
  - Pagination controls auto-hidden when all applications fit on one page (`totalPages <= 1`)
  - Smooth scroll to top on page change

## Files Changed

| File | Type | What Changed |
|------|------|-------------|
| `server/src/modules/jobs/service.js` | Backend | Added `withdrawApplication()`, updated `getMyApplicationsWithDetails()` with pagination |
| `server/src/modules/jobs/controller.js` | Backend | Added `withdrawJobApplication` controller, updated `getMyApplicationsDetailed` for pagination params |
| `server/src/modules/jobs/routes.js` | Backend | Added `PATCH /:id/withdraw` route |
| `client/src/modules/student-jobs/services/jobService.js` | Frontend | Added `withdrawApplication()`, updated `getMyApplicationsDetailed()` with page/limit |
| `client/src/modules/student-jobs/pages/MyApplicationsPage.jsx` | Frontend | Added withdraw button + confirm dialog, pagination Previous/Next controls |

## Withdraw — Status Validation Matrix

| Current Status | Can Withdraw? | Behavior |
|:---:|:---:|---|
| `pending` | Yes | Status changes to `withdrawn` |
| `reviewed` | Yes | Status changes to `withdrawn` |
| `shortlisted` | No | Returns 400: "Cannot withdraw a shortlisted application" |
| `rejected` | No | Returns 400: "Cannot withdraw a rejected application" |
| `withdrawn` | No | Returns 400: "Application is already withdrawn" |

## Validation

- [x] Withdraw works on pending/reviewed applications
- [x] Withdraw blocked on shortlisted/rejected (backend validation)
- [x] Confirmation dialog shown before withdrawal
- [x] Status badge updates immediately after withdrawal (no reload)
- [x] Pagination controls appear when applications exceed page limit
- [x] Pagination hidden when all fit on one page
- [x] Build passes locally

## Screenshots

<!-- Paste your screenshots here -->
<img width="1901" height="837" alt="Screenshot from 2026-05-10 22-18-54" src="https://github.com/user-attachments/assets/c3e98aff-0461-4367-a0aa-7b09bb34bc46" /> 
<img width="1901" height="837" alt="Screenshot from 2026-05-10 22-11-50" src="https://github.com/user-attachments/assets/5a90ddf0-87af-4a7a-9f4c-3f560d3d7092" />