### PR TITLE
fix: implement global light mode support across all pages and shared components

### DIFF
--- a/client/src/app/App.jsx
+++ b/client/src/app/App.jsx
@@ -22,7 +22,6 @@ import JobBoardPage from "../modules/student-jobs/pages/JobBoardPage";
 import ClassroomsDashboard from "../modules/classrooms/pages/ClassroomsDashboard";
 import ClassroomRoom from "../modules/classrooms/pages/ClassroomRoom";
 import ProtectedRoute from "../shared/components/ProtectedRoute";
-import ThemeToggle from "../shared/components/ThemeToggle";
 function App() {
   const dispatch = useDispatch();
   const { token } = useSelector((state) => state.auth);
@@ -35,7 +34,7 @@ function App() {
 
   return (
     <div className="min-h-screen bg-white text-black dark:bg-dark-bg dark:text-text-main transition-colors duration-300">
-      
+
       <Routes>
         <Route path="/" element={<LandingPage />} />
         <Route 

--- a/client/src/app/index.css
+++ b/client/src/app/index.css
@@ -34,7 +34,7 @@
   --transition: all 0.3s ease;
 }
 
-:root.dark {
+.dark {
   --primary: #818CF8;
   --primary-hover: #6366F1;
   --secondary: #34D399;

--- a/client/src/modules/dashboard/DashboardPage.jsx
+++ b/client/src/modules/dashboard/DashboardPage.jsx
@@ -48,7 +48,7 @@ const ROLE_LABELS = {
 const CustomTooltip = ({ active, payload, label }) => {
   if (active && payload && payload.length) {
     return (
-      <div className="bg-slate-900 border border-white/10 p-3 rounded-lg shadow-xl backdrop-blur-md">
+      <div className="bg-slate-900 border border-gray-200 dark:border-white/10 p-3 rounded-lg shadow-xl backdrop-blur-md">
         <p className="text-xs text-slate-400 mb-1">{payload[0].payload.fullDate}</p>
         <p className="text-sm font-bold text-blue-400">Score: {payload[0].value}%</p>
       </div>
@@ -117,7 +117,7 @@ const SuggestionItem = ({ suggestion }) => {
         </div>
         <ChevronRight size={14} className="text-slate-600 group-hover:translate-x-0.5 transition-transform" />
       </div>
-      <p className="text-sm text-slate-300 leading-relaxed font-medium">
+      <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed font-medium">
         {text.split(' ').map((word, i) => {
           const cleanWord = word.toLowerCase().replace(/[^a-z]/g, '');
           const isHighlight = ['skills', 'projects', 'metrics', 'achievements', 'keywords', 'experience', 'ats', 'readability'].includes(cleanWord);
@@ -206,7 +206,7 @@ const DashboardPage = () => {
   }, [recruiterJobs, isRecruiter]);
 
   return (
-    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] p-3 sm:p-5 pt-20 sm:pt-28 text-slate-100">
+    <main className="min-h-screen bg-white dark:bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] p-3 sm:p-5 pt-20 sm:pt-28 text-gray-900 dark:text-slate-100">
       <Navbar />
 
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 sm:gap-8 py-6 sm:py-8 px-0 sm:px-2">
@@ -217,7 +217,7 @@ const DashboardPage = () => {
               <div className="h-2 w-2 rounded-full bg-blue-500 animate-pulse"></div>
               <p className="text-xs sm:text-sm font-medium text-blue-300 uppercase tracking-wider">Professional Intelligence</p>
             </div>
-            <h1 className="text-3xl sm:text-4xl font-extrabold bg-clip-text text-transparent bg-gradient-to-r from-white to-slate-400">
+            <h1 className="text-3xl sm:text-4xl font-extrabold bg-clip-text text-transparent bg-gradient-to-r from-gray-900 to-gray-500 dark:from-white dark:to-slate-400">
               Welcome, {user?.name || "Learner"}
             </h1>
           </div>
@@ -227,7 +227,7 @@ const DashboardPage = () => {
             size="md"
             onClick={handleLogout}
             leftIcon={<LogOut size={16} />}
-            className="border-slate-700/50 bg-slate-900/40 text-slate-300 hover:bg-slate-800 hover:text-white backdrop-blur-sm w-full sm:w-auto transition-all duration-300"
+            className="border-gray-300 dark:border-slate-700/50 bg-gray-100 dark:bg-slate-900/40 text-gray-700 dark:text-slate-300 hover:bg-gray-200 dark:hover:bg-slate-800 hover:text-gray-900 dark:hover:text-white backdrop-blur-sm w-full sm:w-auto transition-all duration-300"
           >
             Logout
           </Button>
@@ -235,36 +235,36 @@ const DashboardPage = () => {
 
         {/* User Stats Grid */}
         <section className="grid gap-4 sm:gap-6 md:grid-cols-3 grid-cols-1 sm:grid-cols-2">
-          <div className="group relative rounded-2xl border border-white/10 bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-blue-500/30">
+          <div className="group relative rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-blue-500/30">
             <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-blue-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity"></div>
             <div className="relative">
               <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/20 text-blue-400 group-hover:scale-110 transition-transform">
                 <User size={24} />
               </div>
-              <p className="text-xs font-semibold text-slate-500 uppercase tracking-widest">Profile Name</p>
-              <p className="mt-1 font-bold text-lg text-slate-100 break-words">{user?.name || "Not available"}</p>
+              <p className="text-xs font-semibold text-gray-500 dark:text-slate-500 uppercase tracking-widest">Profile Name</p>
+              <p className="mt-1 font-bold text-lg text-gray-900 dark:text-slate-100 break-words">{user?.name || "Not available"}</p>
             </div>
           </div>
 
-          <div className="group relative rounded-2xl border border-white/10 bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-emerald-500/30">
+          <div className="group relative rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-emerald-500/30">
              <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-emerald-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity"></div>
             <div className="relative">
               <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-500/20 text-emerald-400 group-hover:scale-110 transition-transform">
                 <Mail size={24} />
               </div>
-              <p className="text-xs font-semibold text-slate-500 uppercase tracking-widest">Email Address</p>
-              <p className="mt-1 font-bold text-lg text-slate-100 break-words">{user?.email || "Not available"}</p>
+              <p className="text-xs font-semibold text-gray-500 dark:text-slate-500 uppercase tracking-widest">Email Address</p>
+              <p className="mt-1 font-bold text-lg text-gray-900 dark:text-slate-100 break-words">{user?.email || "Not available"}</p>
             </div>
           </div>
 
-          <div className="group relative rounded-2xl border border-white/10 bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-violet-500/30 sm:col-span-2 md:col-span-1">
+          <div className="group relative rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-violet-500/30 sm:col-span-2 md:col-span-1">
              <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-violet-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity"></div>
             <div className="relative">
               <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-violet-500/20 text-violet-400 group-hover:scale-110 transition-transform">
                 <Shield size={24} />
               </div>
-              <p className="text-xs font-semibold text-slate-500 uppercase tracking-widest">Access Role</p>
-              <p className="mt-1 font-bold text-lg text-slate-100">
+              <p className="text-xs font-semibold text-gray-500 dark:text-slate-500 uppercase tracking-widest">Access Role</p>
+              <p className="mt-1 font-bold text-lg text-gray-900 dark:text-slate-100">
                 {ROLE_LABELS[user?.role] || user?.role || "Not available"}
               </p>
             </div>
@@ -274,7 +274,7 @@ const DashboardPage = () => {
         {/* Recruiter Specific Stats Grid */}
         {isRecruiter && (
           <section className="grid gap-4 sm:gap-6 md:grid-cols-3 grid-cols-1">
-            <div className="group relative rounded-2xl border border-white/10 bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-blue-500/30">
+            <div className="group relative rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-blue-500/30">
               <div className="relative">
                 <div className="mb-2 flex items-center justify-between">
                   <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/20 text-blue-400">
@@ -282,11 +282,11 @@ const DashboardPage = () => {
                   </div>
                   <span className="text-2xl font-black text-white">{jobStats?.total || 0}</span>
                 </div>
-                <p className="text-xs font-semibold text-slate-500 uppercase tracking-widest">Total Jobs Posted</p>
+                <p className="text-xs font-semibold text-gray-500 dark:text-slate-500 uppercase tracking-widest">Total Jobs Posted</p>
               </div>
             </div>
 
-            <div className="group relative rounded-2xl border border-white/10 bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-emerald-500/30">
+            <div className="group relative rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-emerald-500/30">
               <div className="relative">
                 <div className="mb-2 flex items-center justify-between">
                   <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-500/20 text-emerald-400">
@@ -294,11 +294,11 @@ const DashboardPage = () => {
                   </div>
                   <span className="text-2xl font-black text-white">{jobStats?.open || 0}</span>
                 </div>
-                <p className="text-xs font-semibold text-slate-500 uppercase tracking-widest">Active Postings</p>
+                <p className="text-xs font-semibold text-gray-500 dark:text-slate-500 uppercase tracking-widest">Active Postings</p>
               </div>
             </div>
 
-            <div className="group relative rounded-2xl border border-white/10 bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-amber-500/30">
+            <div className="group relative rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-amber-500/30">
               <div className="relative">
                 <div className="mb-2 flex items-center justify-between">
                   <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-amber-500/20 text-amber-400">
@@ -306,7 +306,7 @@ const DashboardPage = () => {
                   </div>
                   <span className="text-2xl font-black text-white">{(jobStats?.draft || 0) + (jobStats?.closed || 0)}</span>
                 </div>
-                <p className="text-xs font-semibold text-slate-500 uppercase tracking-widest">Drafts / Closed</p>
+                <p className="text-xs font-semibold text-gray-500 dark:text-slate-500 uppercase tracking-widest">Drafts / Closed</p>
               </div>
             </div>
           </section>
@@ -318,7 +318,7 @@ const DashboardPage = () => {
             
             {/* Score Trend Chart - Student Only */}
             {isStudent && (
-              <div className="rounded-2xl border border-white/10 bg-slate-900/50 overflow-hidden backdrop-blur-md">
+              <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 overflow-hidden backdrop-blur-md">
                 <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <BarChart3 className="text-blue-400" size={20} />
@@ -369,7 +369,7 @@ const DashboardPage = () => {
                       </AreaChart>
                     </ResponsiveContainer>
                   ) : (
-                    <div className="h-full flex flex-col items-center justify-center text-slate-500">
+                    <div className="h-full flex flex-col items-center justify-center text-gray-500 dark:text-slate-500">
                       <Activity size={40} className="opacity-20 mb-3" />
                       <p className="text-sm">Need at least 2 analyses to show trend</p>
                     </div>
@@ -380,7 +380,7 @@ const DashboardPage = () => {
 
             {/* Recruiter Jobs List Preview */}
             {isRecruiter && (
-              <div className="rounded-2xl border border-white/10 bg-slate-900/50 overflow-hidden backdrop-blur-md">
+              <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 overflow-hidden backdrop-blur-md">
                 <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <LayoutDashboard className="text-blue-400" size={20} />
@@ -392,7 +392,7 @@ const DashboardPage = () => {
                 <div className="p-6">
                   {recruiterJobs.length === 0 ? (
                     <div className="py-12 flex flex-col items-center justify-center text-center">
-                      <div className="h-16 w-16 bg-slate-800 rounded-full flex items-center justify-center mb-4 text-slate-500">
+                      <div className="h-16 w-16 bg-slate-800 rounded-full flex items-center justify-center mb-4 text-gray-500 dark:text-slate-500">
                         <Briefcase size={32} />
                       </div>
                       <h3 className="text-xl font-semibold mb-2">No jobs posted yet</h3>
@@ -416,8 +416,8 @@ const DashboardPage = () => {
                               <Target size={20} />
                             </div>
                             <div>
-                              <h4 className="font-bold text-slate-100">{job.title || job.designation}</h4>
-                              <p className="text-xs text-slate-500">
+                              <h4 className="font-bold text-gray-900 dark:text-slate-100">{job.title || job.designation}</h4>
+                              <p className="text-xs text-gray-500 dark:text-slate-500">
                                 {typeof job.location === "object" 
                                   ? `${job.location.city || ""}${job.location.city && job.location.state ? ", " : ""}${job.location.state || ""} ${job.location.remote ? "(Remote)" : ""}`.trim() || "Remote"
                                   : job.location || "Remote"} • {new Date(job.createdAt).toLocaleDateString()}
@@ -427,7 +427,7 @@ const DashboardPage = () => {
                           <span className={`px-2 py-0.5 rounded text-[10px] font-bold uppercase ${
                             job.status === 'open' || job.status === 'active' 
                               ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20' 
-                              : 'bg-slate-700 text-slate-300'
+                              : 'bg-slate-700 text-gray-700 dark:text-slate-300'
                           }`}>
                             {job.status || 'Active'}
                           </span>
@@ -440,7 +440,7 @@ const DashboardPage = () => {
             )}
 
             {isStudent && (
-              <div className="rounded-2xl border border-white/10 bg-slate-900/50 overflow-hidden backdrop-blur-md">
+              <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 overflow-hidden backdrop-blur-md">
                 <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <Activity className="text-emerald-400" size={20} />
@@ -457,7 +457,7 @@ const DashboardPage = () => {
                 <div className="p-6">
                   {!latestAnalysis ? (
                     <div className="py-12 flex flex-col items-center justify-center text-center">
-                      <div className="h-16 w-16 bg-slate-800 rounded-full flex items-center justify-center mb-4 text-slate-500">
+                      <div className="h-16 w-16 bg-slate-800 rounded-full flex items-center justify-center mb-4 text-gray-500 dark:text-slate-500">
                         <FileText size={32} />
                       </div>
                       <h3 className="text-xl font-semibold mb-2">No analysis data yet</h3>
@@ -497,13 +497,13 @@ const DashboardPage = () => {
                             <span className="absolute text-xl font-black">{latestAnalysis.score}%</span>
                           </div>
                           <div>
-                            <p className="text-xs font-bold text-slate-500 uppercase tracking-wider">Overall Score</p>
+                            <p className="text-xs font-bold text-gray-500 dark:text-slate-500 uppercase tracking-wider">Overall Score</p>
                             <p className="text-2xl font-black text-white">{latestAnalysis.classification}</p>
                           </div>
                         </div>
 
                         <div className="flex flex-col justify-center p-4 rounded-xl bg-slate-800/50 border border-white/5">
-                          <p className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2">Target Skills Match</p>
+                          <p className="text-xs font-bold text-gray-500 dark:text-slate-500 uppercase tracking-wider mb-2">Target Skills Match</p>
                           <div className="flex flex-wrap gap-2">
                             {latestAnalysis.skills.slice(0, 5).map((skill, idx) => (
                               <span key={idx} className="px-2 py-1 rounded-md bg-blue-500/10 text-blue-400 text-[10px] font-bold border border-blue-500/20 uppercase tracking-tight">
@@ -511,7 +511,7 @@ const DashboardPage = () => {
                               </span>
                             ))}
                             {latestAnalysis.skills.length > 5 && (
-                              <span className="text-[10px] text-slate-500 self-center font-bold">+{latestAnalysis.skills.length - 5} MORE</span>
+                              <span className="text-[10px] text-gray-500 dark:text-slate-500 self-center font-bold">+{latestAnalysis.skills.length - 5} MORE</span>
                             )}
                           </div>
                         </div>
@@ -543,19 +543,19 @@ const DashboardPage = () => {
 
             {/* History Table - Student Only */}
             {isStudent && (
-              <div className="rounded-2xl border border-white/10 bg-slate-900/50 overflow-hidden backdrop-blur-md">
+              <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 overflow-hidden backdrop-blur-md">
                 <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <Clock className="text-violet-400" size={20} />
                     <h2 className="text-lg font-bold">Analysis History</h2>
                   </div>
-                  <span className="text-xs font-medium text-slate-500">{history.length} records found</span>
+                  <span className="text-xs font-medium text-gray-500 dark:text-slate-500">{history.length} records found</span>
                 </div>
                 
                 <div className="overflow-x-auto">
                   <table className="w-full text-left border-collapse">
                     <thead>
-                      <tr className="bg-slate-800/30 text-[10px] uppercase tracking-widest text-slate-500">
+                      <tr className="bg-slate-800/30 text-[10px] uppercase tracking-widest text-gray-500 dark:text-slate-500">
                         <th className="px-6 py-4 font-bold">Date</th>
                         <th className="px-6 py-4 font-bold">Score</th>
                         <th className="px-6 py-4 font-bold">Level</th>
@@ -566,7 +566,7 @@ const DashboardPage = () => {
                       {history.length > 0 ? (
                         history.map((item, idx) => (
                           <tr key={idx} className="hover:bg-white/5 transition-colors group">
-                            <td className="px-6 py-4 text-sm whitespace-nowrap text-slate-300">
+                            <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-700 dark:text-slate-300">
                               {new Date(item.createdAt).toLocaleDateString()}
                             </td>
                             <td className="px-6 py-4 text-sm font-bold whitespace-nowrap">
@@ -595,7 +595,7 @@ const DashboardPage = () => {
                         ))
                       ) : (
                         <tr>
-                          <td colSpan="4" className="px-6 py-12 text-center text-slate-500 text-sm">
+                          <td colSpan="4" className="px-6 py-12 text-center text-gray-500 dark:text-slate-500 text-sm">
                             No history found
                           </td>
                         </tr>
@@ -610,7 +610,7 @@ const DashboardPage = () => {
           <div className="space-y-6">
             {/* Smart Suggestions Card - Student Only */}
             {isStudent && (
-              <div className="rounded-2xl border border-white/10 bg-slate-900/50 overflow-hidden backdrop-blur-md">
+              <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 overflow-hidden backdrop-blur-md">
                 <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center gap-2">
                   <Target className="text-emerald-400" size={20} />
                   <h2 className="text-lg font-bold">Smart Insights</h2>
@@ -621,7 +621,7 @@ const DashboardPage = () => {
                       <SuggestionItem key={idx} suggestion={suggestion} />
                     ))
                   ) : (
-                    <div className="p-8 text-center text-slate-500">
+                    <div className="p-8 text-center text-gray-500 dark:text-slate-500">
                       <Zap size={24} className="mx-auto mb-2 opacity-20" />
                       <p className="text-xs uppercase tracking-widest">No insights generated yet</p>
                     </div>
@@ -631,13 +631,13 @@ const DashboardPage = () => {
             )}
 
             {/* Quick Actions Card */}
-            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-blue-600/20 to-blue-900/40 p-6 shadow-xl backdrop-blur-md relative overflow-hidden group">
+            <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gradient-to-br from-blue-600/20 to-blue-900/40 p-6 shadow-xl backdrop-blur-md relative overflow-hidden group">
               <div className="absolute top-0 right-0 -mt-4 -mr-4 h-24 w-24 bg-blue-500/20 rounded-full blur-3xl group-hover:bg-blue-500/40 transition-all"></div>
               <h3 className="text-xl font-bold mb-2 flex items-center gap-2">
                 <TrendingUp size={20} className="text-blue-400" />
                 {isStudent ? "Improve Profile" : "Recruitment Hub"}
               </h3>
-              <p className="text-sm text-blue-100/70 mb-6">
+              <p className="text-sm text-gray-700 dark:text-blue-100/70 mb-6">
                 {isStudent 
                   ? "Take the next step in your career journey with our AI-driven tools."
                   : "Manage your hiring pipeline and find the perfect candidates."}
@@ -648,7 +648,7 @@ const DashboardPage = () => {
                   <>
                     <Link
                       to="/resume-analyzer"
-                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-white/10 hover:bg-white/20 transition-all"
+                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-gray-200 dark:border-white/10 hover:bg-white/20 transition-all"
                     >
                       <div className="flex items-center gap-3">
                         <FileText size={18} className="text-blue-300" />
@@ -659,7 +659,7 @@ const DashboardPage = () => {
                     
                     <Link
                       to="/job-matcher"
-                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-white/10 hover:bg-white/20 transition-all"
+                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-gray-200 dark:border-white/10 hover:bg-white/20 transition-all"
                     >
                       <div className="flex items-center gap-3">
                         <Target size={18} className="text-emerald-300" />
@@ -670,7 +670,7 @@ const DashboardPage = () => {
 
                     <Link
                       to="/my-applications"
-                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-white/10 hover:bg-white/20 transition-all"
+                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-gray-200 dark:border-white/10 hover:bg-white/20 transition-all"
                     >
                       <div className="flex items-center gap-3">
                         <Briefcase size={18} className="text-violet-300" />
@@ -683,7 +683,7 @@ const DashboardPage = () => {
                   <>
                     <Link
                       to="/recruiter/jobs/new"
-                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-white/10 hover:bg-white/20 transition-all"
+                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-gray-200 dark:border-white/10 hover:bg-white/20 transition-all"
                     >
                       <div className="flex items-center gap-3">
                         <PlusCircle size={18} className="text-blue-300" />
@@ -694,7 +694,7 @@ const DashboardPage = () => {
                     
                     <Link
                       to="/recruiter/jobs"
-                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-white/10 hover:bg-white/20 transition-all"
+                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-gray-200 dark:border-white/10 hover:bg-white/20 transition-all"
                     >
                       <div className="flex items-center gap-3">
                         <Briefcase size={18} className="text-emerald-300" />
@@ -705,7 +705,7 @@ const DashboardPage = () => {
 
                     <Link
                       to="/recruiter/analytics"
-                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-white/10 hover:bg-white/20 transition-all"
+                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-gray-200 dark:border-white/10 hover:bg-white/20 transition-all"
                     >
                       <div className="flex items-center gap-3">
                         <BarChart3 size={18} className="text-violet-300" />
@@ -719,8 +719,8 @@ const DashboardPage = () => {
             </div>
 
             {/* Account Status */}
-            <div className="rounded-2xl border border-white/10 bg-slate-900/50 p-6 backdrop-blur-md">
-              <h3 className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-4">Account Status</h3>
+            <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 p-6 backdrop-blur-md">
+              <h3 className="text-[10px] font-bold text-gray-500 dark:text-slate-500 uppercase tracking-widest mb-4">Account Status</h3>
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
                    <div className="flex items-center gap-3">

--- a/client/src/modules/dashboard/DashboardPage.jsx
+++ b/client/src/modules/dashboard/DashboardPage.jsx
@@ -48,7 +48,7 @@ const ROLE_LABELS = {
 const CustomTooltip = ({ active, payload, label }) => {
   if (active && payload && payload.length) {
     return (
-      <div className="bg-slate-900 border border-white/10 p-3 rounded-lg shadow-xl backdrop-blur-md">
+      <div className="bg-slate-900 border border-gray-200 dark:border-white/10 p-3 rounded-lg shadow-xl backdrop-blur-md">
         <p className="text-xs text-slate-400 mb-1">{payload[0].payload.fullDate}</p>
         <p className="text-sm font-bold text-blue-400">Score: {payload[0].value}%</p>
       </div>
@@ -117,7 +117,7 @@ const SuggestionItem = ({ suggestion }) => {
         </div>
         <ChevronRight size={14} className="text-slate-600 group-hover:translate-x-0.5 transition-transform" />
       </div>
-      <p className="text-sm text-slate-300 leading-relaxed font-medium">
+      <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed font-medium">
         {text.split(' ').map((word, i) => {
           const cleanWord = word.toLowerCase().replace(/[^a-z]/g, '');
           const isHighlight = ['skills', 'projects', 'metrics', 'achievements', 'keywords', 'experience', 'ats', 'readability'].includes(cleanWord);
@@ -206,7 +206,7 @@ const DashboardPage = () => {
   }, [recruiterJobs, isRecruiter]);
 
   return (
-    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] p-3 sm:p-5 pt-20 sm:pt-28 text-slate-100">
+      <main className="min-h-screen bg-white dark:bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] p-3 sm:p-5 pt-20 sm:pt-28 text-gray-900 dark:text-slate-100">
       <Navbar />
 
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 sm:gap-8 py-6 sm:py-8 px-0 sm:px-2">
@@ -227,7 +227,7 @@ const DashboardPage = () => {
             size="md"
             onClick={handleLogout}
             leftIcon={<LogOut size={16} />}
-            className="border-slate-700/50 bg-slate-900/40 text-slate-300 hover:bg-slate-800 hover:text-white backdrop-blur-sm w-full sm:w-auto transition-all duration-300"
+            className="border-slate-700/50 bg-slate-900/40 text-gray-700 dark:text-slate-300 hover:bg-slate-800 hover:text-white backdrop-blur-sm w-full sm:w-auto transition-all duration-300"
           >
             Logout
           </Button>
@@ -235,36 +235,36 @@ const DashboardPage = () => {
 
         {/* User Stats Grid */}
         <section className="grid gap-4 sm:gap-6 md:grid-cols-3 grid-cols-1 sm:grid-cols-2">
-          <div className="group relative rounded-2xl border border-white/10 bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-blue-500/30">
+          <div className="group relative rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-blue-500/30">
             <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-blue-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity"></div>
             <div className="relative">
               <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/20 text-blue-400 group-hover:scale-110 transition-transform">
                 <User size={24} />
               </div>
-              <p className="text-xs font-semibold text-slate-500 uppercase tracking-widest">Profile Name</p>
-              <p className="mt-1 font-bold text-lg text-slate-100 break-words">{user?.name || "Not available"}</p>
+              <p className="text-xs font-semibold text-gray-500 dark:text-slate-500 uppercase tracking-widest">Profile Name</p>
+              <p className="mt-1 font-bold text-lg text-gray-900 dark:text-slate-100 break-words">{user?.name || "Not available"}</p>
             </div>
           </div>
 
-          <div className="group relative rounded-2xl border border-white/10 bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-emerald-500/30">
+          <div className="group relative rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-emerald-500/30">
              <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-emerald-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity"></div>
             <div className="relative">
               <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-500/20 text-emerald-400 group-hover:scale-110 transition-transform">
                 <Mail size={24} />
               </div>
-              <p className="text-xs font-semibold text-slate-500 uppercase tracking-widest">Email Address</p>
-              <p className="mt-1 font-bold text-lg text-slate-100 break-words">{user?.email || "Not available"}</p>
+              <p className="text-xs font-semibold text-gray-500 dark:text-slate-500 uppercase tracking-widest">Email Address</p>
+              <p className="mt-1 font-bold text-lg text-gray-900 dark:text-slate-100 break-words">{user?.email || "Not available"}</p>
             </div>
           </div>
 
-          <div className="group relative rounded-2xl border border-white/10 bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-violet-500/30 sm:col-span-2 md:col-span-1">
+          <div className="group relative rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-violet-500/30 sm:col-span-2 md:col-span-1">
              <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-violet-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity"></div>
             <div className="relative">
               <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-violet-500/20 text-violet-400 group-hover:scale-110 transition-transform">
                 <Shield size={24} />
               </div>
-              <p className="text-xs font-semibold text-slate-500 uppercase tracking-widest">Access Role</p>
-              <p className="mt-1 font-bold text-lg text-slate-100">
+              <p className="text-xs font-semibold text-gray-500 dark:text-slate-500 uppercase tracking-widest">Access Role</p>
+              <p className="mt-1 font-bold text-lg text-gray-900 dark:text-slate-100">
                 {ROLE_LABELS[user?.role] || user?.role || "Not available"}
               </p>
             </div>
@@ -274,7 +274,7 @@ const DashboardPage = () => {
         {/* Recruiter Specific Stats Grid */}
         {isRecruiter && (
           <section className="grid gap-4 sm:gap-6 md:grid-cols-3 grid-cols-1">
-            <div className="group relative rounded-2xl border border-white/10 bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-blue-500/30">
+            <div className="group relative rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-blue-500/30">
               <div className="relative">
                 <div className="mb-2 flex items-center justify-between">
                   <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/20 text-blue-400">
@@ -282,11 +282,11 @@ const DashboardPage = () => {
                   </div>
                   <span className="text-2xl font-black text-white">{jobStats?.total || 0}</span>
                 </div>
-                <p className="text-xs font-semibold text-slate-500 uppercase tracking-widest">Total Jobs Posted</p>
+                <p className="text-xs font-semibold text-gray-500 dark:text-slate-500 uppercase tracking-widest">Total Jobs Posted</p>
               </div>
             </div>
 
-            <div className="group relative rounded-2xl border border-white/10 bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-emerald-500/30">
+            <div className="group relative rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-emerald-500/30">
               <div className="relative">
                 <div className="mb-2 flex items-center justify-between">
                   <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-500/20 text-emerald-400">
@@ -294,11 +294,11 @@ const DashboardPage = () => {
                   </div>
                   <span className="text-2xl font-black text-white">{jobStats?.open || 0}</span>
                 </div>
-                <p className="text-xs font-semibold text-slate-500 uppercase tracking-widest">Active Postings</p>
+                <p className="text-xs font-semibold text-gray-500 dark:text-slate-500 uppercase tracking-widest">Active Postings</p>
               </div>
             </div>
 
-            <div className="group relative rounded-2xl border border-white/10 bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-amber-500/30">
+            <div className="group relative rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 p-5 shadow-2xl backdrop-blur-md transition-all hover:border-amber-500/30">
               <div className="relative">
                 <div className="mb-2 flex items-center justify-between">
                   <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-amber-500/20 text-amber-400">
@@ -306,7 +306,7 @@ const DashboardPage = () => {
                   </div>
                   <span className="text-2xl font-black text-white">{(jobStats?.draft || 0) + (jobStats?.closed || 0)}</span>
                 </div>
-                <p className="text-xs font-semibold text-slate-500 uppercase tracking-widest">Drafts / Closed</p>
+                <p className="text-xs font-semibold text-gray-500 dark:text-slate-500 uppercase tracking-widest">Drafts / Closed</p>
               </div>
             </div>
           </section>
@@ -318,7 +318,7 @@ const DashboardPage = () => {
             
             {/* Score Trend Chart - Student Only */}
             {isStudent && (
-              <div className="rounded-2xl border border-white/10 bg-slate-900/50 overflow-hidden backdrop-blur-md">
+              <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 overflow-hidden backdrop-blur-md">
                 <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <BarChart3 className="text-blue-400" size={20} />
@@ -369,7 +369,7 @@ const DashboardPage = () => {
                       </AreaChart>
                     </ResponsiveContainer>
                   ) : (
-                    <div className="h-full flex flex-col items-center justify-center text-slate-500">
+                    <div className="h-full flex flex-col items-center justify-center text-gray-500 dark:text-slate-500">
                       <Activity size={40} className="opacity-20 mb-3" />
                       <p className="text-sm">Need at least 2 analyses to show trend</p>
                     </div>
@@ -380,7 +380,7 @@ const DashboardPage = () => {
 
             {/* Recruiter Jobs List Preview */}
             {isRecruiter && (
-              <div className="rounded-2xl border border-white/10 bg-slate-900/50 overflow-hidden backdrop-blur-md">
+              <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 overflow-hidden backdrop-blur-md">
                 <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <LayoutDashboard className="text-blue-400" size={20} />
@@ -392,7 +392,7 @@ const DashboardPage = () => {
                 <div className="p-6">
                   {recruiterJobs.length === 0 ? (
                     <div className="py-12 flex flex-col items-center justify-center text-center">
-                      <div className="h-16 w-16 bg-slate-800 rounded-full flex items-center justify-center mb-4 text-slate-500">
+                      <div className="h-16 w-16 bg-slate-800 rounded-full flex items-center justify-center mb-4 text-gray-500 dark:text-slate-500">
                         <Briefcase size={32} />
                       </div>
                       <h3 className="text-xl font-semibold mb-2">No jobs posted yet</h3>
@@ -416,8 +416,8 @@ const DashboardPage = () => {
                               <Target size={20} />
                             </div>
                             <div>
-                              <h4 className="font-bold text-slate-100">{job.title || job.designation}</h4>
-                              <p className="text-xs text-slate-500">
+                              <h4 className="font-bold text-gray-900 dark:text-slate-100">{job.title || job.designation}</h4>
+                              <p className="text-xs text-gray-500 dark:text-slate-500">
                                 {typeof job.location === "object" 
                                   ? `${job.location.city || ""}${job.location.city && job.location.state ? ", " : ""}${job.location.state || ""} ${job.location.remote ? "(Remote)" : ""}`.trim() || "Remote"
                                   : job.location || "Remote"} • {new Date(job.createdAt).toLocaleDateString()}
@@ -427,7 +427,7 @@ const DashboardPage = () => {
                           <span className={`px-2 py-0.5 rounded text-[10px] font-bold uppercase ${
                             job.status === 'open' || job.status === 'active' 
                               ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20' 
-                              : 'bg-slate-700 text-slate-300'
+                              : 'bg-slate-700 text-gray-700 dark:text-slate-300'
                           }`}>
                             {job.status || 'Active'}
                           </span>
@@ -440,7 +440,7 @@ const DashboardPage = () => {
             )}
 
             {isStudent && (
-              <div className="rounded-2xl border border-white/10 bg-slate-900/50 overflow-hidden backdrop-blur-md">
+              <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 overflow-hidden backdrop-blur-md">
                 <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <Activity className="text-emerald-400" size={20} />
@@ -457,7 +457,7 @@ const DashboardPage = () => {
                 <div className="p-6">
                   {!latestAnalysis ? (
                     <div className="py-12 flex flex-col items-center justify-center text-center">
-                      <div className="h-16 w-16 bg-slate-800 rounded-full flex items-center justify-center mb-4 text-slate-500">
+                      <div className="h-16 w-16 bg-slate-800 rounded-full flex items-center justify-center mb-4 text-gray-500 dark:text-slate-500">
                         <FileText size={32} />
                       </div>
                       <h3 className="text-xl font-semibold mb-2">No analysis data yet</h3>
@@ -497,13 +497,13 @@ const DashboardPage = () => {
                             <span className="absolute text-xl font-black">{latestAnalysis.score}%</span>
                           </div>
                           <div>
-                            <p className="text-xs font-bold text-slate-500 uppercase tracking-wider">Overall Score</p>
+                            <p className="text-xs font-bold text-gray-500 dark:text-slate-500 uppercase tracking-wider">Overall Score</p>
                             <p className="text-2xl font-black text-white">{latestAnalysis.classification}</p>
                           </div>
                         </div>
 
                         <div className="flex flex-col justify-center p-4 rounded-xl bg-slate-800/50 border border-white/5">
-                          <p className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2">Target Skills Match</p>
+                          <p className="text-xs font-bold text-gray-500 dark:text-slate-500 uppercase tracking-wider mb-2">Target Skills Match</p>
                           <div className="flex flex-wrap gap-2">
                             {latestAnalysis.skills.slice(0, 5).map((skill, idx) => (
                               <span key={idx} className="px-2 py-1 rounded-md bg-blue-500/10 text-blue-400 text-[10px] font-bold border border-blue-500/20 uppercase tracking-tight">
@@ -511,7 +511,7 @@ const DashboardPage = () => {
                               </span>
                             ))}
                             {latestAnalysis.skills.length > 5 && (
-                              <span className="text-[10px] text-slate-500 self-center font-bold">+{latestAnalysis.skills.length - 5} MORE</span>
+                              <span className="text-[10px] text-gray-500 dark:text-slate-500 self-center font-bold">+{latestAnalysis.skills.length - 5} MORE</span>
                             )}
                           </div>
                         </div>
@@ -543,19 +543,19 @@ const DashboardPage = () => {
 
             {/* History Table - Student Only */}
             {isStudent && (
-              <div className="rounded-2xl border border-white/10 bg-slate-900/50 overflow-hidden backdrop-blur-md">
+              <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 overflow-hidden backdrop-blur-md">
                 <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <Clock className="text-violet-400" size={20} />
                     <h2 className="text-lg font-bold">Analysis History</h2>
                   </div>
-                  <span className="text-xs font-medium text-slate-500">{history.length} records found</span>
+                  <span className="text-xs font-medium text-gray-500 dark:text-slate-500">{history.length} records found</span>
                 </div>
                 
                 <div className="overflow-x-auto">
                   <table className="w-full text-left border-collapse">
                     <thead>
-                      <tr className="bg-slate-800/30 text-[10px] uppercase tracking-widest text-slate-500">
+                      <tr className="bg-slate-800/30 text-[10px] uppercase tracking-widest text-gray-500 dark:text-slate-500">
                         <th className="px-6 py-4 font-bold">Date</th>
                         <th className="px-6 py-4 font-bold">Score</th>
                         <th className="px-6 py-4 font-bold">Level</th>
@@ -566,7 +566,7 @@ const DashboardPage = () => {
                       {history.length > 0 ? (
                         history.map((item, idx) => (
                           <tr key={idx} className="hover:bg-white/5 transition-colors group">
-                            <td className="px-6 py-4 text-sm whitespace-nowrap text-slate-300">
+                            <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-700 dark:text-slate-300">
                               {new Date(item.createdAt).toLocaleDateString()}
                             </td>
                             <td className="px-6 py-4 text-sm font-bold whitespace-nowrap">
@@ -595,7 +595,7 @@ const DashboardPage = () => {
                         ))
                       ) : (
                         <tr>
-                          <td colSpan="4" className="px-6 py-12 text-center text-slate-500 text-sm">
+                          <td colSpan="4" className="px-6 py-12 text-center text-gray-500 dark:text-slate-500 text-sm">
                             No history found
                           </td>
                         </tr>
@@ -610,7 +610,7 @@ const DashboardPage = () => {
           <div className="space-y-6">
             {/* Smart Suggestions Card - Student Only */}
             {isStudent && (
-              <div className="rounded-2xl border border-white/10 bg-slate-900/50 overflow-hidden backdrop-blur-md">
+              <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 overflow-hidden backdrop-blur-md">
                 <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center gap-2">
                   <Target className="text-emerald-400" size={20} />
                   <h2 className="text-lg font-bold">Smart Insights</h2>
@@ -621,7 +621,7 @@ const DashboardPage = () => {
                       <SuggestionItem key={idx} suggestion={suggestion} />
                     ))
                   ) : (
-                    <div className="p-8 text-center text-slate-500">
+                    <div className="p-8 text-center text-gray-500 dark:text-slate-500">
                       <Zap size={24} className="mx-auto mb-2 opacity-20" />
                       <p className="text-xs uppercase tracking-widest">No insights generated yet</p>
                     </div>
@@ -631,7 +631,7 @@ const DashboardPage = () => {
             )}
 
             {/* Quick Actions Card */}
-            <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-blue-600/20 to-blue-900/40 p-6 shadow-xl backdrop-blur-md relative overflow-hidden group">
+            <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gradient-to-br from-blue-600/20 to-blue-900/40 p-6 shadow-xl backdrop-blur-md relative overflow-hidden group">
               <div className="absolute top-0 right-0 -mt-4 -mr-4 h-24 w-24 bg-blue-500/20 rounded-full blur-3xl group-hover:bg-blue-500/40 transition-all"></div>
               <h3 className="text-xl font-bold mb-2 flex items-center gap-2">
                 <TrendingUp size={20} className="text-blue-400" />
@@ -648,7 +648,7 @@ const DashboardPage = () => {
                   <>
                     <Link
                       to="/resume-analyzer"
-                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-white/10 hover:bg-white/20 transition-all"
+                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-gray-200 dark:border-white/10 hover:bg-white/20 transition-all"
                     >
                       <div className="flex items-center gap-3">
                         <FileText size={18} className="text-blue-300" />
@@ -659,7 +659,7 @@ const DashboardPage = () => {
                     
                     <Link
                       to="/job-matcher"
-                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-white/10 hover:bg-white/20 transition-all"
+                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-gray-200 dark:border-white/10 hover:bg-white/20 transition-all"
                     >
                       <div className="flex items-center gap-3">
                         <Target size={18} className="text-emerald-300" />
@@ -672,7 +672,7 @@ const DashboardPage = () => {
                   <>
                     <Link
                       to="/recruiter/jobs/new"
-                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-white/10 hover:bg-white/20 transition-all"
+                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-gray-200 dark:border-white/10 hover:bg-white/20 transition-all"
                     >
                       <div className="flex items-center gap-3">
                         <PlusCircle size={18} className="text-blue-300" />
@@ -683,7 +683,7 @@ const DashboardPage = () => {
                     
                     <Link
                       to="/recruiter/jobs"
-                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-white/10 hover:bg-white/20 transition-all"
+                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-gray-200 dark:border-white/10 hover:bg-white/20 transition-all"
                     >
                       <div className="flex items-center gap-3">
                         <Briefcase size={18} className="text-emerald-300" />
@@ -694,7 +694,7 @@ const DashboardPage = () => {
 
                     <Link
                       to="/recruiter/analytics"
-                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-white/10 hover:bg-white/20 transition-all"
+                      className="flex items-center justify-between group/link w-full p-4 rounded-xl bg-white/10 border border-gray-200 dark:border-white/10 hover:bg-white/20 transition-all"
                     >
                       <div className="flex items-center gap-3">
                         <BarChart3 size={18} className="text-violet-300" />
@@ -708,8 +708,8 @@ const DashboardPage = () => {
             </div>
 
             {/* Account Status */}
-            <div className="rounded-2xl border border-white/10 bg-slate-900/50 p-6 backdrop-blur-md">
-              <h3 className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-4">Account Status</h3>
+            <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 p-6 backdrop-blur-md">
+              <h3 className="text-[10px] font-bold text-gray-500 dark:text-slate-500 uppercase tracking-widest mb-4">Account Status</h3>
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
                    <div className="flex items-center gap-3">

--- a/client/src/modules/job-matcher/pages/JobMatcherPage.jsx
+++ b/client/src/modules/job-matcher/pages/JobMatcherPage.jsx
@@ -73,7 +73,7 @@ export default function JobMatcherPage() {
   };
 
   return (
-    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] text-slate-100 flex flex-col">
+    <main className="min-h-screen bg-white dark:bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] text-gray-900 dark:text-slate-100 flex flex-col">
       <Navbar />
 
       {/* Spacer for fixed navbar */}
@@ -85,7 +85,7 @@ export default function JobMatcherPage() {
           <h1 className="text-5xl md:text-6xl font-black mb-6 tracking-tight leading-tight">
             <span className="text-gradient">Smart Job</span> Matching
           </h1>
-          <p className="text-slate-400 text-xl leading-relaxed font-medium">
+          <p className="text-gray-500 dark:text-slate-400 text-xl leading-relaxed font-medium">
             AI-powered job recommendations based on your resume skills 🚀
           </p>
         </div>
@@ -96,7 +96,7 @@ export default function JobMatcherPage() {
             <LoadingState message="Analyzing your profile for the best matches..." />
           </div>
         ) : error ? (
-          <div className="max-w-lg mx-auto text-center p-10 bg-slate-900/50 rounded-2xl border border-red-500/20">
+          <div className="max-w-lg mx-auto text-center p-10 bg-gray-100 dark:bg-slate-900/50 rounded-2xl border border-red-500/20">
             <AlertCircle size={48} className="text-red-400 mx-auto mb-4" />
             <p className="text-red-300 font-medium mb-6">{error}</p>
             <button
@@ -108,11 +108,11 @@ export default function JobMatcherPage() {
           </div>
         ) : !hasResume ? (
           /* No Resume — Upload Prompt */
-          <div className="max-w-lg mx-auto text-center p-12 bg-slate-900/50 rounded-2xl border border-white/5">
+          <div className="max-w-lg mx-auto text-center p-12 bg-gray-100 dark:bg-slate-900/50 rounded-2xl border border-white/5">
             <div className="inline-flex p-4 bg-blue-500/10 rounded-2xl mb-6">
               <FileUp size={48} className="text-blue-400" />
             </div>
-            <h2 className="text-2xl font-bold text-white mb-3">Upload Your Resume First</h2>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-3">Upload Your Resume First</h2>
             <p className="text-slate-400 mb-8 leading-relaxed">
               {message || "To get personalized job recommendations, please upload and analyze your resume first."}
             </p>
@@ -125,7 +125,7 @@ export default function JobMatcherPage() {
           </div>
         ) : jobs.length === 0 ? (
           /* Resume exists but no matching jobs */
-          <div className="max-w-lg mx-auto text-center p-12 bg-slate-900/50 rounded-2xl border border-white/5">
+          <div className="max-w-lg mx-auto text-center p-12 bg-gray-100 dark:bg-slate-900/50 rounded-2xl border border-white/5">
             <div className="inline-flex p-4 bg-slate-700/30 rounded-2xl mb-6">
               <Briefcase size={48} className="text-slate-500" />
             </div>

--- a/client/src/modules/resume-analyzer/components/DragDropUpload.jsx
+++ b/client/src/modules/resume-analyzer/components/DragDropUpload.jsx
@@ -100,7 +100,7 @@ const DragDropUpload = ({ onFileUpload }) => {
       className={`relative w-full p-12 border-2 border-dashed rounded-[1.5rem] transition-all duration-500 ease-out flex flex-col items-center justify-center space-y-6 focus:outline-none focus:ring-2 focus:ring-primary/40 outline-none ${
         isDragActive
           ? "border-primary bg-primary/5 scale-[1.02] shadow-[0_0_40px_rgba(79,70,229,0.15)]"
-          : "border-border bg-surface/30 hover:bg-surface/50 hover:border-primary/40"
+          : "border-gray-200 dark:border-border bg-gray-50 dark:bg-surface/30 hover:bg-gray-100 dark:hover:bg-surface/50 hover:border-primary/40"
       }`}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}

--- a/client/src/modules/resume-analyzer/components/JobDescriptionInput.jsx
+++ b/client/src/modules/resume-analyzer/components/JobDescriptionInput.jsx
@@ -129,7 +129,7 @@ const JobDescriptionInput = ({ value, onChange }) => {
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
         <div className="flex items-center gap-2 text-primary">
           <ClipboardList className="w-5 h-5" />
-          <h3 className="text-lg font-bold text-text-main">
+          <h3 className="text-lg font-bold text-gray-900 dark:text-text-main">
             Job Description
             <span className="ml-2 text-xs font-normal text-text-muted">(Optional)</span>
           </h3>
@@ -141,7 +141,7 @@ const JobDescriptionInput = ({ value, onChange }) => {
           <button
             type="button"
             onClick={handlePasteFromClipboard}
-            className="flex items-center gap-1.5 text-xs font-medium text-text-muted hover:text-primary transition-colors py-1.5 px-3 border border-border rounded-full bg-surface/50 hover:border-primary/40"
+            className="flex items-center gap-1.5 text-xs font-medium text-text-muted hover:text-primary transition-colors py-1.5 px-3 border border-border rounded-full bg-gray-100 dark:bg-surface/50 hover:border-primary/40"
           >
             <ClipboardPaste className="w-3.5 h-3.5" />
             Paste
@@ -156,7 +156,7 @@ const JobDescriptionInput = ({ value, onChange }) => {
               accept=".txt,.text"
               onChange={handleFileChange}
             />
-            <div className="flex items-center gap-1.5 text-xs font-medium text-text-muted hover:text-primary transition-colors py-1.5 px-3 border border-border rounded-full bg-surface/50 hover:border-primary/40 cursor-pointer">
+            <div className="flex items-center gap-1.5 text-xs font-medium text-text-muted hover:text-primary transition-colors py-1.5 px-3 border border-border rounded-full bg-gray-100 dark:bg-surface/50 hover:border-primary/40 cursor-pointer">
               <Upload className="w-3.5 h-3.5" />
               Upload .txt
             </div>
@@ -167,7 +167,7 @@ const JobDescriptionInput = ({ value, onChange }) => {
             <button
               type="button"
               onClick={handleAutoClean}
-              className="flex items-center gap-1.5 text-xs font-medium text-text-muted hover:text-secondary transition-colors py-1.5 px-3 border border-border rounded-full bg-surface/50 hover:border-secondary/40"
+              className="flex items-center gap-1.5 text-xs font-medium text-text-muted hover:text-secondary transition-colors py-1.5 px-3 border border-border rounded-full bg-gray-100 dark:bg-surface/50 hover:border-secondary/40"
             >
               <Sparkles className="w-3.5 h-3.5" />
               Auto-clean

--- a/client/src/modules/resume-analyzer/pages/ResumeAnalyzerPage.jsx
+++ b/client/src/modules/resume-analyzer/pages/ResumeAnalyzerPage.jsx
@@ -51,7 +51,7 @@ const ResumeAnalyzerPage = () => {
   };
 
   return (
-    <div className="min-h-screen bg-dark-bg text-text-main font-sans">
+    <div className="min-h-screen bg-white dark:bg-dark-bg text-gray-900 dark:text-text-main font-sans">
       <Navbar />
       <div className="max-w-4xl mx-auto pt-32 pb-12 px-4 sm:px-6 lg:px-8 space-y-8 animate-slide-up">
         <PageHeader 
@@ -60,7 +60,7 @@ const ResumeAnalyzerPage = () => {
         />
 
         {/* Main Content Area */}
-        <div className="mt-12 bg-surface border border-border rounded-[2rem] p-8 md:p-12 shadow-2xl relative overflow-hidden">
+        <div className="mt-12 bg-gray-100 dark:bg-surface border border-gray-200 dark:border-border rounded-[2rem] p-8 md:p-12 shadow-2xl relative overflow-hidden">
           {/* Background Decorative Element */}
           <div className="absolute -top-24 -right-24 w-64 h-64 bg-primary/5 rounded-full blur-[100px] pointer-events-none"></div>
 
@@ -146,9 +146,9 @@ const ResumeAnalyzerPage = () => {
           ].map((item, id) => (
             <div
               key={id}
-              className="p-6 bg-surface border border-border rounded-2xl hover:border-primary/30 transition-all group"
+              className="p-6 bg-gray-100 dark:bg-surface border border-gray-200 dark:border-border rounded-2xl hover:border-primary/30 transition-all group"
             >
-              <h4 className="font-heading font-bold text-text-main mb-2 group-hover:text-primary transition-colors">
+              <h4 className="font-heading font-bold text-gray-900 dark:text-text-main mb-2 group-hover:text-primary transition-colors">
                 {item.title}
               </h4>
               <p className="text-sm text-text-muted leading-relaxed">

--- a/client/src/modules/student-jobs/components/JobFilters.jsx
+++ b/client/src/modules/student-jobs/components/JobFilters.jsx
@@ -52,15 +52,15 @@ const JobFilters = ({ onFilterChange }) => {
   ];
 
   return (
-    <div className="bg-slate-900/50 backdrop-blur-xl border border-white/10 rounded-2xl p-6 h-fit sticky top-28">
+    <div className="bg-gray-100 dark:bg-slate-900/50 backdrop-blur-xl border border-gray-200 dark:border-white/10 rounded-2xl p-6 h-fit sticky top-28">
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-bold text-white flex items-center gap-2">
+        <h2 className="text-xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
           <Filter size={20} className="text-blue-400" />
           Filters
         </h2>
         <button
           onClick={handleClear}
-          className="text-xs font-medium text-slate-400 hover:text-white transition-colors flex items-center gap-1"
+          className="text-xs font-medium text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white transition-colors flex items-center gap-1"
         >
           <X size={14} />
           Clear All
@@ -70,7 +70,7 @@ const JobFilters = ({ onFilterChange }) => {
       <div className="space-y-6">
         {/* Designation */}
         <div>
-          <label htmlFor="filter-designation" className="block text-sm font-medium text-slate-300 mb-2">
+          <label htmlFor="filter-designation" className="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
             Designation
           </label>
           <Input
@@ -86,7 +86,7 @@ const JobFilters = ({ onFilterChange }) => {
 
         {/* Salary Range */}
         <div>
-          <label htmlFor="filter-min-salary" className="block text-sm font-medium text-slate-300 mb-2">
+          <label htmlFor="filter-min-salary" className="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
             Expected Salary (₹)
           </label>
           <div className="grid grid-cols-2 gap-3">
@@ -113,7 +113,7 @@ const JobFilters = ({ onFilterChange }) => {
 
         {/* Date Posted */}
         <div>
-          <label htmlFor="filter-date-posted" className="block text-sm font-medium text-slate-300 mb-2">
+          <label htmlFor="filter-date-posted" className="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
             Date Posted
           </label>
           <Select

--- a/client/src/modules/student-jobs/pages/JobBoardPage.jsx
+++ b/client/src/modules/student-jobs/pages/JobBoardPage.jsx
@@ -74,7 +74,7 @@ const JobBoardPage = () => {
   };
 
   return (
-    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] text-slate-100 flex flex-col">
+    <main className="min-h-screen bg-white dark:bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] text-gray-900 dark:text-slate-100 flex flex-col">
       <Navbar />
       
       {/* Spacer to push content below the fixed Navbar */}
@@ -86,7 +86,7 @@ const JobBoardPage = () => {
           <h1 className="text-5xl md:text-6xl font-black mb-6 tracking-tight leading-tight">
             <span className="text-gradient">Opportunities</span> Await
           </h1>
-          <p className="text-slate-400 text-xl leading-relaxed font-medium">
+          <p className="text-gray-500 dark:text-slate-400 text-xl leading-relaxed font-medium">
             Browse through curated job listings from top companies looking for talent like you.
           </p>
         </div>
@@ -100,7 +100,7 @@ const JobBoardPage = () => {
           {/* Job List Area */}
           <div className="lg:col-span-3">
             <div className="mb-6 flex items-center justify-between">
-              <h2 className="text-xl font-semibold text-slate-200 flex items-center gap-2">
+              <h2 className="text-xl font-semibold text-gray-800 dark:text-slate-200 flex items-center gap-2">
                 Available Jobs
                 <span className="text-sm font-normal text-slate-500 bg-slate-800/50 px-2 py-0.5 rounded-full border border-white/5">
                   {loading ? "..." : jobs.length}

--- a/client/src/shared/components/EmptyState.jsx
+++ b/client/src/shared/components/EmptyState.jsx
@@ -22,11 +22,11 @@ const EmptyState = ({
   return (
     <div className={`flex flex-col items-center justify-center py-20 text-center ${className}`}>
       <div className="opacity-40">{icon}</div>
-      <h3 className="text-2xl font-heading font-medium text-text-main mb-2">
+      <h3 className="text-2xl font-heading font-medium text-gray-800 dark:text-text-main mb-2">
         {title}
       </h3>
       {description && (
-        <p className="text-text-muted max-w-md mx-auto mb-8">
+        <p className="text-gray-500 dark:text-text-muted max-w-md mx-auto mb-8">
           {description}
         </p>
       )}

--- a/client/src/shared/components/Input.jsx
+++ b/client/src/shared/components/Input.jsx
@@ -44,7 +44,7 @@ const Input = ({
   const inputType = isPassword ? (showPassword ? "text" : "password") : type;
 
   const baseInput = [
-    "w-full rounded-lg border bg-slate-800 px-3.5 py-2.5 text-sm text-white caret-white",
+    "w-full rounded-lg border bg-white dark:bg-slate-800 px-3.5 py-2.5 text-sm text-gray-900 dark:text-white caret-gray-900 dark:caret-white",
     "placeholder:text-gray-500 transition-all duration-150",
     "focus:outline-none focus:ring-2 focus:ring-offset-0",
     "autofill-fix",
@@ -52,10 +52,10 @@ const Input = ({
     (rightIcon || isPassword) ? "pr-10" : "",
     hasError
       ? "border-red-400 focus:ring-red-400 focus:border-red-400"
-      : "border-slate-600 focus:ring-blue-500 focus:border-blue-500",
+      : "border-gray-300 dark:border-slate-600 focus:ring-blue-500 focus:border-blue-500",
     disabled
-      ? "cursor-not-allowed bg-slate-800/50 text-slate-500 border-slate-700"
-      : "hover:border-slate-500",
+      ? "cursor-not-allowed bg-gray-100 dark:bg-slate-800/50 text-gray-400 dark:text-slate-500 border-gray-200 dark:border-slate-700"
+      : "hover:border-gray-400 dark:hover:border-slate-500",
   ]
     .filter(Boolean)
     .join(" ");

--- a/client/src/shared/components/Select.jsx
+++ b/client/src/shared/components/Select.jsx
@@ -35,16 +35,16 @@ const Select = ({
   const hasError = Boolean(error);
 
   const selectClasses = [
-    "w-full appearance-none rounded-lg border bg-slate-800 px-3.5 py-2.5 pr-9",
+    "w-full appearance-none rounded-lg border bg-gray-100 dark:bg-slate-800 px-3.5 py-2.5 pr-9",
     "text-sm transition-all duration-150 cursor-pointer",
     "focus:outline-none focus:ring-2 focus:ring-offset-0",
     hasError
       ? "border-red-400 text-white focus:ring-red-400 focus:border-red-400"
-      : "border-slate-600 text-white focus:ring-blue-500 focus:border-blue-500 hover:border-slate-500",
+      : "border-gray-300 dark:border-slate-600 text-gray-900 dark:text-white focus:ring-blue-500 focus:border-blue-500 hover:border-gray-400 dark:hover:border-slate-500",
     disabled
-      ? "cursor-not-allowed bg-slate-800/50 text-slate-500 border-slate-700"
+      ? "cursor-not-allowed bg-gray-200 dark:bg-slate-800/50 text-gray-400 dark:text-slate-500 border-gray-300 dark:border-slate-700"
       : "",
-    !value ? "text-slate-400" : "text-white",
+    !value ? "text-gray-400 dark:text-slate-400" : "text-gray-900 dark:text-white",
   ]
     .filter(Boolean)
     .join(" ");

--- a/client/src/shared/components/TextArea.jsx
+++ b/client/src/shared/components/TextArea.jsx
@@ -21,14 +21,14 @@ const TextArea = ({
   const hasError = Boolean(error);
 
   const baseTextArea = [
-    "w-full rounded-xl border bg-slate-800/50 px-4 py-3 text-sm text-white caret-primary transition-all duration-200 outline-none",
+    "w-full rounded-xl border bg-white dark:bg-slate-800/50 px-4 py-3 text-sm text-gray-900 dark:text-white caret-primary transition-all duration-200 outline-none",
     "placeholder:text-gray-500 focus:ring-2",
     hasError
       ? "border-red-400 focus:ring-red-400/20 focus:border-red-400"
-      : "border-slate-700 focus:ring-primary/20 focus:border-primary",
+      : "border-gray-300 dark:border-slate-700 focus:ring-primary/20 focus:border-primary",
     disabled
       ? "opacity-50 cursor-not-allowed"
-      : "hover:border-slate-600",
+      : "hover:border-gray-400 dark:hover:border-slate-600",
   ]
     .filter(Boolean)
     .join(" ");


### PR DESCRIPTION
Closes #250 

## What I did
- Fixed `:root.dark` to `.dark` in `index.css` so CSS variables apply correctly when theme toggles
- Added `dark:` variants to `DashboardPage`, `JobBoardPage`, `JobMatcherPage`, `ResumeAnalyzerPage`
- Fixed shared components: `Input`, `Select`, `TextArea`, `EmptyState`, `JobFilters`, `DragDropUpload`, `JobDescriptionInput`
- Fixed welcome heading gradient visibility in light mode
- Removed unused `ThemeToggle` import from `App.jsx`

Dark mode behavior unchanged.