### PR TITLE
fix: implement global light mode support across all pages and shared components

### DIFF
--- a/client/src/modules/resume-analyzer/components/DragDropUpload.jsx
+++ b/client/src/modules/resume-analyzer/components/DragDropUpload.jsx
@@ -117,7 +117,7 @@ const DragDropUpload = ({ onFileUpload }) => {
       </div>
 
       <div className="text-center space-y-2">
-        <p className="text-2xl font-heading font-bold text-text-main italic">
+        <p className="text-2xl font-heading font-bold text-gray-800 dark:text-text-main italic">
           Drag & Drop your resume here
         </p>
         <p className="text-text-muted">
@@ -138,11 +138,11 @@ const DragDropUpload = ({ onFileUpload }) => {
       </div>
 
       <div className="my-4 flex items-center justify-center space-x-4 w-full max-w-sm px-4">
-        <div className="h-px bg-border flex-1"></div>
+        <div className="h-px bg-gray-300 dark:bg-border flex-1"></div>
         <span className="text-[10px] text-text-muted uppercase font-black tracking-[0.3em]">
           OR
         </span>
-        <div className="h-px bg-border flex-1"></div>
+        <div className="h-px bg-gray-300 dark:bg-border flex-1"></div>
       </div>
 
       <div className="relative group">


### PR DESCRIPTION
## What I did
- Fixed `:root.dark` to `.dark` in `index.css` so CSS variables apply correctly when theme toggles
- Added `dark:` variants to `DashboardPage`, `JobBoardPage`, `JobMatcherPage`, `ResumeAnalyzerPage`
- Fixed shared components: `Input`, `Select`, `TextArea`, `EmptyState`, `JobFilters`, `DragDropUpload`, `JobDescriptionInput`
- Fixed welcome heading gradient visibility in light mode
- Fixed drag & drop text and OR divider visibility in light mode
- Removed unused `ThemeToggle` import from `App.jsx`

Dark mode behavior unchanged.

Screenshoots-

<img width="1919" height="1027" alt="Screenshot 2026-05-11 000313" src="https://github.com/user-attachments/assets/6806e004-21d5-4ec6-a6dc-59b108d9900c" />
-
-
<img width="1919" height="1026" alt="Screenshot 2026-05-11 000329" src="https://github.com/user-attachments/assets/9cfd98b3-7608-467f-9b31-80f81142d26f" />
-
-
<img width="1919" height="989" alt="Screenshot 2026-05-11 000353" src="https://github.com/user-attachments/assets/c5feb741-2954-4250-98d3-9937f281a521" />
-
-
<img width="1917" height="1022" alt="image" src="https://github.com/user-attachments/assets/917e7428-a13c-4615-9723-da1b175524f8" />
-
-
<img width="1919" height="1027" alt="Screenshot 2026-05-11 000409" src="https://github.com/user-attachments/assets/5b0fa597-8e32-4f96-bc06-4effa03b92ee" />
