### PR TITLE
fix: add salary range validation for job filters(NSOC'26)

### DIFF
--- a/client/src/modules/student-jobs/components/JobFilters.jsx
+++ b/client/src/modules/student-jobs/components/JobFilters.jsx
@@ -4,6 +4,7 @@ import { Search, Filter, Calendar, IndianRupee, X } from "lucide-react";
 import Input from "../../../shared/components/Input";
 import Select from "../../../shared/components/Select";
 
+
 const JobFilters = ({ onFilterChange }) => {
   const [filters, setFilters] = useState({
     designation: "",
@@ -13,6 +14,8 @@ const JobFilters = ({ onFilterChange }) => {
   });
 
   const [debouncedDesignation, setDebouncedDesignation] = useState("");
+  // State for salary range validation message
+  const [salaryError, setSalaryError] = useState("");
 
   // Debounce designation search
   useEffect(() => {
@@ -22,17 +25,35 @@ const JobFilters = ({ onFilterChange }) => {
     return () => clearTimeout(timer);
   }, [filters.designation]);
 
-  // Trigger filter change when filters update
+  // Prevent invalid salary filters from triggering API calls
   useEffect(() => {
+    if(salaryError) return;
+
     onFilterChange({
       ...filters,
       designation: debouncedDesignation,
     });
-  }, [debouncedDesignation, filters.minSalary, filters.maxSalary, filters.postedWithin]);
+  }, [ debouncedDesignation,filters.minSalary,filters.maxSalary, filters.postedWithin, salaryError,]);
 
+
+  
   const handleChange = (e) => {
     const { name, value } = e.target;
-    setFilters((prev) => ({ ...prev, [name]: value }));
+    const updatedFilters = {
+      ...filters,
+      [name]: value,
+    };
+    setFilters(updatedFilters);
+    // Validate salary range before applying filters
+    const min = Number(updatedFilters.minSalary);
+    const max = Number(updatedFilters.maxSalary);
+
+    if(updatedFilters.minSalary && updatedFilters.maxSalary && min>max) {
+      setSalaryError("Minimum salary cannot be greater than maximum salary");
+    }
+    else {
+      setSalaryError("");
+    }
   };
 
   const handleClear = () => {
@@ -110,6 +131,12 @@ const JobFilters = ({ onFilterChange }) => {
             />
           </div>
         </div>
+
+
+        {/* Salary validation feedback */}
+        {salaryError && (
+          <p className="text-red-400 text-sm mt-2"> {salaryError} </p>
+        )}
 
         {/* Date Posted */}
         <div>


### PR DESCRIPTION
### NSOC'26

## Summary

Added salary range validation for the Jobs page filters to improve user experience and prevent invalid filter combinations.
Previously, users could enter a minimum salary greater than the maximum salary, which silently returned "No Jobs Found". This update adds proper validation feedback and prevents invalid filters from triggering unnecessary API calls.

---

## Type of Change

* [ ] Feature
* [x] Bug fix
* [ ] Refactor
* [ ] Documentation
* [ ] Chore

---

## Related Issue

Closes #259 

---

## Changes Made

* Added frontend validation for invalid salary ranges
* Added inline validation message for users
* Prevented invalid salary filters from triggering filter updates/API calls
* Improved overall filter UX for the Jobs page

---

## Validation

* [x] Build passes locally
* [ ] Relevant tests added/updated
* [ ] Documentation updated (if needed)

---

## Screenshots 

### Invalid Salary Range Validation

* Added inline error feedback when minimum salary exceeds maximum salary

<img width="1406" height="790" alt="Screenshot from 2026-05-11 17-42-16" src="https://github.com/user-attachments/assets/e4291ba2-04f4-43d9-8fb7-597a03348036" />


### Valid Salary Range

* Filters work normally after correcting salary values

<img width="1406" height="790" alt="Screenshot from 2026-05-11 17-41-57" src="https://github.com/user-attachments/assets/fbacc72f-e4df-42c8-9baa-1c839d2a061c" />

