### PR TITLE
feat(jobs): add update/delete flow for recruiters

### DIFF
--- a/client/src/app/App.jsx
+++ b/client/src/app/App.jsx
@@ -18,6 +18,7 @@ import ProfilePage from "../modules/profile/ProfilePage";
 import RecruiterJobsPage from "../modules/recruiter-jobs/pages/RecruiterJobsPage";
 import RecruiterAnalyticsPage from "../modules/recruiter-jobs/pages/RecruiterAnalyticsPage";
 import CreateJobPostingPage from "../modules/recruiter-jobs/pages/CreateJobPostingPage";
+import EditJobPostingPage from "../modules/recruiter-jobs/pages/EditJobPostingPage";
 import JobBoardPage from "../modules/student-jobs/pages/JobBoardPage";
 import MyApplicationsPage from "../modules/student-jobs/pages/MyApplicationsPage";
 import ClassroomsDashboard from "../modules/classrooms/pages/ClassroomsDashboard";
@@ -91,6 +92,14 @@ function App() {
           element={
             <ProtectedRoute requiredRole="recruiter">
               <CreateJobPostingPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/recruiter/jobs/edit/:id"
+          element={
+            <ProtectedRoute requiredRole="recruiter">
+              <EditJobPostingPage />
             </ProtectedRoute>
           }
         />

--- a/client/src/modules/recruiter-jobs/pages/EditJobPostingPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/EditJobPostingPage.jsx
@@ -1,0 +1,119 @@
+import React, { useState, useEffect } from "react";
+import { useSelector } from "react-redux";
+import { useNavigate, useParams, Link } from "react-router-dom";
+import { ArrowLeft, Edit3 } from "lucide-react";
+import Navbar from "../../../shared/landing/Navbar";
+import JobPostingForm from "../components/JobPostingForm";
+import LoadingState from "../../../shared/components/LoadingState";
+import { updateJobPosting, getJobPostingById } from "../services/jobPostingService";
+
+const EditJobPostingPage = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { token } = useSelector((state) => state.auth);
+
+  const [jobData, setJobData] = useState(null);
+  const [isLoadingData, setIsLoadingData] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
+  const [fieldErrors, setFieldErrors] = useState({});
+
+  useEffect(() => {
+    let ignore = false;
+    async function fetchJob() {
+      setIsLoadingData(true);
+      try {
+        const response = await getJobPostingById(id, token);
+        if (!ignore) {
+          setJobData(response.job);
+        }
+      } catch (err) {
+        if (!ignore) {
+          setSubmitError(err.message || "Failed to load job posting data.");
+        }
+      } finally {
+        if (!ignore) {
+          setIsLoadingData(false);
+        }
+      }
+    }
+    fetchJob();
+    return () => { ignore = true; };
+  }, [id, token]);
+
+  const handleSubmit = async (payload) => {
+    setSubmitError("");
+    setFieldErrors({});
+    setIsSubmitting(true);
+
+    try {
+      await updateJobPosting(id, payload, token);
+      navigate("/recruiter/jobs");
+    } catch (error) {
+      setSubmitError(error.message || "Failed to update job posting. Please try again.");
+      if (error.errors) {
+        setFieldErrors(error.errors);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] p-3 sm:p-5 pt-20 sm:pt-28 text-slate-100">
+      <Navbar />
+
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 py-8">
+        <Link 
+          to="/recruiter/jobs" 
+          className="inline-flex items-center gap-2 text-slate-400 hover:text-blue-400 transition-colors w-fit group"
+        >
+          <ArrowLeft size={18} className="group-hover:-translate-x-1 transition-transform" />
+          <span>Back to Jobs</span>
+        </Link>
+
+        <div className="flex flex-col gap-1 mb-2">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-blue-500/10 rounded-lg text-blue-400">
+              <Edit3 size={24} />
+            </div>
+            <h1 className="text-3xl font-bold text-white">Edit Job Posting</h1>
+          </div>
+          <p className="text-slate-400 mt-2">
+            Update the details below to edit your job posting. Changes will be reflected immediately.
+          </p>
+        </div>
+
+        {submitError && (
+          <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-xl text-red-400 text-sm flex items-start gap-3">
+            <svg className="w-5 h-5 shrink-0 mt-0.5" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M18 10A8 8 0 1 1 2 10a8 8 0 0 1 16 0Zm-8-5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 10 5Zm0 10a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+            </svg>
+            <p>{submitError}</p>
+          </div>
+        )}
+
+        <div className="bg-slate-900/70 border border-white/10 rounded-2xl p-6 sm:p-8 shadow-2xl backdrop-blur">
+          {isLoadingData ? (
+            <div className="py-12">
+              <LoadingState message="Loading job details..." />
+            </div>
+          ) : jobData ? (
+            <JobPostingForm 
+              initialData={jobData}
+              onSubmit={handleSubmit} 
+              isLoading={isSubmitting} 
+              fieldErrors={fieldErrors} 
+            />
+          ) : (
+            <div className="text-center py-10 text-slate-400">
+              Could not load job data.
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default EditJobPostingPage;

--- a/client/src/modules/recruiter-jobs/pages/RecruiterJobsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterJobsPage.jsx
@@ -9,7 +9,7 @@ import LoadingState from "../../../shared/components/LoadingState";
 import ErrorState from "../../../shared/components/ErrorState";
 import EmptyState from "../../../shared/components/EmptyState";
 import { JobViewerCard } from "../../../shared/components";
-import { getRecruiterJobs } from "../services/jobPostingService";
+import { getRecruiterJobs, deleteJobPosting } from "../services/jobPostingService";
 
 const RecruiterJobsPage = () => {
   const navigate = useNavigate();
@@ -75,8 +75,19 @@ const RecruiterJobsPage = () => {
   });
 
   const handleEditJob = (job) => {
-    // navigate(`/recruiter/jobs/edit/${job.id}`);
-    console.log("Edit job", job);
+    navigate(`/recruiter/jobs/edit/${job._id || job.id}`);
+  };
+
+  const handleDeleteJob = async (job) => {
+    if (window.confirm(`Are you sure you want to delete "${job.title}"?`)) {
+      try {
+        await deleteJobPosting(job._id || job.id, token);
+        // Refresh the jobs list
+        setJobs(jobs.filter(j => (j._id || j.id) !== (job._id || job.id)));
+      } catch (err) {
+        alert(err.message || "Failed to delete job posting.");
+      }
+    }
   };
 
   const handleViewRecommendations = (job) => {
@@ -139,6 +150,7 @@ const RecruiterJobsPage = () => {
                 job={job}
                 viewerRole="recruiter"
                 onEdit={handleEditJob}
+                onDelete={handleDeleteJob}
                 onViewStats={handleViewRecommendations}
               />
             ))}

--- a/client/src/modules/recruiter-jobs/services/jobPostingService.js
+++ b/client/src/modules/recruiter-jobs/services/jobPostingService.js
@@ -124,3 +124,57 @@ export const getRecruiterAnalytics = async (token) => {
     throw normalizedError;
   }
 };
+
+/**
+ * Update an existing job posting
+ * @param {string} id - Job posting ID
+ * @param {Object} jobData - Job posting payload
+ * @param {string} token - Auth bearer token
+ * @returns {Promise<{success: boolean, job: Object}>}
+ */
+export const updateJobPosting = async (id, jobData, token) => {
+  try {
+    const payload = {
+      ...jobData,
+      skills: Array.isArray(jobData.skills)
+        ? jobData.skills
+        : jobData.skills.split(",").map((s) => s.trim()).filter(Boolean),
+    };
+
+    const response = await apiRequest(`/api/jobs/${id}`, {
+      method: "PUT",
+      body: payload,
+      token,
+    });
+
+    return {
+      success: true,
+      job: response.job || response.data,
+    };
+  } catch (error) {
+    const normalizedError = handleServiceError(error);
+    throw normalizedError;
+  }
+};
+
+/**
+ * Delete a job posting
+ * @param {string} id - Job posting ID
+ * @param {string} token - Auth bearer token
+ * @returns {Promise<{success: boolean}>}
+ */
+export const deleteJobPosting = async (id, token) => {
+  try {
+    await apiRequest(`/api/jobs/${id}`, {
+      method: "DELETE",
+      token,
+    });
+
+    return {
+      success: true,
+    };
+  } catch (error) {
+    const normalizedError = handleServiceError(error);
+    throw normalizedError;
+  }
+};

--- a/server/src/modules/jobs/controller.js
+++ b/server/src/modules/jobs/controller.js
@@ -9,6 +9,8 @@ import {
   getMyAppliedJobIds as getMyAppliedJobIdsService,
   getMyApplicationsWithDetails as getMyAppsDetailedService,
   withdrawApplication as withdrawAppService,
+  updateJob as updateJobService,
+  deleteJob as deleteJobService,
 } from "./service.js";
 import AppError from "../../utils/AppError.js";
 import asyncHandler from "../../utils/asyncHandler.js";
@@ -121,6 +123,32 @@ export const getJobPostingById = asyncHandler(async (req, res) => {
   res.status(200).json({
     success: true,
     job,
+  });
+});
+
+/**
+ * @desc    Update a job posting
+ * @route   PUT /api/jobs/:id
+ * @access  Private (Recruiters only)
+ */
+export const updateJobPosting = asyncHandler(async (req, res) => {
+  const updatedJob = await updateJobService(req.params.id, req.body, req.user._id);
+  res.status(200).json({
+    success: true,
+    job: updatedJob,
+  });
+});
+
+/**
+ * @desc    Delete a job posting
+ * @route   DELETE /api/jobs/:id
+ * @access  Private (Recruiters only)
+ */
+export const deleteJobPosting = asyncHandler(async (req, res) => {
+  await deleteJobService(req.params.id, req.user._id);
+  res.status(200).json({
+    success: true,
+    message: "Job deleted successfully",
   });
 });
 

--- a/server/src/modules/jobs/routes.js
+++ b/server/src/modules/jobs/routes.js
@@ -12,6 +12,8 @@ import {
   getMyApplications,
   getMyApplicationsDetailed,
   withdrawJobApplication,
+  updateJobPosting,
+  deleteJobPosting,
 } from "./controller.js";
 
 const router = express.Router();
@@ -35,7 +37,9 @@ router.get("/my-applications/details", authorizeRoles("student"), getMyApplicati
 // Job-specific routes
 router
   .route("/:id")
-  .get(authorizeRoles("recruiter"), getJobPostingById);
+  .get(authorizeRoles("recruiter"), getJobPostingById)
+  .put(authorizeRoles("recruiter"), updateJobPosting)
+  .delete(authorizeRoles("recruiter"), deleteJobPosting);
 
 // Application routes
 router.post("/:id/apply", authorizeRoles("student"), applyToJobPosting);

--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -139,6 +139,9 @@ export const deleteJob = async (id, recruiterId) => {
     throw new AppError("You do not have permission to delete this job", 403);
   }
 
+  // Delete all associated applications
+  await JobApplication.deleteMany({ job: id });
+  
   await JobPosting.findByIdAndDelete(id);
 };
 


### PR DESCRIPTION
## Summary

This PR introduces full update and delete functionalities for recruiters managing their job postings. It adds the necessary backend endpoints, prevents orphaned database records by deleting associated applications when a job is removed, and integrates the edit/delete flows into the frontend dashboard. 

## Type of Change

- [x] Feature

## Related Issue

Closes #275 

## Changes Made

- **Backend**: Added `PUT /api/jobs/:id` and `DELETE /api/jobs/:id` protected endpoints in the jobs controller and routes.
- **Backend**: Updated `deleteJob` service to cascade deletion, removing all associated `JobApplication` records.
- **Frontend**: Created a new `EditJobPostingPage` that reuses `JobPostingForm` to fetch and update job details.
- **Frontend**: Wired up the `handleDeleteJob` with a confirmation modal and `handleEditJob` actions in `RecruiterJobsPage`.
- **Frontend**: Added `updateJobPosting` and `deleteJobPosting` fetch calls to `jobPostingService.js` and registered the new edit route in `App.jsx`.

## Validation

- [x] Build passes locally


## Screenshots 
<img width="1138" height="465" alt="image" src="https://github.com/user-attachments/assets/57e0bbe7-a368-495f-ac23-8b6a033f420c" />
