### PR TITLE
feat(profile): implement update and delete user account functionality

### DIFF
--- a/client/src/features/auth/authSlice.js
+++ b/client/src/features/auth/authSlice.js
@@ -252,6 +252,20 @@ const authSlice = createSlice({
       state.loading = false;
       state.error = null;
     },
+    updateUserProfile: (state, action) => {
+      state.user = action.payload;
+      
+      // Update storage as well
+      const storage = window.localStorage.getItem("skillssphere.auth.token") 
+        ? window.localStorage 
+        : window.sessionStorage;
+      
+      try {
+        storage.setItem("skillssphere.auth.user", JSON.stringify(action.payload));
+      } catch (e) {
+        // Ignore storage errors
+      }
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -346,6 +360,7 @@ export const {
   logout,
   setPendingVerificationEmail,
   setOAuthData,
+  updateUserProfile,
 } = authSlice.actions;
 
 export default authSlice.reducer;

--- a/client/src/modules/profile/ProfilePage.jsx
+++ b/client/src/modules/profile/ProfilePage.jsx
@@ -17,15 +17,11 @@ import Input from "../../shared/components/Input";
 import Button from "../../shared/components/Button";
 import ProfileField from "./components/ProfileField";
 
-// Mock user — no API calls, frontend-only
-const MOCK_USER = {
-  name: "Candidate One",
-  email: "candidate@example.com",
-  role: "student",           // "student" | "tutor" | "recruiter"
-  isEmailVerified: true,
-  createdAt: "2024-12-01T10:30:00Z",
-  updatedAt: "2025-03-15T08:45:00Z",
-};
+import { useSelector, useDispatch } from "react-redux";
+import { useNavigate } from "react-router-dom";
+import { updateUserProfile, logout } from "../../features/auth/authSlice";
+import { updateProfile, deleteProfile } from "./services/profileService";
+import LoadingState from "../../shared/components/LoadingState";
 
 const ROLE_LABELS = {
   student: "Student",
@@ -61,22 +57,28 @@ function getInitials(name) {
 }
 
 const ProfilePage = () => {
-  const [user, setUser] = useState(MOCK_USER);
+  const { user, token } = useSelector((state) => state.auth);
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
   const [isEditing, setIsEditing] = useState(false);
-  const [formData, setFormData] = useState({ name: user.name });
+  const [formData, setFormData] = useState({ name: user?.name || "" });
   const [errors, setErrors] = useState({});
   const [saveSuccess, setSaveSuccess] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [apiError, setApiError] = useState("");
 
   const handleEditClick = () => {
-    setFormData({ name: user.name });
+    setFormData({ name: user?.name || "" });
     setErrors({});
     setSaveSuccess(false);
     setIsEditing(true);
   };
 
   const handleCancel = () => {
-    setFormData({ name: user.name });
+    setFormData({ name: user?.name || "" });
     setErrors({});
+    setApiError("");
     setIsEditing(false);
   };
 
@@ -99,7 +101,7 @@ const ProfilePage = () => {
     return newErrors;
   };
 
-  const handleSave = (e) => {
+  const handleSave = async (e) => {
     e.preventDefault();
     const newErrors = validate();
     if (Object.keys(newErrors).length > 0) {
@@ -107,20 +109,46 @@ const ProfilePage = () => {
       return;
     }
 
-    // Persist locally — no API call (frontend-only)
-    setUser((prev) => ({
-      ...prev,
-      name: formData.name.trim(),
-      updatedAt: new Date().toISOString(),
-    }));
+    try {
+      setApiError("");
+      const response = await updateProfile({ name: formData.name.trim() }, token);
+      dispatch(updateUserProfile(response.user));
+      
+      setSaveSuccess(true);
+      setIsEditing(false);
+      setErrors({});
 
-    setSaveSuccess(true);
-    setIsEditing(false);
-    setErrors({});
-
-    // Clear success toast after 3 s
-    setTimeout(() => setSaveSuccess(false), 3000);
+      setTimeout(() => setSaveSuccess(false), 3000);
+    } catch (err) {
+      setApiError(err.message || "Failed to update profile");
+    }
   };
+
+  const handleDeleteAccount = async () => {
+    if (
+      window.confirm(
+        "Are you absolutely sure you want to delete your account? This action cannot be undone."
+      )
+    ) {
+      setIsDeleting(true);
+      try {
+        await deleteProfile(token);
+        dispatch(logout());
+        navigate("/login");
+      } catch (err) {
+        alert(err.message || "Failed to delete account");
+        setIsDeleting(false);
+      }
+    }
+  };
+
+  if (!user) {
+    return (
+      <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] flex items-center justify-center">
+        <LoadingState message="Loading profile..." />
+      </div>
+    );
+  }
 
   const verificationBadge = user.isEmailVerified ? (
     <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold bg-emerald-500/20 text-emerald-400 border border-emerald-500/30">
@@ -169,8 +197,12 @@ const ProfilePage = () => {
         <div className="mb-5 p-6 rounded-[20px] backdrop-blur-[20px] bg-slate-900/70 border border-white/10 shadow-[0_0_40px_rgba(0,0,0,0.6)]">
           <div className="flex flex-col sm:flex-row items-center sm:items-start gap-4">
             {/* Avatar */}
-            <div className="w-20 h-20 rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 flex items-center justify-center text-white text-2xl font-bold shadow-[0_0_20px_rgba(99,102,241,0.4)] flex-shrink-0 select-none">
-              {getInitials(user.name)}
+            <div className="w-20 h-20 rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 flex items-center justify-center text-white text-2xl font-bold shadow-[0_0_20px_rgba(99,102,241,0.4)] flex-shrink-0 select-none overflow-hidden">
+              {user.profilePic ? (
+                <img src={user.profilePic} alt={user.name} className="w-full h-full object-cover" />
+              ) : (
+                getInitials(user.name || "")
+              )}
             </div>
 
             {/* Name + role */}
@@ -225,6 +257,13 @@ const ProfilePage = () => {
               )}
             </div>
           </div>
+
+          {apiError && (
+            <div className="mt-4 flex items-start gap-2 p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 text-sm">
+              <AlertCircle size={16} className="shrink-0 mt-0.5" />
+              <p>{apiError}</p>
+            </div>
+          )}
 
           {/* Save success toast */}
           {saveSuccess && (
@@ -352,11 +391,31 @@ const ProfilePage = () => {
             value={formatDate(user.createdAt)}
             icon={<Calendar size={16} />}
           />
-          <ProfileField
-            label="Last Updated"
-            value={formatDate(user.updatedAt)}
-            icon={<Clock size={16} />}
-          />
+          {user.updatedAt && (
+            <ProfileField
+              label="Last Updated"
+              value={formatDate(user.updatedAt)}
+              icon={<Clock size={16} />}
+            />
+          )}
+        </div>
+
+        {/* Danger Zone */}
+        <div className="mb-8 p-6 rounded-[20px] backdrop-blur-[20px] bg-red-950/20 border border-red-500/20 shadow-[0_0_40px_rgba(239,68,68,0.05)]">
+          <h2 className="text-sm font-semibold text-red-400 uppercase tracking-widest mb-4">
+            Danger Zone
+          </h2>
+          <p className="text-sm text-slate-400 mb-6 leading-relaxed">
+            Once you delete your account, there is no going back. Please be certain.
+          </p>
+          <Button
+            variant="danger"
+            onClick={handleDeleteAccount}
+            loading={isDeleting}
+            className="w-full sm:w-auto"
+          >
+            Delete Account
+          </Button>
         </div>
       </div>
     </div>

--- a/client/src/modules/profile/services/profileService.js
+++ b/client/src/modules/profile/services/profileService.js
@@ -1,0 +1,73 @@
+import { apiRequest, normalizeApiError } from "../../../services/apiClient";
+
+/**
+ * Handle API errors consistently for profile service
+ */
+const handleProfileError = (error) => {
+  const normalized = normalizeApiError(error);
+
+  if (normalized.status === 401 || normalized.status === 403) {
+    return {
+      ...normalized,
+      message: "You are not authorized. Please log in again.",
+    };
+  }
+
+  if (normalized.status === 400 || normalized.status === 422) {
+    return {
+      ...normalized,
+      message: normalized.message || "Please check your input and try again.",
+    };
+  }
+
+  if (normalized.status === 0 || normalized.status >= 500) {
+    return {
+      ...normalized,
+      message: "Unable to connect to the server. Please try again later.",
+    };
+  }
+
+  return normalized;
+};
+
+/**
+ * Update user profile details
+ * @param {Object} payload - Profile update data (e.g., { name })
+ * @param {string} token - Auth bearer token
+ * @returns {Promise<{success: boolean, user: Object}>}
+ */
+export const updateProfile = async (payload, token) => {
+  try {
+    const response = await apiRequest("/api/users/me", {
+      method: "PUT",
+      body: payload,
+      token,
+    });
+    return {
+      success: true,
+      user: response.user,
+    };
+  } catch (error) {
+    throw handleProfileError(error);
+  }
+};
+
+/**
+ * Delete user account
+ * @param {string} token - Auth bearer token
+ * @returns {Promise<{success: boolean}>}
+ */
+export const deleteProfile = async (token) => {
+  try {
+    const response = await apiRequest("/api/users/me", {
+      method: "DELETE",
+      token,
+    });
+    return {
+      success: true,
+      message: response.message,
+    };
+  } catch (error) {
+    throw handleProfileError(error);
+  }
+};

--- a/client/src/shared/landing/Navbar.jsx
+++ b/client/src/shared/landing/Navbar.jsx
@@ -138,6 +138,14 @@ const Navbar = () => {
                     <LayoutDashboard size={18} />
                     Dashboard
                   </Link>
+                  <Link 
+                    to="/profile" 
+                    className="flex items-center gap-3 px-4 py-2.5 text-sm text-[var(--text-muted)] hover:text-[var(--text-main)] hover:bg-[var(--surface-hover)] transition-colors"
+                    onClick={() => setIsProfileOpen(false)}
+                  >
+                    <User size={18} />
+                    Profile
+                  </Link>
                   {user?.role === 'student' && (
                     <Link 
                       to="/my-applications" 
@@ -265,6 +273,9 @@ const Navbar = () => {
                 </div>
                 <Button variant="primary" size="lg" to="/dashboard" className="w-full justify-center">
                   Go to Dashboard
+                </Button>
+                <Button variant="outline" size="lg" to="/profile" className="w-full justify-center border-[var(--border)] text-[var(--text-main)] hover:bg-[var(--surface-hover)]">
+                  <User size={20} /> View Profile
                 </Button>
                 <Button variant="ghost" size="lg" onClick={handleLogout} className="w-full justify-center text-red-400 hover:text-red-300 hover:bg-red-400/10">
                   <LogOut size={20} /> Logout

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,7 @@ import jobRoutes from "./src/modules/jobs/routes.js";
 import matchingRoutes from "./src/modules/matching/routes.js";
 import dashboardRoutes from "./src/modules/dashboard/routes.js";
 import classroomRoutes from "./src/modules/classrooms/routes.js";
+import userRoutes from "./src/modules/users/routes.js";
 import { initClassroomSockets } from "./src/modules/classrooms/socket.js";
 import globalErrorHandler from "./src/middleware/errorMiddleware.js";
 import { logEvaluatorConfig } from "./src/config/evaluatorConfig.js";
@@ -74,6 +75,7 @@ app.use("/api/jobs", jobRoutes);
 app.use("/api/matching", matchingRoutes);
 app.use("/api/dashboard", dashboardRoutes);
 app.use("/api/classrooms", classroomRoutes);
+app.use("/api/users", userRoutes);
 
 // Initialize Sockets
 initClassroomSockets(io);

--- a/server/src/modules/users/controller.js
+++ b/server/src/modules/users/controller.js
@@ -1,0 +1,56 @@
+import User from "../../database/models/User.js";
+import AppError from "../../utils/AppError.js";
+import asyncHandler from "../../utils/asyncHandler.js";
+
+/**
+ * @desc    Update user profile details
+ * @route   PUT /api/users/me
+ * @access  Private
+ */
+export const updateProfile = asyncHandler(async (req, res, next) => {
+  const { name } = req.body;
+
+  if (!name || name.trim().length < 2) {
+    return next(new AppError("Please provide a valid name (at least 2 characters)", 400));
+  }
+
+  // Update user in database
+  const updatedUser = await User.findByIdAndUpdate(
+    req.user._id,
+    { name: name.trim() },
+    { new: true, runValidators: true }
+  ).select("-password -__v");
+
+  if (!updatedUser) {
+    return next(new AppError("User not found", 404));
+  }
+
+  res.status(200).json({
+    success: true,
+    message: "Profile updated successfully",
+    user: updatedUser,
+  });
+});
+
+/**
+ * @desc    Delete user account completely
+ * @route   DELETE /api/users/me
+ * @access  Private
+ */
+export const deleteProfile = asyncHandler(async (req, res, next) => {
+  const user = await User.findById(req.user._id);
+
+  if (!user) {
+    return next(new AppError("User not found", 404));
+  }
+
+  // We could also delete related records here (e.g., resumes, applications, jobs)
+  // But for the scope of this issue, we start with deleting the user.
+  // A robust implementation might use a pre('remove') hook on the User model.
+  await User.findByIdAndDelete(req.user._id);
+
+  res.status(200).json({
+    success: true,
+    message: "Account deleted successfully",
+  });
+});

--- a/server/src/modules/users/routes.js
+++ b/server/src/modules/users/routes.js
@@ -1,0 +1,16 @@
+import express from "express";
+import { protect } from "../../middleware/authMiddleware.js";
+import { updateProfile, deleteProfile } from "./controller.js";
+
+const router = express.Router();
+
+// All user routes require authentication
+router.use(protect);
+
+// 👤 Update Current User Profile
+router.put("/me", updateProfile);
+
+// 🗑️ Delete Current User Account
+router.delete("/me", deleteProfile);
+
+export default router;


### PR DESCRIPTION
## Summary

This PR implements the missing user profile management features. Authenticated users can now update their profile name and permanently delete their accounts from their Profile dashboard.

## Type of Change

- [x] Feature


## Related Issue

Closes #276 

## Changes Made

- **Backend**: Created the `users` module with new `PUT /api/users/me` and `DELETE /api/users/me` endpoints.
- **Frontend**: Added `profileService.js` to manage the profile API calls.
- **Frontend**: Wired up `ProfilePage.jsx` to fetch real data from Redux, save name updates, and handle account deletion (with confirmation).
- **Frontend**: Added an `updateUserProfile` action in `authSlice` to update the local state without needing to refresh.
- **Frontend**: Added the missing "Profile" link to the Navigation dropdown and mobile menu.

## Validation

- [x] Build passes locally


## Screenshots 
<img width="355" height="302" alt="image" src="https://github.com/user-attachments/assets/217203fd-c648-4615-b651-d2b356cafd93" />
---
<img width="580" height="767" alt="image" src="https://github.com/user-attachments/assets/dc852bd7-4550-4873-ab59-0a48c9c2c217" />
