### PR TITLE
security(jobs): apply rate limiting to job creation endpoint

### DIFF
--- a/server/src/middleware/rateLimiter.js
+++ b/server/src/middleware/rateLimiter.js
@@ -18,3 +18,22 @@ export const authRateLimiter = rateLimit({
     res.status(429).json(options.message);
   }
 });
+
+/**
+ * Rate Limiter for Job Creation
+ * Prevents spamming of the job database by malicious or compromised accounts
+ */
+export const jobCreationLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour window
+  max: parseInt(process.env.JOB_CREATION_LIMIT_MAX) || 15, // Default 15 jobs per hour
+  message: {
+    success: false,
+    message: "You have reached the maximum number of job postings allowed per hour. Please try again later.",
+    error: "RATE_LIMIT_EXCEEDED"
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res, next, options) => {
+    res.status(429).json(options.message);
+  }
+});

--- a/server/src/modules/jobs/routes.js
+++ b/server/src/modules/jobs/routes.js
@@ -1,5 +1,6 @@
 import express from "express";
 import { protect, authorizeRoles } from "../../middleware/authMiddleware.js";
+import { jobCreationLimiter } from "../../middleware/rateLimiter.js";
 import {
   createJobPosting,
   getRecruiterJobs,
@@ -26,7 +27,7 @@ router.get("/recommendations", getRecommendations);
 // Recruiter-only routes
 router.get("/recruiter", authorizeRoles("recruiter"), getRecruiterJobs);
 router.get("/recruiter/analytics", authorizeRoles("recruiter"), getRecruiterAnalytics);
-router.post("/", authorizeRoles("recruiter"), createJobPosting);
+router.post("/", authorizeRoles("recruiter"), jobCreationLimiter, createJobPosting);
 
 // Student application routes (must be before /:id to avoid route conflict)
 router.get("/my-applications", authorizeRoles("student"), getMyApplications);


### PR DESCRIPTION

## Summary

This PR addresses a critical security flaw by implementing rate limiting on the job creation endpoint. It prevents malicious attacks compromised recruiter accounts from spamming the database with bogus job postings, ensuring platform stability.

## Type of Change


- [x] Bug fix (Security)


## Related Issue

Closes #282 

## Changes Made

- **Backend**: Created a new `jobCreationLimiter` in `server/src/middleware/rateLimiter.js`.
- Configured the limiter to restrict recruiter accounts to a maximum of 15 job postings per hour to prevent abuse.
- **Backend**: Attached the `jobCreationLimiter` middleware to the `POST /api/jobs` endpoint in `server/src/modules/jobs/routes.js`.

## Validation

- [x] Build passes locally
- [x] Verified rate limiter returns `429 Too Many Requests` after exceeding the threshold.


