### PR TITLE
fix: add light mode color variants to badge and component systems

### DIFF
--- a/client/src/modules/ai-assistant/components/ChatBox.jsx
+++ b/client/src/modules/ai-assistant/components/ChatBox.jsx
@@ -65,15 +65,15 @@ const ChatBox = () => {
         height: "100%",
         borderRadius: "10px",
         overflow: "hidden",
-        backgroundColor: "#ffffff",
-        boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+        backgroundColor: "var(--surface)",
+        boxShadow: "var(--shadow-soft)",
       }}
     >
       {/* Header */}
       <div
         style={{
           padding: "10px",
-          backgroundColor: "#2563eb",
+          backgroundColor: "var(--primary)",
           color: "#fff",
           fontWeight: "bold",
         }}
@@ -99,7 +99,7 @@ const ChatBox = () => {
       <div
         style={{
           display: "flex",
-          borderTop: "1px solid #ddd",
+          borderTop: "1px solid var(--border)",
           padding: "8px",
         }}
       >
@@ -112,8 +112,10 @@ const ChatBox = () => {
             flex: 1,
             padding: "8px",
             borderRadius: "6px",
-            border: "1px solid #ccc",
+            border: "1px solid var(--border)",
             outline: "none",
+            color: "var(--text-main)",
+            backgroundColor: "var(--surface)",
           }}
         />
 
@@ -122,7 +124,7 @@ const ChatBox = () => {
           style={{
             marginLeft: "8px",
             padding: "8px 12px",
-            backgroundColor: "#2563eb",
+            backgroundColor: "var(--primary)",
             color: "#fff",
             border: "none",
             borderRadius: "6px",

--- a/client/src/modules/ai-assistant/components/ChatWidget.jsx
+++ b/client/src/modules/ai-assistant/components/ChatWidget.jsx
@@ -20,14 +20,14 @@ const ChatWidget = () => {
           width: "55px",
           height: "55px",
           borderRadius: "50%",
-          backgroundColor: "#2563eb",
+          backgroundColor: "var(--primary)",
           color: "#fff",
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
           fontSize: "24px",
           cursor: "pointer",
-          boxShadow: "0 4px 10px rgba(0,0,0,0.2)",
+          boxShadow: "var(--shadow-soft)",
           zIndex: 1000,
         }}
       >

--- a/client/src/modules/classrooms/pages/ClassroomsDashboard.jsx
+++ b/client/src/modules/classrooms/pages/ClassroomsDashboard.jsx
@@ -35,10 +35,10 @@ export default function ClassroomsDashboard() {
     <div className="min-h-screen bg-[#020617] text-white pt-24 px-6">
       <div className="max-w-4xl mx-auto">
         <div className="text-center mb-12">
-          <div className="inline-flex items-center justify-center p-3 bg-indigo-500/20 text-indigo-400 rounded-2xl mb-6">
+          <div className="inline-flex items-center justify-center p-3 bg-indigo-100 text-indigo-900 dark:bg-indigo-500/20 dark:text-indigo-400 rounded-2xl mb-6">
             <MonitorPlay size={32} />
           </div>
-          <h1 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-to-r from-indigo-400 to-purple-400 bg-clip-text text-transparent">
+          <h1 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-to-r from-indigo-900 to-purple-900 dark:from-indigo-400 dark:to-purple-400 bg-clip-text text-transparent">
             Live Interactive Classrooms
           </h1>
           <p className="text-slate-400 text-lg max-w-2xl mx-auto">
@@ -49,7 +49,7 @@ export default function ClassroomsDashboard() {
         <div className="grid md:grid-cols-2 gap-8">
           {/* Start a Session */}
           <div className="bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-8 hover:bg-slate-800 transition-colors">
-            <div className="bg-indigo-500/20 w-12 h-12 rounded-xl flex items-center justify-center text-indigo-400 mb-6">
+            <div className="bg-indigo-100 w-12 h-12 rounded-xl flex items-center justify-center text-indigo-900 dark:bg-indigo-500/20 dark:text-indigo-400 mb-6">
               <Video size={24} />
             </div>
             <h2 className="text-2xl font-semibold mb-3">Start a New Session</h2>
@@ -74,7 +74,7 @@ export default function ClassroomsDashboard() {
 
           {/* Join a Session */}
           <div className="bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-8 hover:bg-slate-800 transition-colors">
-            <div className="bg-purple-500/20 w-12 h-12 rounded-xl flex items-center justify-center text-purple-400 mb-6">
+            <div className="bg-purple-100 w-12 h-12 rounded-xl flex items-center justify-center text-purple-900 dark:bg-purple-500/20 dark:text-purple-400 mb-6">
               <Users size={24} />
             </div>
             <h2 className="text-2xl font-semibold mb-3">Join a Session</h2>

--- a/client/src/modules/dashboard/DashboardPage.jsx
+++ b/client/src/modules/dashboard/DashboardPage.jsx
@@ -214,8 +214,8 @@ const DashboardPage = () => {
         <div className="flex flex-col gap-3 sm:gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <div className="flex items-center gap-2 mb-1">
-              <div className="h-2 w-2 rounded-full bg-blue-500 animate-pulse"></div>
-              <p className="text-xs sm:text-sm font-medium text-blue-300 uppercase tracking-wider">Professional Intelligence</p>
+              <div className="h-2 w-2 rounded-full bg-blue-500 dark:bg-blue-500/20 animate-pulse"></div>
+              <p className="text-xs sm:text-sm font-medium text-blue-900 dark:text-blue-300 uppercase tracking-wider">Professional Intelligence</p>
             </div>
             <h1 className="text-3xl sm:text-4xl font-extrabold bg-clip-text text-transparent bg-gradient-to-r from-gray-900 to-gray-500 dark:from-white dark:to-slate-400">
               Welcome, {user?.name || "Learner"}

--- a/client/src/modules/job-matcher/components/MatcherForm.jsx
+++ b/client/src/modules/job-matcher/components/MatcherForm.jsx
@@ -30,7 +30,7 @@ export default function MatcherForm({ onSubmit }) {
             ${
               type === "existing"
                 ? "bg-gradient-to-r from-indigo-500 to-purple-600 text-white shadow-[0_4px_14px_0_rgba(79,70,229,0.39)]"
-                : "bg-gray-700 text-gray-300 hover:bg-gray-600"
+                : "bg-gray-300 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
             }
           `}
         >

--- a/client/src/modules/job-matcher/components/RecommendedJobsList.jsx
+++ b/client/src/modules/job-matcher/components/RecommendedJobsList.jsx
@@ -2,7 +2,7 @@ export default function RecommendedJobsList({ jobs }) {
   return (
     <div className="bg-white/10 backdrop-blur-lg border border-white/20 p-5 rounded-2xl shadow-xl text-white">
       
-      <h3 className="text-lg font-semibold mb-4 text-blue-300">
+      <h3 className="text-lg font-semibold mb-4 text-blue-900 dark:text-blue-300">
         💼 Recommended Jobs
       </h3>
 
@@ -10,7 +10,7 @@ export default function RecommendedJobsList({ jobs }) {
         {jobs.map((job, i) => (
           <div
             key={i}
-            className="bg-gray-800/80 border border-gray-700 p-4 rounded-xl 
+            className="bg-gray-100 border border-gray-300 dark:bg-gray-800/80 dark:border-gray-700 p-4 rounded-xl  
                        hover:shadow-lg hover:scale-[1.02] transition duration-300"
           >
             {/* Job Title */}
@@ -19,13 +19,13 @@ export default function RecommendedJobsList({ jobs }) {
             </h4>
 
             {/* Company Badge */}
-            <p className="inline-block mt-2 px-3 py-1 text-sm rounded-full 
-                          bg-blue-500/20 text-blue-300">
+              <p className="inline-block mt-2 px-3 py-1 text-sm rounded-full 
+                            bg-blue-100 text-blue-900 dark:bg-blue-500/20 dark:text-blue-300">
               {job.company}
             </p>
 
             {/* Match Score */}
-            <p className="text-sm mt-3 text-green-400 font-medium">
+            <p className="text-sm mt-3 text-green-700 dark:text-green-400 font-medium">
               Match: {job.score}%
             </p>
           </div>

--- a/client/src/modules/student-jobs/components/JobFilters.jsx
+++ b/client/src/modules/student-jobs/components/JobFilters.jsx
@@ -156,8 +156,8 @@ const JobFilters = ({ onFilterChange }) => {
       </div>
 
       {/* Quick Tips */}
-      <div className="mt-8 p-4 bg-blue-500/5 rounded-xl border border-blue-500/10">
-        <p className="text-xs text-blue-300 leading-relaxed">
+      <div className="mt-8 p-4 bg-blue-100 dark:bg-blue-500/5 rounded-xl border border-blue-300 dark:border-blue-500/10">
+        <p className="text-xs text-blue-900 dark:text-blue-300 leading-relaxed">
           <span className="font-bold">Pro Tip:</span> Refine your search to find jobs matching your skill set more accurately.
         </p>
       </div>

--- a/client/src/modules/student-jobs/pages/MyApplicationsPage.jsx
+++ b/client/src/modules/student-jobs/pages/MyApplicationsPage.jsx
@@ -199,7 +199,7 @@ const MyApplicationsPage = () => {
                           {job.skills.slice(0, 5).map((skill) => (
                             <span
                               key={skill}
-                              className="px-2 py-0.5 bg-blue-500/10 text-blue-300 text-xs rounded-md border border-blue-500/20"
+                              className="px-2 py-0.5 bg-blue-100 text-blue-900 dark:bg-blue-500/10 dark:text-blue-300 text-xs rounded-md border border-blue-300 dark:border-blue-500/20"
                             >
                               {skill}
                             </span>

--- a/client/src/shared/components/ConfirmDialog.jsx
+++ b/client/src/shared/components/ConfirmDialog.jsx
@@ -29,16 +29,16 @@ const ConfirmDialog = ({
 
   const variantStyles = {
     danger: {
-      icon: "bg-red-500/15 text-red-400 border-red-500/25",
-      button: "bg-red-600 hover:bg-red-500 focus:ring-red-500/40",
+      icon: "bg-red-100 text-red-900 border-red-300 dark:bg-red-500/15 dark:text-red-400 dark:border-red-500/25",
+      button: "bg-red-600 hover:bg-red-500 focus:ring-red-500/40 dark:bg-red-600 dark:hover:bg-red-500",
     },
     warning: {
-      icon: "bg-yellow-500/15 text-yellow-400 border-yellow-500/25",
-      button: "bg-yellow-600 hover:bg-yellow-500 focus:ring-yellow-500/40",
+      icon: "bg-yellow-100 text-yellow-900 border-yellow-300 dark:bg-yellow-500/15 dark:text-yellow-400 dark:border-yellow-500/25",
+      button: "bg-yellow-600 hover:bg-yellow-500 focus:ring-yellow-500/40 dark:bg-yellow-600 dark:hover:bg-yellow-500",
     },
     info: {
-      icon: "bg-blue-500/15 text-blue-400 border-blue-500/25",
-      button: "bg-blue-600 hover:bg-blue-500 focus:ring-blue-500/40",
+      icon: "bg-blue-100 text-blue-900 border-blue-300 dark:bg-blue-500/15 dark:text-blue-400 dark:border-blue-500/25",
+      button: "bg-blue-600 hover:bg-blue-500 focus:ring-blue-500/40 dark:bg-blue-600 dark:hover:bg-blue-500",
     },
   };
 

--- a/client/src/shared/components/JobDetailsView.jsx
+++ b/client/src/shared/components/JobDetailsView.jsx
@@ -37,11 +37,11 @@ const JOB_LEVEL_COLORS = {
 
 const Badge = ({ children, color = "slate" }) => {
   const colors = {
-    blue: "bg-blue-500/15 text-blue-300 border-blue-500/25",
-    emerald: "bg-emerald-500/15 text-emerald-300 border-emerald-500/25",
-    yellow: "bg-yellow-500/15 text-yellow-300 border-yellow-500/25",
-    purple: "bg-purple-500/15 text-purple-300 border-purple-500/25",
-    slate: "bg-slate-700/60 text-slate-300 border-slate-600/40",
+    blue: "bg-blue-100 text-blue-900 border-blue-300 dark:bg-blue-500/15 dark:text-blue-300 dark:border-blue-500/25",
+    emerald: "bg-emerald-100 text-emerald-900 border-emerald-300 dark:bg-emerald-500/15 dark:text-emerald-300 dark:border-emerald-500/25",
+    yellow: "bg-yellow-100 text-yellow-900 border-yellow-300 dark:bg-yellow-500/15 dark:text-yellow-300 dark:border-yellow-500/25",
+    purple: "bg-purple-100 text-purple-900 border-purple-300 dark:bg-purple-500/15 dark:text-purple-300 dark:border-purple-500/25",
+    slate: "bg-gray-200 text-gray-900 border-gray-400 dark:bg-slate-700/60 dark:text-slate-300 dark:border-slate-600/40",
   };
   return (
     <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${colors[color] || colors.slate}`}>

--- a/client/src/shared/components/JobViewerCard.jsx
+++ b/client/src/shared/components/JobViewerCard.jsx
@@ -84,18 +84,18 @@ const formatDate = (dateString) => {
 // ─── Status badge color map ───────────────────────────────────────────────────
 
 const STATUS_STYLES = {
-  open: "bg-emerald-500/15 text-emerald-300 border-emerald-500/25",
-  draft: "bg-yellow-500/15 text-yellow-300 border-yellow-500/25",
-  closed: "bg-slate-700/60 text-slate-400 border-slate-600/40",
+  open: "bg-emerald-100 text-emerald-900 border-emerald-300 dark:bg-emerald-500/15 dark:text-emerald-300 dark:border-emerald-500/25",
+  draft: "bg-yellow-100 text-yellow-900 border-yellow-300 dark:bg-yellow-500/15 dark:text-yellow-300 dark:border-yellow-500/25",
+  closed: "bg-gray-200 text-gray-900 border-gray-400 dark:bg-slate-700/60 dark:text-slate-400 dark:border-slate-600/40",
 };
 
 const JOB_LEVEL_STYLES = {
-  Internship: "bg-blue-500/15 text-blue-300 border-blue-500/25",
-  "Entry Level": "bg-blue-500/15 text-blue-300 border-blue-500/25",
-  Associate: "bg-purple-500/15 text-purple-300 border-purple-500/25",
-  "Mid-Senior Level": "bg-purple-500/15 text-purple-300 border-purple-500/25",
-  Director: "bg-yellow-500/15 text-yellow-300 border-yellow-500/25",
-  Executive: "bg-yellow-500/15 text-yellow-300 border-yellow-500/25",
+  Internship: "bg-blue-100 text-blue-900 border-blue-300 dark:bg-blue-500/15 dark:text-blue-300 dark:border-blue-500/25",
+  "Entry Level": "bg-blue-100 text-blue-900 border-blue-300 dark:bg-blue-500/15 dark:text-blue-300 dark:border-blue-500/25",
+  Associate: "bg-purple-100 text-purple-900 border-purple-300 dark:bg-purple-500/15 dark:text-purple-300 dark:border-purple-500/25",
+  "Mid-Senior Level": "bg-purple-100 text-purple-900 border-purple-300 dark:bg-purple-500/15 dark:text-purple-300 dark:border-purple-500/25",
+  Director: "bg-yellow-100 text-yellow-900 border-yellow-300 dark:bg-yellow-500/15 dark:text-yellow-300 dark:border-yellow-500/25",
+  Executive: "bg-yellow-100 text-yellow-900 border-yellow-300 dark:bg-yellow-500/15 dark:text-yellow-300 dark:border-yellow-500/25",
 };
 
 // ─── Component ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #290 

## Description:

Fixed multiple light mode UI inconsistencies across dashboard, resume analyzer, job board and related sections.

## Changes include:
- improved text visibility in light mode
- fixed washed out cards/buttons/badges
- added proper `dark:` variants for theme consistency
- improved contrast for upload sections, filters and status components

Dark mode styling remains unchanged.

## Screenshots:

<img width="1919" height="1024" alt="image" src="https://github.com/user-attachments/assets/a87facc9-e293-42a5-befa-ee30664f6238" />
-
<img width="1919" height="1022" alt="image" src="https://github.com/user-attachments/assets/0e4abd65-2a94-4766-8b62-1e79f85ee21b" />
-
<img width="1919" height="1022" alt="image" src="https://github.com/user-attachments/assets/ad55df14-9004-4f4f-8d2f-4882e70cbf86" />
-
<img width="1919" height="1012" alt="image" src="https://github.com/user-attachments/assets/8f3bbf0c-9edd-4a76-b967-fe6628103071" />
-
<img width="1919" height="1018" alt="image" src="https://github.com/user-attachments/assets/905fe6f3-bf11-4b66-93bd-61dce1619cf0" />
-
<img width="1919" height="1023" alt="image" src="https://github.com/user-attachments/assets/f7e6a034-017d-46d6-a20f-af48247dfd97" />
-
<img width="1919" height="1016" alt="image" src="https://github.com/user-attachments/assets/fc7322ee-a322-44d6-bec6-c97c3af5f080" />
