### PR TITLE
feat: disable clear filters button when no filters are active

### DIFF
--- a/client/src/modules/student-jobs/components/JobFilters.jsx
+++ b/client/src/modules/student-jobs/components/JobFilters.jsx
@@ -63,7 +63,11 @@ const JobFilters = ({ onFilterChange }) => {
       maxSalary: "",
       postedWithin: "",
     });
+    // Reset salary validation state when clearing filters
+    setSalaryError("");
   };
+  // Check whether any job filters are currently active
+  const hasActiveFilters = filters.designation || filters.minSalary || filters.maxSalary || filters.postedWithin;
 
   const dateOptions = [
     { value: "", label: "Anytime" },
@@ -81,7 +85,12 @@ const JobFilters = ({ onFilterChange }) => {
         </h2>
         <button
           onClick={handleClear}
-          className="text-xs font-medium text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white transition-colors flex items-center gap-1"
+          disabled={!hasActiveFilters}
+          className={`text-xs font-medium flex items-center gap-1 transition-colors ${
+            hasActiveFilters 
+            ? "text-slate-400 hover:text-white cursor-pointer" 
+            : "text-slate-600 cursor-not-allowed opacity-50"
+          }`}
         >
           <X size={14} />
           Clear All


### PR DESCRIPTION
## Summary

Improved the Jobs page filter experience by adding a proper disabled state for the “Clear All” button when no filters are active.
Previously, the button remained clickable even when all filter fields were empty. This update adds better visual feedback and prevents unnecessary interactions, making the filtering experience feel more intuitive and polished.

---

## Type of Change

* [x] Feature
* [ ] Bug fix
* [ ] Refactor
* [ ] Documentation
* [ ] Chore

---

## Related Issue

Closes #286

---

## Changes Made

* Added logic to detect whether any job filters are currently active
* Disabled the “Clear All” button when no filters are applied
* Added inactive styling and cursor feedback for disabled state
* Reset salary validation state properly while clearing filters

---

## Validation

* [x] Build passes locally
* [ ] Relevant tests added/updated
* [ ] Documentation updated (if needed)

---

## Screenshots (if UI change)

### Before

* “Clear All” remained clickable even when filters were empty

---

<img width="1392" height="802" alt="Screenshot from 2026-05-12 16-18-08" src="https://github.com/user-attachments/assets/ccc7a518-0c1e-40e2-9b0f-57aefd87e4ae" />

---

### After

* button now appears visually disabled until at least one filter is applied
* improves UX clarity and avoids unnecessary interactions

---

<img width="1813" height="950" alt="Screenshot from 2026-05-12 16-15-48" src="https://github.com/user-attachments/assets/5970c026-2589-4604-8d02-9f03639dd951" />
