### PR TITLE
feat: add loading skeleton UI for job cards(NSOC'26)

### DIFF
--- a/client/src/modules/student-jobs/components/JobCardSkeleton.jsx
+++ b/client/src/modules/student-jobs/components/JobCardSkeleton.jsx
@@ -1,0 +1,28 @@
+// Skeleton placeholder card displayed during jobs loading state
+
+const JobCardSkeleton = () => {
+  return (
+    <div className="animate-pulse rounded-2xl border border-white/5 bg-slate-900/40 p-6">
+      <div className="flex justify-between items-start mb-5">
+        <div className="space-y-3 w-2/3">
+          <div className="h-5 bg-slate-700 rounded w-3/4"></div>
+          <div className="h-4 bg-slate-800 rounded w-1/2"></div>
+        </div>
+
+        <div className="h-10 w-24 bg-slate-700 rounded-lg"></div>
+      </div>
+
+      <div className="space-y-3 mb-5">
+        <div className="h-4 bg-slate-800 rounded"></div>
+        <div className="h-4 bg-slate-800 rounded w-5/6"></div>
+      </div>
+
+      <div className="flex gap-3">
+        <div className="h-8 w-20 bg-slate-700 rounded-full"></div>
+        <div className="h-8 w-24 bg-slate-700 rounded-full"></div>
+      </div>
+    </div>
+  );
+};
+
+export default JobCardSkeleton;

--- a/client/src/modules/student-jobs/pages/JobBoardPage.jsx
+++ b/client/src/modules/student-jobs/pages/JobBoardPage.jsx
@@ -2,13 +2,13 @@ import React, { useState, useEffect, useCallback } from "react";
 import { useSelector } from "react-redux";
 import { Briefcase, Info } from "lucide-react";
 import Navbar from "../../../shared/landing/Navbar";
-import LoadingState from "../../../shared/components/LoadingState";
 import ErrorState from "../../../shared/components/ErrorState";
 import EmptyState from "../../../shared/components/EmptyState";
 import { JobViewerCard, Pagination } from "../../../shared/components";
 import JobFilters from "../components/JobFilters";
 import JobApplyForm from "../components/JobApplyForm";
 import { getJobs, applyToJob, getMyAppliedJobIds } from "../services/jobService";
+import JobCardSkeleton from "../components/JobCardSkeleton";
 
 const JobBoardPage = () => {
   const { token, user } = useSelector((state) => state.auth);
@@ -122,11 +122,15 @@ const JobBoardPage = () => {
               </h2>
             </div>
 
+
+            {/* Display skeleton cards while jobs are loading */}
             {loading ? (
-              <div className="min-h-[400px] flex items-center justify-center bg-slate-900/30 rounded-2xl border border-white/5 backdrop-blur-sm">
-                <LoadingState message="Searching for opportunities..." />
+              <div className="grid grid-cols-1 gap-5">
+                {Array.from({ length: 5 }).map((_, index) => (
+                  <JobCardSkeleton key={index} />
+                ))}
               </div>
-            ) : error ? (
+            ): error ? (
               <ErrorState message={error} onRetry={() => fetchJobs(filters)} />
             ) : jobs.length === 0 ? (
               <EmptyState


### PR DESCRIPTION
### NSOC'26

## Summary

Improved the Jobs page loading experience by replacing the generic loading state with reusable skeleton loading cards.

Previously, the jobs section appeared mostly empty while data was being fetched. This update preserves layout structure during loading and provides a smoother, more polished UI experience for users browsing jobs.

---

## Type of Change

* [x] Feature
* [ ] Bug fix
* [ ] Refactor
* [ ] Documentation
* [ ] Chore

---

## Related Issue

Closes #296

---

## Changes Made

* Added a reusable `JobCardSkeleton` component for loading placeholders
* Replaced the existing generic loader with skeleton job cards
* Preserved jobs layout structure during asynchronous fetching
* Improved perceived loading responsiveness and UI smoothness

---

## Validation

* [x] Build passes locally
* [ ] Relevant tests added/updated
* [ ] Documentation updated (if needed)

---

## Screenshots (if UI change)

### Before

* generic loading state displayed while jobs were being fetched

---

<img width="1030" height="977" alt="Screenshot from 2026-05-13 21-42-36" src="https://github.com/user-attachments/assets/171ab1fe-7d1c-4709-be0e-b390a9a092bc" />



---

### After

* skeleton placeholder cards now appear during loading
* layout remains visually stable while job data loads

---
<img width="1030" height="977" alt="Screenshot from 2026-05-13 21-42-32" src="https://github.com/user-attachments/assets/c5e33d5c-20fd-48fb-8ff5-4a5e8ea92e2d" />
