### PR TITLE
feat: add MongoDB models for AI Interview Engine (#332)

### DIFF
--- a/server/src/database/models/ConceptGraph.js
+++ b/server/src/database/models/ConceptGraph.js
@@ -1,0 +1,60 @@
+import mongoose from "mongoose";
+
+const conceptNodeSchema = new mongoose.Schema(
+  {
+    conceptId: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+    },
+
+    label: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+
+    parent: {
+      type: String,
+      default: null,
+    },
+
+    children: {
+      type: [String],
+      default: [],
+    },
+  },
+  { _id: false }
+);
+
+const conceptGraphSchema = new mongoose.Schema(
+  {
+    topic: {
+      type: String,
+      required: [true, "Topic is required"],
+      unique: true,
+      trim: true,
+      lowercase: true,
+    },
+
+    label: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+
+    concepts: {
+      type: [conceptNodeSchema],
+      default: [],
+      validate: {
+        validator: (val) => Array.isArray(val) && val.length > 0,
+        message: "At least one concept is required",
+      },
+    },
+  },
+  { timestamps: true }
+);
+
+const ConceptGraph = mongoose.model("ConceptGraph", conceptGraphSchema);
+export default ConceptGraph;

--- a/server/src/database/models/InterviewSession.js
+++ b/server/src/database/models/InterviewSession.js
@@ -1,0 +1,140 @@
+import mongoose from "mongoose";
+
+const answerSchema = new mongoose.Schema(
+  {
+    questionId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "QuestionBank",
+      required: true,
+    },
+
+    questionText: {
+      type: String,
+      required: true,
+    },
+
+    audioPath: {
+      type: String,
+      default: null,
+    },
+
+    transcript: {
+      type: String,
+      default: "",
+    },
+
+    scores: {
+      technical: { type: Number, default: 0, min: 0, max: 100 },
+      communication: { type: Number, default: 0, min: 0, max: 100 },
+      relevance: { type: Number, default: 0, min: 0, max: 100 },
+      _id: false,
+    },
+
+    concepts: {
+      expected: { type: [String], default: [] },
+      detected: { type: [String], default: [] },
+      missed: { type: [String], default: [] },
+      _id: false,
+    },
+
+    fillerWords: {
+      type: Number,
+      default: 0,
+    },
+
+    speakingSpeed: {
+      type: String,
+      enum: ["slow", "normal", "fast"],
+      default: "normal",
+    },
+
+    answeredAt: {
+      type: Date,
+      default: null,
+    },
+  },
+  { _id: false }
+);
+
+const interviewSessionSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: [true, "User ID is required"],
+      index: true,
+    },
+
+    topic: {
+      type: String,
+      required: [true, "Interview topic is required"],
+      trim: true,
+      lowercase: true,
+    },
+
+    difficulty: {
+      type: String,
+      enum: ["easy", "medium", "hard"],
+      default: "medium",
+    },
+
+    status: {
+      type: String,
+      enum: ["in_progress", "completed", "abandoned"],
+      default: "in_progress",
+    },
+
+    answers: {
+      type: [answerSchema],
+      default: [],
+    },
+
+    currentQuestionIndex: {
+      type: Number,
+      default: 0,
+    },
+
+    totalQuestions: {
+      type: Number,
+      default: 0,
+    },
+
+    overallScore: {
+      type: Number,
+      default: 0,
+      min: 0,
+      max: 100,
+    },
+
+    weakConcepts: {
+      type: [String],
+      default: [],
+    },
+
+    duration: {
+      type: Number, // total seconds
+      default: 0,
+    },
+
+    startedAt: {
+      type: Date,
+      default: Date.now,
+    },
+
+    completedAt: {
+      type: Date,
+      default: null,
+    },
+  },
+  { timestamps: true }
+);
+
+// Index for fetching user's interview history efficiently
+interviewSessionSchema.index({ userId: 1, createdAt: -1 });
+interviewSessionSchema.index({ status: 1 });
+
+const InterviewSession = mongoose.model(
+  "InterviewSession",
+  interviewSessionSchema
+);
+export default InterviewSession;

--- a/server/src/database/models/QuestionBank.js
+++ b/server/src/database/models/QuestionBank.js
@@ -1,0 +1,62 @@
+import mongoose from "mongoose";
+
+const questionBankSchema = new mongoose.Schema(
+  {
+    topic: {
+      type: String,
+      required: [true, "Topic is required"],
+      trim: true,
+      lowercase: true,
+      index: true,
+    },
+
+    subtopic: {
+      type: String,
+      required: [true, "Subtopic is required"],
+      trim: true,
+      lowercase: true,
+    },
+
+    difficulty: {
+      type: String,
+      enum: ["easy", "medium", "hard"],
+      required: [true, "Difficulty level is required"],
+      default: "medium",
+    },
+
+    questionText: {
+      type: String,
+      required: [true, "Question text is required"],
+      trim: true,
+    },
+
+    expectedConcepts: {
+      type: [String],
+      required: [true, "Expected concepts are required"],
+      validate: {
+        validator: (val) => Array.isArray(val) && val.length > 0,
+        message: "At least one expected concept is required",
+      },
+    },
+
+    expectedAnswer: {
+      type: String,
+      required: [true, "Expected answer is required"],
+      trim: true,
+    },
+
+    followUpQuestions: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "QuestionBank",
+      },
+    ],
+  },
+  { timestamps: true }
+);
+
+// Compound index for fetching questions by topic + difficulty
+questionBankSchema.index({ topic: 1, difficulty: 1 });
+
+const QuestionBank = mongoose.model("QuestionBank", questionBankSchema);
+export default QuestionBank;


### PR DESCRIPTION
## Summary

Adds 3 MongoDB models (InterviewSession, QuestionBank, ConceptGraph) for the AI Interview Engine. These are the foundation for the interview feature discussed in Discussion #237.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #332

## Changes Made

- Added `InterviewSession` model — stores interview sessions with nested answers, scores, and concept tracking
- Added `QuestionBank` model — pre-stored questions tagged by topic/subtopic/difficulty with expected answers and concepts
- Added `ConceptGraph` model — topic knowledge trees with parent-child concept relationships for gap analysis
- Added proper indexes for efficient queries (userId + createdAt, topic + difficulty)
- Followed existing model patterns (JobPosting.js as reference)

## Validation

- [x] Build passes locally
- [ ] Relevant tests added/updated
- [x] Documentation updated (if needed)

## Screenshots (if UI change)

N/A — backend models only, no UI changes.
