### PR TITLE
feat: harden Node.js ↔ Python AI service integration (#341)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,13 @@ EMAIL_FROM="SkillsSphere AI" <no-reply@skillssphere.ai>
 # AI/ML Configuration (Hugging Face — free tier, required for semantic matching)
 # Get your free token at: https://huggingface.co/settings/tokens
 HF_API_TOKEN=your_hugging_face_token_here
+
+# ==========================================
+# Interview AI Service Configuration
+# ==========================================
+# URL of the Python AI microservice for interview evaluation
+INTERVIEW_AI_URL=http://localhost:8000
+# Timeout for evaluation requests (ms)
+INTERVIEW_AI_TIMEOUT=10000
+# Timeout for audio transcription requests (ms)
+INTERVIEW_AI_TRANSCRIBE_TIMEOUT=30000

--- a/server/src/integrations/aiInterviewService.js
+++ b/server/src/integrations/aiInterviewService.js
@@ -5,14 +5,33 @@
  * - Speech-to-text (audio transcription via faster-whisper)
  * - Answer evaluation (semantic similarity + concept detection)
  *
- * Falls back to mock responses when the Python service is unavailable.
+ * Features:
+ * - Retry logic with exponential backoff (3 attempts)
+ * - Configurable timeouts for transcription and evaluation
+ * - Graceful fallback to mock scores when Python service is unavailable
+ * - Request timing logs for performance monitoring
  */
 
 const AI_SERVICE_URL =
   process.env.INTERVIEW_AI_URL || "http://localhost:8000";
+const EVAL_TIMEOUT = parseInt(process.env.INTERVIEW_AI_TIMEOUT || "10000", 10);
+const TRANSCRIBE_TIMEOUT = parseInt(
+  process.env.INTERVIEW_AI_TRANSCRIBE_TIMEOUT || "30000",
+  10
+);
+const MAX_RETRIES = 3;
+
+/**
+ * Sleep for a given number of milliseconds.
+ * Used for exponential backoff between retries.
+ */
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Check if the Python AI service is available.
+ * Uses a 2-second timeout to avoid blocking the request pipeline.
+ *
+ * @returns {Promise<boolean>} True if the service is reachable and healthy.
  */
 const isServiceAvailable = async () => {
   try {
@@ -30,8 +49,76 @@ const isServiceAvailable = async () => {
 };
 
 /**
+ * Make an HTTP request to the Python service with retry logic.
+ * Retries up to MAX_RETRIES times with exponential backoff on failure.
+ *
+ * @param {string} endpoint - The API endpoint path (e.g. '/api/evaluate').
+ * @param {object} options - Fetch options (method, headers, body).
+ * @param {number} timeoutMs - Request timeout in milliseconds.
+ * @returns {Promise<Response>} The fetch response.
+ * @throws {Error} If all retry attempts fail.
+ */
+const fetchWithRetry = async (endpoint, options, timeoutMs) => {
+  let lastError;
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+      const startTime = Date.now();
+      const res = await fetch(`${AI_SERVICE_URL}${endpoint}`, {
+        ...options,
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+
+      const duration = Date.now() - startTime;
+      console.log(
+        `[aiInterviewService] ${endpoint} responded in ${duration}ms (attempt ${attempt})`
+      );
+
+      if (res.ok) return res;
+
+      // Non-retryable status codes
+      if (res.status === 400 || res.status === 422) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(
+          error.detail || `Request failed with status ${res.status}`
+        );
+      }
+
+      lastError = new Error(`Request failed with status ${res.status}`);
+    } catch (err) {
+      lastError = err;
+
+      if (err.name === "AbortError") {
+        lastError = new Error(
+          `Request to ${endpoint} timed out after ${timeoutMs}ms`
+        );
+      }
+
+      if (attempt < MAX_RETRIES) {
+        const backoff = Math.pow(2, attempt - 1) * 500; // 500ms, 1s, 2s
+        console.log(
+          `[aiInterviewService] Attempt ${attempt} failed for ${endpoint}, retrying in ${backoff}ms...`
+        );
+        await sleep(backoff);
+      }
+    }
+  }
+
+  throw lastError;
+};
+
+/**
  * Generate mock evaluation scores when the Python service is unavailable.
  * Uses basic keyword matching as a simple fallback.
+ *
+ * @param {string} transcript - The student's answer text.
+ * @param {string} expectedAnswer - The expected/ideal answer.
+ * @param {string[]} expectedConcepts - Concept IDs to check for.
+ * @returns {object} Mock evaluation result matching the Python API contract.
  */
 const mockEvaluate = (transcript, expectedAnswer, expectedConcepts) => {
   const transcriptLower = transcript.toLowerCase();
@@ -61,7 +148,9 @@ const mockEvaluate = (transcript, expectedAnswer, expectedConcepts) => {
   if (wordCount > 50 && wordCount < 200) communication = 85;
 
   // Count filler words
-  const fillers = ["um", "uh", "like", "you know", "basically", "actually", "so yeah"];
+  const fillers = [
+    "um", "uh", "like", "you know", "basically", "actually", "so yeah",
+  ];
   const fillerCount = fillers.reduce((count, filler) => {
     const regex = new RegExp(`\\b${filler}\\b`, "gi");
     return count + (transcriptLower.match(regex) || []).length;
@@ -74,40 +163,52 @@ const mockEvaluate = (transcript, expectedAnswer, expectedConcepts) => {
     concepts: { detected, missed },
     fillerWords: fillerCount,
     speakingSpeed: wordCount < 30 ? "slow" : wordCount > 150 ? "fast" : "normal",
+    _mock: true,
   };
 };
 
 /**
  * Send audio to the Python service for transcription.
- * Falls back with an error if the service is unavailable.
+ * Uses a longer timeout (30s default) since audio processing is slower.
+ *
+ * @param {Buffer} audioBuffer - Raw audio file buffer.
+ * @param {string} [filename='audio.webm'] - Original filename for format detection.
+ * @returns {Promise<object>} Object with 'transcript' field.
+ * @throws {Error} If the service is unavailable or transcription fails.
  */
-export const transcribeAudio = async (audioBuffer) => {
+export const transcribeAudio = async (audioBuffer, filename = "audio.webm") => {
   const available = await isServiceAvailable();
 
   if (!available) {
+    console.warn(
+      "[aiInterviewService] ⚠️ Python AI service is not reachable at",
+      AI_SERVICE_URL
+    );
     throw new Error(
       "AI transcription service is not available. Please submit text instead."
     );
   }
 
   const formData = new FormData();
-  formData.append("audio", new Blob([audioBuffer]), "audio.webm");
+  formData.append("audio", new Blob([audioBuffer]), filename);
 
-  const res = await fetch(`${AI_SERVICE_URL}/api/transcribe`, {
-    method: "POST",
-    body: formData,
-  });
-
-  if (!res.ok) {
-    throw new Error(`Transcription failed with status ${res.status}`);
-  }
+  const res = await fetchWithRetry(
+    "/api/transcribe",
+    { method: "POST", body: formData },
+    TRANSCRIBE_TIMEOUT
+  );
 
   return res.json();
 };
 
 /**
  * Send transcript to the Python service for evaluation.
- * Falls back to mock evaluation if the service is unavailable.
+ * Falls back to mock evaluation if the service is unavailable or errors out.
+ *
+ * @param {string} transcript - The student's answer text.
+ * @param {string} expectedAnswer - The expected/ideal answer.
+ * @param {string[]} expectedConcepts - Concept IDs to check for.
+ * @returns {Promise<object>} Evaluation result with technical, communication, relevance scores.
  */
 export const evaluateAnswer = async (
   transcript,
@@ -117,24 +218,48 @@ export const evaluateAnswer = async (
   const available = await isServiceAvailable();
 
   if (!available) {
-    console.log(
-      "[aiInterviewService] Python service unavailable, using mock evaluation"
+    console.warn(
+      "[aiInterviewService] ⚠️ Python service unavailable, falling back to mock evaluation"
     );
     return mockEvaluate(transcript, expectedAnswer, expectedConcepts);
   }
 
-  const res = await fetch(`${AI_SERVICE_URL}/api/evaluate`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ transcript, expectedAnswer, expectedConcepts }),
-  });
-
-  if (!res.ok) {
-    console.log(
-      `[aiInterviewService] Evaluation failed (${res.status}), using mock`
+  try {
+    const res = await fetchWithRetry(
+      "/api/evaluate",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transcript, expectedAnswer, expectedConcepts }),
+      },
+      EVAL_TIMEOUT
     );
+
+    return res.json();
+  } catch (err) {
+    console.warn(
+      `[aiInterviewService] ⚠️ Evaluation failed after ${MAX_RETRIES} retries: ${err.message}`
+    );
+    console.warn("[aiInterviewService] Falling back to mock evaluation");
     return mockEvaluate(transcript, expectedAnswer, expectedConcepts);
   }
+};
 
-  return res.json();
+/**
+ * Get the current connection status of the Python AI service.
+ * Useful for health check endpoints and debugging.
+ *
+ * @returns {Promise<object>} Status info including url, available, and mock mode.
+ */
+export const getServiceStatus = async () => {
+  const available = await isServiceAvailable();
+  return {
+    url: AI_SERVICE_URL,
+    available,
+    mode: available ? "ai" : "mock",
+    timeouts: {
+      evaluation: EVAL_TIMEOUT,
+      transcription: TRANSCRIBE_TIMEOUT,
+    },
+  };
 };

--- a/server/src/modules/interviews/controller.js
+++ b/server/src/modules/interviews/controller.js
@@ -7,6 +7,7 @@ import {
   getSessionResults as getResults,
   listAvailableTopics,
 } from "./service.js";
+import { getServiceStatus } from "../../integrations/aiInterviewService.js";
 import asyncHandler from "../../utils/asyncHandler.js";
 import AppError from "../../utils/AppError.js";
 
@@ -156,5 +157,19 @@ export const getAvailableTopics = asyncHandler(async (req, res) => {
   res.status(200).json({
     success: true,
     data: topics,
+  });
+});
+
+/**
+ * @desc    Get AI service connection status
+ * @route   GET /api/interviews/ai-status
+ * @access  Private
+ */
+export const getAIServiceStatus = asyncHandler(async (req, res) => {
+  const status = await getServiceStatus();
+
+  res.status(200).json({
+    success: true,
+    data: status,
   });
 });

--- a/server/src/modules/interviews/routes.js
+++ b/server/src/modules/interviews/routes.js
@@ -1,4 +1,5 @@
 import express from "express";
+import multer from "multer";
 import { protect } from "../../middleware/authMiddleware.js";
 import {
   startInterview,
@@ -8,9 +9,33 @@ import {
   getInterviewHistory,
   getSessionResults,
   getAvailableTopics,
+  getAIServiceStatus,
 } from "./controller.js";
 
 const router = express.Router();
+
+// Multer config for audio uploads (max 10MB, memory storage)
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    const allowed = [
+      "audio/webm",
+      "audio/wav",
+      "audio/x-wav",
+      "audio/mpeg",
+      "audio/mp3",
+      "audio/ogg",
+      "audio/m4a",
+      "audio/mp4",
+    ];
+    if (allowed.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error(`Unsupported audio format: ${file.mimetype}`), false);
+    }
+  },
+});
 
 // All interview routes require authentication
 router.use(protect);
@@ -18,11 +43,14 @@ router.use(protect);
 // Topic discovery
 router.get("/topics", getAvailableTopics);
 
+// AI service status (for debugging)
+router.get("/ai-status", getAIServiceStatus);
+
 // Interview session flow
 router.post("/start", startInterview);
 router.get("/history", getInterviewHistory);
 router.get("/:id", getSession);
-router.post("/:id/answer", submitAnswer);
+router.post("/:id/answer", upload.single("audio"), submitAnswer);
 router.post("/:id/complete", completeInterview);
 router.get("/:id/results", getSessionResults);
 


### PR DESCRIPTION
## Summary

Hardens the Node.js ↔ Python AI service connection with retry logic, configurable timeouts, audio upload support, and a status endpoint. Makes the integration production-ready instead of a basic one-shot fetch. Ref: Discussion #237.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #341 

## Changes Made

### 1. Retry Logic (`aiInterviewService.js`)
- Added `fetchWithRetry()` — 3 attempts with exponential backoff (500ms → 1s → 2s)
- Non-retryable errors (400/422) fail immediately
- Falls back to mock scores only after all retries exhausted
- Request timing logs for performance monitoring (`[aiInterviewService] /api/evaluate responded in 230ms`)
- Mock responses tagged with `_mock: true` flag
- Added `getServiceStatus()` for checking Python service connectivity

### 2. Configurable Timeouts
- Evaluation timeout: 10s (via `INTERVIEW_AI_TIMEOUT`)
- Transcription timeout: 30s (via `INTERVIEW_AI_TRANSCRIBE_TIMEOUT`)
- Both configurable through environment variables

### 3. Audio Upload Support (`routes.js`)
- Added multer middleware on `POST /:id/answer` for audio file uploads
- Validates audio format: webm, wav, mp3, ogg, m4a
- Max file size: 10MB, memory storage
- Audio buffer forwarded to Python `/api/transcribe` endpoint

### 4. AI Status Endpoint (`controller.js`)
- Added `GET /api/interviews/ai-status` — returns Python service status
- Response includes: url, available, mode (ai/mock), timeout config
- Useful for debugging and frontend status indicators

### 5. Environment Config (`.env.example`)
- Added `INTERVIEW_AI_URL` (default: http://localhost:8000)
- Added `INTERVIEW_AI_TIMEOUT` (default: 10000ms)
- Added `INTERVIEW_AI_TRANSCRIBE_TIMEOUT` (default: 30000ms)

## Validation

- [x] Build passes locally
- [ ] Relevant tests added/updated
- [x] Documentation updated (if needed)

## Screenshots (if UI change)

N/A — backend changes only.
