### PR TITLE
Fix unauthorized public access to uploaded resumes and avatars

### DIFF
--- a/client/src/modules/profile/ProfilePage.jsx
+++ b/client/src/modules/profile/ProfilePage.jsx
@@ -29,6 +29,7 @@ import { useNavigate } from "react-router-dom";
 import { updateUserProfile, logout } from "../../features/auth/authSlice";
 import { updateProfile, deleteProfile, uploadAvatar, removeAvatar } from "./services/profileService";
 import LoadingState from "../../shared/components/LoadingState";
+import { getProtectedAssetUrl } from "../../utils/protectedAssetUrl";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -145,7 +146,7 @@ const DeleteModal = ({ onConfirm, onCancel, loading }) => (
 
 // ─── Avatar Editor ────────────────────────────────────────────────────────────
 
-const AvatarEditor = ({ user, roleConfig, onUpload, onRemove, uploading, isEditing }) => {
+const AvatarEditor = ({ user, roleConfig, onUpload, onRemove, uploading, isEditing, token }) => {
   const fileRef = useRef(null);
   const [preview, setPreview] = useState(null);
   const [pendingFile, setPendingFile] = useState(null);
@@ -194,7 +195,7 @@ const AvatarEditor = ({ user, roleConfig, onUpload, onRemove, uploading, isEditi
     onRemove();
   };
 
-  const displayPic = preview || user.profilePic;
+  const displayPic = preview || getProtectedAssetUrl(user.profilePic, token);
   const initials = getInitials(user.name || "");
   const hasPendingChange = Boolean(pendingFile);
 
@@ -555,6 +556,7 @@ const ProfilePage = () => {
                 onRemove={handleAvatarRemove}
                 uploading={avatarUploading}
                 isEditing={isEditing}
+                token={token}
               />
 
               {avatarError && (

--- a/client/src/shared/landing/Navbar.jsx
+++ b/client/src/shared/landing/Navbar.jsx
@@ -4,9 +4,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Home, FileText, LayoutDashboard, MessageSquare, LogIn, UserPlus, X, Menu, LogOut, User, ChevronDown, Briefcase, Moon, Sun, Sparkles } from 'lucide-react';
 import Button from './Button';
 import { logout } from '../../features/auth/authSlice';
+import { getProtectedAssetUrl } from '../../utils/protectedAssetUrl';
 
 const Navbar = () => {
-  const { isAuthenticated, user } = useSelector((state) => state.auth);
+  const { isAuthenticated, user, token } = useSelector((state) => state.auth);
+  const avatarSrc = user?.profilePic ? getProtectedAssetUrl(user.profilePic, token) : null;
   const dispatch = useDispatch();
   const navigate = useNavigate();
   
@@ -116,8 +118,8 @@ const Navbar = () => {
                 className="flex items-center gap-3 hover:bg-[var(--surface-hover)] p-2 rounded-xl transition-colors duration-200"
               >
                 <div className="w-9 h-9 rounded-full bg-[var(--surface-soft)] flex items-center justify-center text-[var(--primary)] font-bold border border-[var(--border)] overflow-hidden flex-shrink-0">
-                  {user?.profilePic
-                    ? <img src={user.profilePic} alt={user.name} className="w-full h-full object-cover" />
+                  {avatarSrc
+                    ? <img src={avatarSrc} alt={user.name} className="w-full h-full object-cover" />
                     : (user?.name?.charAt(0).toUpperCase() || <User size={18} />)
                   }
                 </div>
@@ -267,8 +269,8 @@ const Navbar = () => {
               <div className="flex flex-col gap-3">
                 <div className="flex items-center gap-3 px-2 mb-2">
                   <div className="w-10 h-10 rounded-full bg-[var(--surface-soft)] flex items-center justify-center text-[var(--primary)] font-bold border border-[var(--border)] overflow-hidden flex-shrink-0">
-                    {user?.profilePic
-                      ? <img src={user.profilePic} alt={user.name} className="w-full h-full object-cover" />
+                    {avatarSrc
+                      ? <img src={avatarSrc} alt={user.name} className="w-full h-full object-cover" />
                       : (user?.name?.charAt(0).toUpperCase() || <User size={20} />)
                     }
                   </div>

--- a/client/src/utils/protectedAssetUrl.js
+++ b/client/src/utils/protectedAssetUrl.js
@@ -1,0 +1,55 @@
+const TOKEN_KEY = "skillssphere.auth.token";
+
+const getApiBaseUrl = () => {
+  try {
+    const env = import.meta?.env;
+    return env?.VITE_API_URL || env?.VITE_API_BASE_URL || "http://localhost:5000";
+  } catch {
+    return "http://localhost:5000";
+  }
+};
+
+export const getAuthToken = () =>
+  localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY) || "";
+
+/**
+ * Turn stored asset URLs into authenticated download URLs.
+ * External URLs (e.g. Google profile photos) are returned unchanged.
+ */
+export const getProtectedAssetUrl = (url, token = getAuthToken()) => {
+  if (!url || typeof url !== "string") return url;
+  if (!token) return url;
+
+  // Skip third-party URLs
+  if (/^https?:\/\//i.test(url) && !url.includes("/uploads/") && !url.includes("/api/files/")) {
+    return url;
+  }
+
+  let apiPath = url;
+
+  // Legacy public static paths → protected API routes
+  if (url.includes("/uploads/avatars/")) {
+    const filename = url.split("/uploads/avatars/").pop()?.split("?")[0];
+    apiPath = `/api/files/avatars/${filename}`;
+  } else if (url.includes("/uploads/")) {
+    const filename = url.split("/uploads/").pop()?.split("?")[0];
+    apiPath = `/api/files/resumes/${filename}`;
+  } else if (url.startsWith("/api/files/")) {
+    apiPath = url.split("?")[0];
+  } else if (url.startsWith("http")) {
+    try {
+      const parsed = new URL(url);
+      if (parsed.pathname.startsWith("/api/files/")) {
+        apiPath = parsed.pathname;
+      }
+    } catch {
+      return url;
+    }
+  }
+
+  if (!apiPath.startsWith("/api/files/")) return url;
+
+  const base = getApiBaseUrl().replace(/\/$/, "");
+  const separator = apiPath.includes("?") ? "&" : "?";
+  return `${base}${apiPath}${separator}token=${encodeURIComponent(token)}`;
+};

--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,6 @@ dotenv.config();
 
 import http from "http";
 import { Server } from "socket.io";
-import path from "path";
 import connectDB from "./src/database/db.js";
 import authRoutes from "./src/modules/auth/routes.js";
 import resumeRoutes from "./src/modules/resumes/routes.js";
@@ -15,6 +14,7 @@ import dashboardRoutes from "./src/modules/dashboard/routes.js";
 import classroomRoutes from "./src/modules/classrooms/routes.js";
 import userRoutes from "./src/modules/users/routes.js";
 import interviewRoutes from "./src/modules/interviews/routes.js";
+import fileRoutes from "./src/modules/files/routes.js";
 import { initClassroomSockets } from "./src/modules/classrooms/socket.js";
 import globalErrorHandler from "./src/middleware/errorMiddleware.js";
 import { logEvaluatorConfig } from "./src/config/evaluatorConfig.js";
@@ -38,7 +38,7 @@ setIO(io);
 app.use(cors());
 
 app.use(express.json());
-app.use("/uploads", express.static(path.resolve("src", "uploads")));
+// Uploads are NOT served publicly — use /api/files/* with auth (see files/routes.js)
 
 await connectDB();
 logEvaluatorConfig();
@@ -82,6 +82,7 @@ app.use("/api/dashboard", dashboardRoutes);
 app.use("/api/classrooms", classroomRoutes);
 app.use("/api/users", userRoutes);
 app.use("/api/interviews", interviewRoutes);
+app.use("/api/files", fileRoutes);
 
 // Initialize Sockets
 initClassroomSockets(io);

--- a/server/src/middleware/fileAuthMiddleware.js
+++ b/server/src/middleware/fileAuthMiddleware.js
@@ -1,0 +1,43 @@
+import jwt from "jsonwebtoken";
+import User from "../database/models/User.js";
+import AppError from "../utils/AppError.js";
+import asyncHandler from "../utils/asyncHandler.js";
+
+/**
+ * Auth for file downloads. Accepts JWT via Authorization header OR ?token= query
+ * so <img src="..."> can load protected avatars without custom fetch logic.
+ */
+export const protectFileAccess = asyncHandler(async (req, res, next) => {
+  let token;
+
+  if (
+    req.headers.authorization &&
+    req.headers.authorization.startsWith("Bearer")
+  ) {
+    token = req.headers.authorization.split(" ")[1];
+  } else if (typeof req.query.token === "string" && req.query.token.trim()) {
+    token = req.query.token.trim();
+  }
+
+  if (!token) {
+    return next(
+      new AppError("You are not logged in! Please log in to get access.", 401)
+    );
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const currentUser = await User.findById(decoded.userId).select("-password");
+
+    if (!currentUser) {
+      return next(
+        new AppError("The user belonging to this token no longer exists.", 401)
+      );
+    }
+
+    req.user = currentUser;
+    next();
+  } catch {
+    return next(new AppError("Invalid token. Please log in again.", 401));
+  }
+});

--- a/server/src/modules/files/__tests__/uploadPaths.test.js
+++ b/server/src/modules/files/__tests__/uploadPaths.test.js
@@ -1,0 +1,23 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "path";
+import { resolveUploadPath } from "../../../utils/uploadPaths.js";
+
+describe("resolveUploadPath", () => {
+  it("rejects path traversal in filename", () => {
+    const result = resolveUploadPath("resumes", "../../../etc/passwd");
+    assert.equal(result, null);
+  });
+
+  it("returns safe basename for valid filenames", () => {
+    const result = resolveUploadPath("resumes", "resume-123.pdf");
+    assert.ok(result);
+    assert.equal(result.safeName, "resume-123.pdf");
+    assert.ok(result.absolutePath.endsWith("resume-123.pdf"));
+  });
+
+  it("rejects filenames containing path separators", () => {
+    const result = resolveUploadPath("avatars", "foo/../../secret.jpg");
+    assert.equal(result, null);
+  });
+});

--- a/server/src/modules/files/controller.js
+++ b/server/src/modules/files/controller.js
@@ -1,0 +1,86 @@
+import fs from "fs";
+import path from "path";
+import User from "../../database/models/User.js";
+import Resume from "../../database/models/Resume.js";
+import AppError from "../../utils/AppError.js";
+import asyncHandler from "../../utils/asyncHandler.js";
+import { resolveUploadPath } from "../../utils/uploadPaths.js";
+
+const sendFileIfExists = (res, absolutePath, filename) => {
+  if (!fs.existsSync(absolutePath)) {
+    return false;
+  }
+
+  const ext = path.extname(filename).toLowerCase();
+  const mimeByExt = {
+    ".pdf": "application/pdf",
+    ".doc": "application/msword",
+    ".docx":
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".txt": "text/plain",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+  };
+
+  res.setHeader("Content-Type", mimeByExt[ext] || "application/octet-stream");
+  res.setHeader("Cache-Control", "private, no-store");
+  res.sendFile(absolutePath);
+  return true;
+};
+
+/**
+ * @desc    Serve a resume file (owner only)
+ * @route   GET /api/files/resumes/:filename
+ */
+export const serveResume = asyncHandler(async (req, res, next) => {
+  const resolved = resolveUploadPath("resumes", req.params.filename);
+
+  if (!resolved) {
+    return next(new AppError("Invalid file path", 400));
+  }
+
+  const ownedResume = await Resume.findOne({
+    user: req.user._id,
+    $or: [
+      { "file.storedName": resolved.safeName },
+      { "file.path": { $regex: resolved.safeName } },
+    ],
+  }).select("_id");
+
+  if (!ownedResume) {
+    return next(
+      new AppError("You do not have permission to access this file", 403)
+    );
+  }
+
+  if (!sendFileIfExists(res, resolved.absolutePath, resolved.safeName)) {
+    return next(new AppError("File not found", 404));
+  }
+});
+
+/**
+ * @desc    Serve an avatar image (any authenticated user)
+ * @route   GET /api/files/avatars/:filename
+ */
+export const serveAvatar = asyncHandler(async (req, res, next) => {
+  const resolved = resolveUploadPath("avatars", req.params.filename);
+
+  if (!resolved) {
+    return next(new AppError("Invalid file path", 400));
+  }
+
+  const avatarOwner = await User.findOne({
+    profilePic: { $regex: resolved.safeName },
+  }).select("_id");
+
+  if (!avatarOwner) {
+    return next(new AppError("File not found", 404));
+  }
+
+  if (!sendFileIfExists(res, resolved.absolutePath, resolved.safeName)) {
+    return next(new AppError("File not found", 404));
+  }
+});

--- a/server/src/modules/files/routes.js
+++ b/server/src/modules/files/routes.js
@@ -1,0 +1,11 @@
+import express from "express";
+import { protectFileAccess } from "../../middleware/fileAuthMiddleware.js";
+import { serveResume, serveAvatar } from "./controller.js";
+
+const router = express.Router();
+
+// All file access requires authentication (header or ?token= for images)
+router.get("/resumes/:filename", protectFileAccess, serveResume);
+router.get("/avatars/:filename", protectFileAccess, serveAvatar);
+
+export default router;

--- a/server/src/modules/resumes/controller.js
+++ b/server/src/modules/resumes/controller.js
@@ -17,6 +17,7 @@ import {
 import * as resumeService from "./service.js";
 import AnalysisHistory from "../../database/models/AnalysisHistory.js";
 import { verifyLinks } from "../../utils/linkVerifier.js";
+import { buildResumeFileUrl } from "../../utils/uploadPaths.js";
 
 const defaultDependencies = {
   parseResume,
@@ -61,7 +62,7 @@ export const uploadResume = asyncHandler(async (req, res, next) => {
     file: {
       originalName: req.file.originalname,
       storedName: req.file.filename,
-      path: `/uploads/${req.file.filename}`,
+      path: buildResumeFileUrl(req.file.filename),
       size: `${(req.file.size / 1024).toFixed(2)} KB`,
       mimeType: req.file.mimetype,
     },

--- a/server/src/modules/users/controller.js
+++ b/server/src/modules/users/controller.js
@@ -3,6 +3,7 @@ import AppError from "../../utils/AppError.js";
 import asyncHandler from "../../utils/asyncHandler.js";
 import fs from "fs";
 import path from "path";
+import { buildAvatarFileUrl } from "../../utils/uploadPaths.js";
 
 /**
  * @desc    Update user profile details
@@ -44,7 +45,7 @@ export const uploadAvatar = asyncHandler(async (req, res, next) => {
   }
 
   const baseUrl = process.env.BACKEND_URL || `http://localhost:${process.env.PORT || 5000}`;
-  const profilePic = `${baseUrl}/uploads/avatars/${req.file.filename}`;
+  const profilePic = `${baseUrl}${buildAvatarFileUrl(req.file.filename)}`;
 
   const updatedUser = await User.findByIdAndUpdate(
     req.user._id,
@@ -73,7 +74,11 @@ export const removeAvatar = asyncHandler(async (req, res, next) => {
   if (!user) return next(new AppError("User not found", 404));
 
   // Delete file from disk if it's a local upload
-  if (user.profilePic && user.profilePic.includes("/uploads/avatars/")) {
+  if (
+    user.profilePic &&
+    (user.profilePic.includes("/uploads/avatars/") ||
+      user.profilePic.includes("/api/files/avatars/"))
+  ) {
     const filename = path.basename(user.profilePic);
     const filePath = path.join(process.cwd(), "src", "uploads", "avatars", filename);
     if (fs.existsSync(filePath)) fs.unlinkSync(filePath);

--- a/server/src/utils/uploadPaths.js
+++ b/server/src/utils/uploadPaths.js
@@ -1,0 +1,33 @@
+import path from "path";
+
+const UPLOADS_ROOT = path.join(process.cwd(), "src", "uploads");
+const AVATARS_DIR = path.join(UPLOADS_ROOT, "avatars");
+const RESUMES_DIR = UPLOADS_ROOT;
+
+/**
+ * Resolve a safe absolute path inside the uploads directory (blocks path traversal).
+ */
+export const resolveUploadPath = (subdir, filename) => {
+  if (
+    !filename ||
+    typeof filename !== "string" ||
+    filename.includes("..") ||
+    /[\\/]/.test(filename)
+  ) {
+    return null;
+  }
+
+  const safeName = path.basename(filename);
+  const baseDir = subdir === "avatars" ? AVATARS_DIR : RESUMES_DIR;
+  const absolutePath = path.resolve(baseDir, safeName);
+  const resolvedBase = path.resolve(baseDir);
+
+  if (!absolutePath.startsWith(resolvedBase + path.sep) && absolutePath !== resolvedBase) {
+    return null;
+  }
+
+  return { safeName, absolutePath };
+};
+
+export const buildAvatarFileUrl = (filename) => `/api/files/avatars/${filename}`;
+export const buildResumeFileUrl = (filename) => `/api/files/resumes/${filename}`;


### PR DESCRIPTION
This PR fixes a security issue where uploaded resumes and profile images were previously accessible through public /uploads/... URLs. Anyone who knew or guessed a file name could directly access private user files without authentication.

The public exposure has now been removed and file access is handled through protected API routes under /api/files/.... Authentication checks are now enforced before serving resumes or avatar images, which prevents unauthorized access to sensitive user data.
I verified that direct access to /uploads/... now returns Cannot GET, and protected routes correctly return authentication errors for unauthenticated users. Resume upload, resume analysis, and profile avatar functionality continue to work normally after the changes.
This improves overall application security by protecting user-uploaded assets from public exposure while preserving existing functionality.

I have also attached screenshots showing the protected route implementation, blocked public access, unauthorized access response, and successful functionality testing after the fix.
Closes #351

<img width="1678" height="664" alt="Screenshot 2026-05-16 201914" src="https://github.com/user-attachments/assets/167279ca-fea1-411f-acb6-c5d808f0fe4c" />
<img width="1919" height="1008" alt="Screenshot 2026-05-16 201344" src="https://github.com/user-attachments/assets/8660bed8-d0c4-49c8-a229-1acc8ed1cf9a" />
<img width="1919" height="1009" alt="Screenshot 2026-05-16 201312" src="https://github.com/user-attachments/assets/354e897d-e127-4a1d-ade5-8a15e3e93216" />

