### PR TITLE
feat: implement learning progress tracking and roadmap backend

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,7 @@ import connectDB from "./src/database/db.js";
 import authRoutes from "./src/modules/auth/routes.js";
 import resumeRoutes from "./src/modules/resumes/routes.js";
 import jobRoutes from "./src/modules/jobs/routes.js";
+import roadmapRoutes from "./src/modules/roadmap/routes.js";
 import matchingRoutes from "./src/modules/matching/routes.js";
 import dashboardRoutes from "./src/modules/dashboard/routes.js";
 import classroomRoutes from "./src/modules/classrooms/routes.js";
@@ -72,6 +73,7 @@ app.post("/api/chat", (req, res) => {
 app.use("/api/auth", authRoutes);
 app.use("/api/resume", resumeRoutes);
 app.use("/api/jobs", jobRoutes);
+app.use("/api/roadmap", roadmapRoutes);
 app.use("/api/matching", matchingRoutes);
 app.use("/api/dashboard", dashboardRoutes);
 app.use("/api/classrooms", classroomRoutes);

--- a/server/src/database/models/LearningProgress.js
+++ b/server/src/database/models/LearningProgress.js
@@ -1,0 +1,60 @@
+import mongoose from "mongoose";
+
+const topicProgressSchema = new mongoose.Schema({
+  topicName: {
+    type: String,
+    required: true,
+  },
+  status: {
+    type: String,
+    enum: ["not_started", "in_progress", "completed"],
+    default: "not_started",
+  },
+  completedAt: {
+    type: Date,
+  },
+  resources: [
+    {
+      title: String,
+      url: String,
+      type: { type: String, enum: ["video", "article", "documentation"] }
+    }
+  ]
+});
+
+const learningProgressSchema = new mongoose.Schema(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      unique: true,
+    },
+    targetRole: {
+      type: String,
+      required: true,
+    },
+    roadmap: [topicProgressSchema],
+    overallProgress: {
+      type: Number,
+      default: 0,
+    },
+  },
+  { timestamps: true }
+);
+
+// Middleware to calculate overall progress before saving
+learningProgressSchema.pre("save", function (next) {
+  if (this.roadmap && this.roadmap.length > 0) {
+    const completedCount = this.roadmap.filter(
+      (topic) => topic.status === "completed"
+    ).length;
+    this.overallProgress = Math.round((completedCount / this.roadmap.length) * 100);
+  } else {
+    this.overallProgress = 0;
+  }
+  next();
+});
+
+const LearningProgress = mongoose.model("LearningProgress", learningProgressSchema);
+export default LearningProgress;

--- a/server/src/modules/roadmap/controller.js
+++ b/server/src/modules/roadmap/controller.js
@@ -1,0 +1,103 @@
+import LearningProgress from "../../database/models/LearningProgress.js";
+import asyncHandler from "../../utils/asyncHandler.js";
+import AppError from "../../utils/AppError.js";
+
+/**
+ * Get the current user's learning progress and roadmap
+ */
+export const getMyProgress = asyncHandler(async (req, res) => {
+  const progress = await LearningProgress.findOne({ user: req.user._id });
+  
+  if (!progress) {
+    return res.status(200).json({
+      success: true,
+      data: null,
+      message: "No active roadmap found. Please generate one from your analysis."
+    });
+  }
+
+  res.status(200).json({
+    success: true,
+    data: progress
+  });
+});
+
+/**
+ * Generate or Update a roadmap based on analysis results
+ */
+export const syncRoadmap = asyncHandler(async (req, res) => {
+  const { targetRole, topics } = req.body;
+
+  if (!targetRole || !Array.isArray(topics)) {
+    throw new AppError("Target role and topics are required", 400);
+  }
+
+  let progress = await LearningProgress.findOne({ user: req.user._id });
+
+  const roadmapData = topics.map(topic => ({
+    topicName: topic,
+    status: "not_started"
+  }));
+
+  if (progress) {
+    // If roadmap exists, we merge (don't overwrite completed topics)
+    const existingTopics = new Map(progress.roadmap.map(t => [t.topicName, t]));
+    
+    progress.targetRole = targetRole;
+    progress.roadmap = topics.map(topicName => {
+      if (existingTopics.has(topicName)) {
+        return existingTopics.get(topicName);
+      }
+      return { topicName, status: "not_started" };
+    });
+  } else {
+    progress = new LearningProgress({
+      user: req.user._id,
+      targetRole,
+      roadmap: roadmapData
+    });
+  }
+
+  await progress.save();
+
+  res.status(201).json({
+    success: true,
+    message: "Roadmap synced successfully",
+    data: progress
+  });
+});
+
+/**
+ * Update the status of a specific topic in the roadmap
+ */
+export const updateTopicStatus = asyncHandler(async (req, res) => {
+  const { topicId, status } = req.body;
+
+  if (!["not_started", "in_progress", "completed"].includes(status)) {
+    throw new AppError("Invalid status value", 400);
+  }
+
+  const progress = await LearningProgress.findOne({ user: req.user._id });
+
+  if (!progress) {
+    throw new AppError("No active roadmap found", 404);
+  }
+
+  const topic = progress.roadmap.id(topicId);
+  if (!topic) {
+    throw new AppError("Topic not found in roadmap", 404);
+  }
+
+  topic.status = status;
+  if (status === "completed") {
+    topic.completedAt = Date.now();
+  }
+
+  await progress.save();
+
+  res.status(200).json({
+    success: true,
+    message: `Topic marked as ${status.replace("_", " ")}`,
+    data: progress
+  });
+});

--- a/server/src/modules/roadmap/routes.js
+++ b/server/src/modules/roadmap/routes.js
@@ -1,0 +1,14 @@
+import express from "express";
+import * as roadmapController from "./controller.js";
+import { protect } from "../../middleware/authMiddleware.js";
+
+const router = express.Router();
+
+// All roadmap routes are protected (require login)
+router.use(protect);
+
+router.get("/me", roadmapController.getMyProgress);
+router.post("/sync", roadmapController.syncRoadmap);
+router.patch("/update-topic", roadmapController.updateTopicStatus);
+
+export default router;


### PR DESCRIPTION


## Summary
Implements the core backend infrastructure for personalized learning roadmaps. It provides the logic to store skill topics, track completion statuses, and calculate overall job-readiness percentages based on student progress.

## Type of Change
- [x] Feature


## Related Issue
Closes #365 

## Changes Made
- Created the **`LearningProgress`** Mongoose model to store user-specific roadmaps and milestones.
- Implemented a **Roadmap Controller** with endpoints for syncing analysis results and updating topic statuses.
- Registered the new API routes at **`/api/roadmap`** in the main server entry point.
- Added pre-save middleware to automatically calculate overall progress percentages.

## Validation
- [x] Build passes locally


---

