### PR TITLE
feat: implement tutor live classroom session management API

### DIFF
--- a/server/src/database/models/ClassroomSession.js
+++ b/server/src/database/models/ClassroomSession.js
@@ -1,0 +1,56 @@
+import mongoose from "mongoose";
+
+const classroomSessionSchema = new mongoose.Schema(
+  {
+    roomId: {
+      type: String,
+      required: [true, "Room ID is required"],
+      unique: true,
+      index: true,
+    },
+
+    title: {
+      type: String,
+      required: [true, "Session title is required"],
+      trim: true,
+      maxlength: [100, "Session title cannot exceed 100 characters"],
+    },
+
+    subject: {
+      type: String,
+      trim: true,
+      maxlength: [100, "Subject cannot exceed 100 characters"],
+      default: "",
+    },
+
+    host: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: [true, "Host reference is required"],
+      index: true,
+    },
+
+    status: {
+      type: String,
+      enum: ["active", "ended"],
+      default: "active",
+      index: true,
+    },
+
+    maxParticipants: {
+      type: Number,
+      default: 30,
+      min: [2, "A session must allow at least 2 participants"],
+      max: [100, "A session cannot exceed 100 participants"],
+    },
+
+    endedAt: {
+      type: Date,
+      default: null,
+    },
+  },
+  { timestamps: true }
+);
+
+const ClassroomSession = mongoose.model("ClassroomSession", classroomSessionSchema);
+export default ClassroomSession;

--- a/server/src/modules/classrooms/controller.js
+++ b/server/src/modules/classrooms/controller.js
@@ -1,0 +1,67 @@
+import asyncHandler from "../../utils/asyncHandler.js";
+import * as classroomService from "./service.js";
+
+/**
+ * @desc    Create a new live classroom session
+ * @route   POST /api/classrooms/create
+ * @access  Private (Tutors only)
+ */
+export const createClassroomSession = asyncHandler(async (req, res, next) => {
+  const { title, subject, maxParticipants } = req.body;
+  const session = await classroomService.createSession(req.user._id, {
+    title,
+    subject,
+    maxParticipants,
+  });
+
+  res.status(201).json({
+    success: true,
+    message: "Classroom session created successfully",
+    data: session,
+  });
+});
+
+/**
+ * @desc    Get all classroom sessions created by the logged-in tutor
+ * @route   GET /api/classrooms/my-sessions
+ * @access  Private (Tutors only)
+ */
+export const getTutorClassroomSessions = asyncHandler(async (req, res, next) => {
+  const sessions = await classroomService.getTutorSessions(req.user._id);
+
+  res.status(200).json({
+    success: true,
+    data: sessions,
+  });
+});
+
+/**
+ * @desc    Get classroom session metadata by room ID
+ * @route   GET /api/classrooms/:roomId
+ * @access  Private (Students and Tutors)
+ */
+export const getClassroomSessionByRoomId = asyncHandler(async (req, res, next) => {
+  const { roomId } = req.params;
+  const session = await classroomService.getSessionByRoomId(roomId);
+
+  res.status(200).json({
+    success: true,
+    data: session,
+  });
+});
+
+/**
+ * @desc    End a live classroom session
+ * @route   PATCH /api/classrooms/:roomId/end
+ * @access  Private (Tutor host only)
+ */
+export const endClassroomSession = asyncHandler(async (req, res, next) => {
+  const { roomId } = req.params;
+  const session = await classroomService.endSession(roomId, req.user._id);
+
+  res.status(200).json({
+    success: true,
+    message: "Classroom session ended successfully",
+    data: session,
+  });
+});

--- a/server/src/modules/classrooms/routes.js
+++ b/server/src/modules/classrooms/routes.js
@@ -1,11 +1,98 @@
 import express from "express";
-import { v4 as uuidv4 } from "uuid";
+import { protect, authorizeRoles } from "../../middleware/authMiddleware.js";
+import {
+  createClassroomSession,
+  getTutorClassroomSessions,
+  getClassroomSessionByRoomId,
+  endClassroomSession,
+} from "./controller.js";
 
 const router = express.Router();
 
-router.post("/create", (req, res) => {
-  const roomId = uuidv4();
-  res.status(201).json({ success: true, roomId });
-});
+// Authenticate all routes
+router.use(protect);
+
+/**
+ * @openapi
+ * /api/classrooms/create:
+ *   post:
+ *     summary: Create a new live classroom session
+ *     tags: [Classrooms]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - title
+ *             properties:
+ *               title:
+ *                 type: string
+ *               subject:
+ *                 type: string
+ *               maxParticipants:
+ *                 type: number
+ *     responses:
+ *       201:
+ *         description: Classroom session created successfully
+ */
+router.post("/create", authorizeRoles("tutor"), createClassroomSession);
+
+/**
+ * @openapi
+ * /api/classrooms/my-sessions:
+ *   get:
+ *     summary: Get all classroom sessions created by the tutor
+ *     tags: [Classrooms]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Success
+ */
+router.get("/my-sessions", authorizeRoles("tutor"), getTutorClassroomSessions);
+
+/**
+ * @openapi
+ * /api/classrooms/{roomId}:
+ *   get:
+ *     summary: Get classroom session metadata by room ID
+ *     tags: [Classrooms]
+ *     parameters:
+ *       - in: path
+ *         name: roomId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Success
+ */
+router.get("/:roomId", getClassroomSessionByRoomId);
+
+/**
+ * @openapi
+ * /api/classrooms/{roomId}/end:
+ *   patch:
+ *     summary: End a live classroom session
+ *     tags: [Classrooms]
+ *     parameters:
+ *       - in: path
+ *         name: roomId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Classroom session ended successfully
+ */
+router.patch("/:roomId/end", authorizeRoles("tutor"), endClassroomSession);
 
 export default router;

--- a/server/src/modules/classrooms/service.js
+++ b/server/src/modules/classrooms/service.js
@@ -1,0 +1,84 @@
+import { v4 as uuidv4 } from "uuid";
+import ClassroomSession from "../../database/models/ClassroomSession.js";
+import AppError from "../../utils/AppError.js";
+
+/**
+ * Create a new live classroom session
+ * @param {string} hostId - User ID of the tutor/host
+ * @param {Object} sessionData - Title, subject, and optional participant limit
+ * @returns {Promise<Object>} The created session document
+ */
+export const createSession = async (hostId, { title, subject, maxParticipants }) => {
+  if (!title || !title.trim()) {
+    throw new AppError("Session title is required", 400);
+  }
+
+  const roomId = uuidv4();
+  const session = await ClassroomSession.create({
+    roomId,
+    title,
+    subject,
+    maxParticipants,
+    host: hostId,
+    status: "active",
+  });
+
+  return session;
+};
+
+/**
+ * Fetch all sessions hosted by a specific tutor
+ * @param {string} hostId - User ID of the tutor
+ * @returns {Promise<Array>} List of session documents
+ */
+export const getTutorSessions = async (hostId) => {
+  return await ClassroomSession.find({ host: hostId })
+    .sort({ createdAt: -1 })
+    .lean();
+};
+
+/**
+ * Retrieve session metadata by its public Room ID
+ * @param {string} roomId - UUID of the room
+ * @returns {Promise<Object>} The session document
+ */
+export const getSessionByRoomId = async (roomId) => {
+  const session = await ClassroomSession.findOne({ roomId })
+    .populate("host", "name profilePic role")
+    .lean();
+
+  if (!session) {
+    throw new AppError("Classroom session not found", 404);
+  }
+
+  return session;
+};
+
+/**
+ * End a live classroom session (host/tutor only)
+ * @param {string} roomId - UUID of the room
+ * @param {string} hostId - User ID of the requesting user
+ * @returns {Promise<Object>} The updated session document
+ */
+export const endSession = async (roomId, hostId) => {
+  const session = await ClassroomSession.findOne({ roomId });
+
+  if (!session) {
+    throw new AppError("Classroom session not found", 404);
+  }
+
+  // Authorize: Only the host/tutor who created the session can end it
+  if (session.host.toString() !== hostId.toString()) {
+    throw new AppError("You do not have permission to end this session", 403);
+  }
+
+  if (session.status === "ended") {
+    return session; // already ended
+  }
+
+  session.status = "ended";
+  session.endedAt = new Date();
+  await session.save();
+
+  return session;
+};


### PR DESCRIPTION

## Summary

Implemented a secure, fully-featured, and persistent backend architecture for Tutor live classroom sessions. This replaces the unprotected, ephemeral session generation with a complete Mongoose schema, full service layer CRUD actions, and role-guarded Express controllers. 

Additionally, this adds interactive REST APIs and OpenAPI (Swagger) specifications for classroom lifecycle management.

## Type of Change

- [x] Feature

## Related Issue

Closes #380 

## Changes Made

### 1. Database Model (`server/src/database/models/ClassroomSession.js`)
Created a new `ClassroomSession` schema with validations:
*   `roomId`: Unique index (UUIDv4) linking directly to live WebRTC signalling.
*   `title`: (Required) String, max 100 characters.
*   `subject`: String, max 100 characters.
*   `host`: ObjectId referencing the host `User` (index).
*   `status`: String enum (`"active"`, `"ended"`).
*   `maxParticipants`: Number (min 2, max 100, defaults to 30).
*   `endedAt`: Datetime stamp recorded when ended.

### 2. Created API Endpoints (`server/src/modules/classrooms/routes.js`)
All endpoints are secure and require a valid JWT token (`protect`).

| Method | Endpoint | Access Level | Description |
| :--- | :--- | :--- | :--- |
| **`POST`** | `/api/classrooms/create` | **Tutors Only** | Creates a new classroom session, persists it to MongoDB, and returns room details. |
| **`GET`** | `/api/classrooms/my-sessions` | **Tutors Only** | Lists all classroom sessions created by the authenticated tutor (newest first). |
| **`GET`** | `/api/classrooms/:roomId` | **All Roles** | Fetches active classroom session metadata (populating host name/avatar) before joining WebRTC. |
| **`PATCH`** | `/api/classrooms/:roomId/end` | **Host Tutor Only** | Ends an active session and sets `status` to `"ended"` after authorizing ownership. |

### 3. Business Service Layer (`server/src/modules/classrooms/service.js`)
*   `createSession`: Performs validations and instantiates active rooms.
*   `getTutorSessions`: Queries and returns history of hosted classrooms.
*   `getSessionByRoomId`: Resolves room metadata with full host populating.
*   `endSession`: Protects the socket lifecycle by validating that the requesting host matches the original creator of the session.

### 4. Controller Layer (`server/src/modules/classrooms/controller.js`)
*   Fully wrapped all Express endpoint handlers with `asyncHandler` to safely integrate with the global error handler middleware.

### 5. Swagger/OpenAPI Docs
*   Implemented fully-documented route decorators inside `routes.js` for seamless `/api-docs` testing.

## Validation

- [x] Build passes locally
- [x] Manual API validation complete (via Swagger & custom requests)
- [x] OpenAPI Swagger documentation updated and verified
```