### PR TITLE
security: apply rate limiting to resume upload and AI analysis endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ JWT_SECRET=replace_with_a_long_random_secret
 JWT_EXPIRES_IN=7d
 AUTH_LIMIT_WINDOW=900000
 AUTH_LIMIT_MAX=5
+RESUME_LIMIT_WINDOW=3600000
+RESUME_LIMIT_MAX=10
 
 # Frontend URL (used for OAuth callback redirect)
 FRONTEND_URL=http://localhost:5174

--- a/server/src/middleware/rateLimiter.js
+++ b/server/src/middleware/rateLimiter.js
@@ -37,3 +37,22 @@ export const jobCreationLimiter = rateLimit({
     res.status(429).json(options.message);
   }
 });
+
+/**
+ * Rate Limiter for Resume Uploads and Analysis
+ * Prevents API quota abuse and CPU starvation from excessive file processing
+ */
+export const resumeAnalysisLimiter = rateLimit({
+  windowMs: parseInt(process.env.RESUME_LIMIT_WINDOW) || 60 * 60 * 1000, // Default 1 hour
+  max: parseInt(process.env.RESUME_LIMIT_MAX) || 10, // Default 10 resume analyses per window
+  message: {
+    success: false,
+    message: "Too many resume analysis attempts. Please try again later.",
+    error: "RATE_LIMIT_EXCEEDED"
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res, next, options) => {
+    res.status(429).json(options.message);
+  }
+});

--- a/server/src/modules/resumes/routes.js
+++ b/server/src/modules/resumes/routes.js
@@ -7,7 +7,7 @@ import {
   getLatestResume,
   compareVersions
 } from "./controller.js";
-
+import { resumeAnalysisLimiter } from "../../middleware/rateLimiter.js";
 
 import { protect, authorizeRoles } from "../../middleware/authMiddleware.js";
 
@@ -35,7 +35,7 @@ const router = express.Router();
  *       200:
  *         description: Resume uploaded successfully
  */
-router.post("/upload", protect, authorizeRoles("student"), uploadResumeMiddleware, uploadResume);
+router.post("/upload", protect, authorizeRoles("student"), resumeAnalysisLimiter, uploadResumeMiddleware, uploadResume);
 
 /**
  * @openapi
@@ -62,7 +62,7 @@ router.post("/upload", protect, authorizeRoles("student"), uploadResumeMiddlewar
  *       200:
  *         description: Analysis complete
  */
-router.post("/analyze", protect, authorizeRoles("student"), uploadResumeMiddleware, analyzeResume);
+router.post("/analyze", protect, authorizeRoles("student"), resumeAnalysisLimiter, uploadResumeMiddleware, analyzeResume);
 
 /**
  * @openapi


### PR DESCRIPTION
## Summary

Implemented a dedicated rate-limiting middleware layer for the PDF resume upload and AI resume analysis endpoints to protect the server from Denial of Service (DoS), storage exhaustion, and Gemini API quota abuse.

## Type of Change


- [x] Bug fix / Security Patch


## Related Issue

Closes #384 

## Changes Made

### 1. Middleware Layer (`server/src/middleware/rateLimiter.js`)
*   Added `resumeAnalysisLimiter` limiting requests by client IP with clean `429 Too Many Requests` responses.
*   Configured defaults to **10 analyses/uploads per hour**.

### 2. Guarded Endpoints (`server/src/modules/resumes/routes.js`)
*   Guarded `POST /api/resume/upload` (combats server storage exhaustion).
*   Guarded `POST /api/resume/analyze` (combats CPU parsing starvation and external Gemini API quota depletion).

### 3. Environment Schemas (`.env` & `.env.example`)
*   Exposed configurable environment keys: `RESUME_LIMIT_WINDOW` (ms) and `RESUME_LIMIT_MAX` (count).

## Validation

- [x] Local server starts up and injects new rate-limit variables cleanly
- [x] Manually verified 429 response on consecutive local calls exceeding limit window
