### PR TITLE
Validate `jobSkills` in resume analysis (return 400 on invalid JSON)

### DIFF
--- a/docs/api/resume-analyze-contract.md
+++ b/docs/api/resume-analyze-contract.md
@@ -112,10 +112,10 @@ Notes for contract tests:
 - `keywordMatch` may be `{}` when no non-empty `jobDescription` is supplied or parsed resume text is unavailable.
 - `experienceMatch` is currently always an object from `experienceEvaluator`.
 - `evaluatorBreakdown` and `overallScore` are additive pipeline fields from the refactor; existing top-level fields remain unchanged for backward compatibility.
-- If `jobSkills` starts with `[` but is invalid JSON, the request can still succeed with this message:
+- If `jobSkills` is invalid JSON or not an array, the request returns `400` with this message:
 
 ```json
 {
-  "message": "Resume parsed and saved, but jobSkills JSON format is invalid"
+  "message": "jobSkills must be a valid JSON array"
 }
 ```

--- a/server/src/modules/resumes/__tests__/controller.analyze.test.js
+++ b/server/src/modules/resumes/__tests__/controller.analyze.test.js
@@ -142,6 +142,18 @@ test("analyze with jobDescription preserves legacy fields and includes evaluator
   assert.deepEqual(savedPayloads[0].evaluatorBreakdown, body.evaluatorBreakdown);
 });
 
+test("analyze rejects invalid jobSkills JSON", async () => {
+  stubControllerDependencies();
+
+  const { status, body } = await postAnalyze({
+    jobSkills: "foo",
+  });
+
+  assert.equal(status, 400);
+  assert.equal(body.success, false);
+  assert.equal(body.message, "jobSkills must be a valid JSON array");
+});
+
 test("analyze without jobDescription still works with empty optional evaluator fields", async () => {
   const savedPayloads = stubControllerDependencies();
 

--- a/server/src/modules/resumes/controller.js
+++ b/server/src/modules/resumes/controller.js
@@ -70,6 +70,27 @@ export const uploadResume = asyncHandler(async (req, res, next) => {
   });
 });
 
+const normalizeJobSkills = (rawSkills) => {
+  if (rawSkills === undefined || rawSkills === null || rawSkills === "") {
+    return [];
+  }
+
+  if (Array.isArray(rawSkills)) {
+    return rawSkills;
+  }
+
+  if (typeof rawSkills !== "string") {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawSkills);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
 export const analyzeResume = async (req, res) => {
   try {
     const file = req.file;
@@ -88,7 +109,13 @@ export const analyzeResume = async (req, res) => {
     console.timeEnd("ResumeParsing");
 
     // Parse job inputs
-    const jobSkills = JSON.parse(req.body.jobSkills || "[]");
+    const jobSkills = normalizeJobSkills(req.body.jobSkills);
+    if (jobSkills === null) {
+      return res.status(400).json({
+        success: false,
+        message: "jobSkills must be a valid JSON array",
+      });
+    }
     const jobDescription = req.body.jobDescription || "";
 
     // 🧠 RUN PIPELINE (ONLY LOGIC ENTRY)


### PR DESCRIPTION
## Summary
- Add safe parsing/validation for `jobSkills` in resume analysis.
- Return `400 Bad Request` with a clear message when `jobSkills` is invalid.
- Add test coverage for the invalid payload case.
- Update API contract note.

## Approach
`jobSkills` was parsed directly from request body; malformed JSON caused a `500` and broke the core analysis flow. This change makes the error user‑actionable and prevents server errors from bad input.

## Changes
- Normalize/validate `jobSkills` in resume analysis controller.
- New test for invalid `jobSkills`.
- Contract doc updated to reflect `400` response.

## Testing
-  Run (recommend: `cd server && npm test`).

## Notes
- No behavior change for valid `jobSkills` input.
- this PR closes issue #410 