### PR TITLE
Secure signed URLs for protected file access

### DIFF
--- a/client/src/modules/profile/ProfilePage.jsx
+++ b/client/src/modules/profile/ProfilePage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
 import ProfileSkeleton from "./components/ProfileSkeleton";
 import {
@@ -18,7 +18,7 @@ import {
   removeAvatar,
 } from "./services/profileService";
 import LoadingState from "../../shared/components/LoadingState";
-import { getProtectedAssetUrl } from "../../utils/protectedAssetUrl";
+import { getSignedFileUrl } from "../../services/fileService";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -96,7 +96,7 @@ const DeleteModal = ({ onConfirm, onCancel, loading }) => (
   </div>
 );
 
-const AvatarEditor = ({ user, roleConfig, onUpload, onRemove, uploading, isEditing, token }) => {
+const AvatarEditor = ({ user, roleConfig, onUpload, onRemove, uploading, isEditing, avatarSrc }) => {
   const fileRef = useRef(null);
   const [preview, setPreview] = useState(null);
   const [pendingFile, setPendingFile] = useState(null);
@@ -120,7 +120,7 @@ const AvatarEditor = ({ user, roleConfig, onUpload, onRemove, uploading, isEditi
     setTimeout(() => setJustSaved(false), 3000);
   };
 
-  const displayPic = preview || getProtectedAssetUrl(user.profilePic, token);
+  const displayPic = preview || avatarSrc;
   const initials = getInitials(user.name || "");
   const hasPending = Boolean(pendingFile);
 
@@ -197,8 +197,24 @@ const ProfilePage = () => {
   const [apiError, setApiError] = useState("");
   const [avatarUploading, setAvatarUploading] = useState(false);
   const [avatarError, setAvatarError] = useState("");
+  const [avatarSrc, setAvatarSrc] = useState(null);
 
   const roleConfig = ROLE_CONFIG[user?.role] ?? ROLE_CONFIG.student;
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (!user?.profilePic) {
+      setAvatarSrc(null);
+      return () => { isMounted = false; };
+    }
+
+    getSignedFileUrl(user.profilePic, token).then((url) => {
+      if (isMounted) setAvatarSrc(url);
+    });
+
+    return () => { isMounted = false; };
+  }, [user?.profilePic, token]);
 
   const handleAvatarUpload = async (file) => {
     setAvatarUploading(true);
@@ -348,7 +364,7 @@ const ProfilePage = () => {
                 onRemove={handleAvatarRemove}
                 uploading={avatarUploading}
                 isEditing={isEditing}
-                token={token}
+                avatarSrc={avatarSrc}
               />
               {avatarError && <p className="mt-2 text-xs text-red-500 dark:text-red-400">{avatarError}</p>}
               

--- a/client/src/services/fileService.js
+++ b/client/src/services/fileService.js
@@ -1,0 +1,22 @@
+import { apiRequest } from "./apiClient";
+import { resolveProtectedFilePath } from "../utils/protectedAssetUrl";
+
+export const getSignedFileUrl = async (url, token) => {
+  if (!url || typeof url !== "string") return url;
+
+  const filePath = resolveProtectedFilePath(url);
+  if (!filePath) return url;
+  if (!token) return url;
+
+  try {
+    const response = await apiRequest("/api/files/sign", {
+      method: "POST",
+      body: { path: filePath },
+      token,
+    });
+
+    return response.url || url;
+  } catch {
+    return url;
+  }
+};

--- a/client/src/shared/landing/Navbar.jsx
+++ b/client/src/shared/landing/Navbar.jsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Home, FileText, LayoutDashboard, MessageSquare, LogIn, UserPlus, X, Menu, LogOut, User, ChevronDown, Briefcase, Moon, Sun, Sparkles, Rocket, Video } from 'lucide-react';
 import Button from './Button';
 import { logout } from '../../features/auth/authSlice';
-import { getProtectedAssetUrl } from '../../utils/protectedAssetUrl';
+import { getSignedFileUrl } from '../../services/fileService';
 
 const getStoredTheme = () => {
   try {
@@ -24,7 +24,7 @@ const storeTheme = (theme) => {
 
 const Navbar = () => {
   const { isAuthenticated, user, token } = useSelector((state) => state.auth);
-  const avatarSrc = user?.profilePic ? getProtectedAssetUrl(user.profilePic, token) : null;
+  const [avatarSrc, setAvatarSrc] = useState(null);
   const dispatch = useDispatch();
   const navigate = useNavigate();
   
@@ -61,6 +61,21 @@ const Navbar = () => {
     root.classList.toggle('light', theme === 'light');
     storeTheme(theme);
   }, [theme]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (!user?.profilePic) {
+      setAvatarSrc(null);
+      return () => { isMounted = false; };
+    }
+
+    getSignedFileUrl(user.profilePic, token).then((url) => {
+      if (isMounted) setAvatarSrc(url);
+    });
+
+    return () => { isMounted = false; };
+  }, [user?.profilePic, token]);
 
   const toggleTheme = () => setTheme((current) => (current === 'dark' ? 'light' : 'dark'));
 

--- a/client/src/utils/protectedAssetUrl.js
+++ b/client/src/utils/protectedAssetUrl.js
@@ -1,28 +1,14 @@
 const TOKEN_KEY = "skillssphere.auth.token";
 
-const getApiBaseUrl = () => {
-  try {
-    const env = import.meta?.env;
-    return env?.VITE_API_URL || env?.VITE_API_BASE_URL || "http://localhost:5000";
-  } catch {
-    return "http://localhost:5000";
-  }
-};
-
 export const getAuthToken = () =>
   localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY) || "";
 
-/**
- * Turn stored asset URLs into authenticated download URLs.
- * External URLs (e.g. Google profile photos) are returned unchanged.
- */
-export const getProtectedAssetUrl = (url, token = getAuthToken()) => {
-  if (!url || typeof url !== "string") return url;
-  if (!token) return url;
+export const resolveProtectedFilePath = (url) => {
+  if (!url || typeof url !== "string") return null;
 
   // Skip third-party URLs
   if (/^https?:\/\//i.test(url) && !url.includes("/uploads/") && !url.includes("/api/files/")) {
-    return url;
+    return null;
   }
 
   let apiPath = url;
@@ -30,10 +16,10 @@ export const getProtectedAssetUrl = (url, token = getAuthToken()) => {
   // Legacy public static paths → protected API routes
   if (url.includes("/uploads/avatars/")) {
     const filename = url.split("/uploads/avatars/").pop()?.split("?")[0];
-    apiPath = `/api/files/avatars/${filename}`;
+    apiPath = filename ? `/api/files/avatars/${filename}` : url;
   } else if (url.includes("/uploads/")) {
     const filename = url.split("/uploads/").pop()?.split("?")[0];
-    apiPath = `/api/files/resumes/${filename}`;
+    apiPath = filename ? `/api/files/resumes/${filename}` : url;
   } else if (url.startsWith("/api/files/")) {
     apiPath = url.split("?")[0];
   } else if (url.startsWith("http")) {
@@ -43,13 +29,11 @@ export const getProtectedAssetUrl = (url, token = getAuthToken()) => {
         apiPath = parsed.pathname;
       }
     } catch {
-      return url;
+      return null;
     }
   }
 
-  if (!apiPath.startsWith("/api/files/")) return url;
+  if (!apiPath.startsWith("/api/files/")) return null;
 
-  const base = getApiBaseUrl().replace(/\/$/, "");
-  const separator = apiPath.includes("?") ? "&" : "?";
-  return `${base}${apiPath}${separator}token=${encodeURIComponent(token)}`;
+  return apiPath;
 };

--- a/docs/api/resume-analyze-contract.md
+++ b/docs/api/resume-analyze-contract.md
@@ -112,10 +112,10 @@ Notes for contract tests:
 - `keywordMatch` may be `{}` when no non-empty `jobDescription` is supplied or parsed resume text is unavailable.
 - `experienceMatch` is currently always an object from `experienceEvaluator`.
 - `evaluatorBreakdown` and `overallScore` are additive pipeline fields from the refactor; existing top-level fields remain unchanged for backward compatibility.
-- If `jobSkills` starts with `[` but is invalid JSON, the request can still succeed with this message:
+- If `jobSkills` is invalid JSON or not an array, the request returns `400` with this message:
 
 ```json
 {
-  "message": "Resume parsed and saved, but jobSkills JSON format is invalid"
+  "message": "jobSkills must be a valid JSON array"
 }
 ```

--- a/server/src/middleware/fileAuthMiddleware.js
+++ b/server/src/middleware/fileAuthMiddleware.js
@@ -2,21 +2,35 @@ import jwt from "jsonwebtoken";
 import User from "../database/models/User.js";
 import AppError from "../utils/AppError.js";
 import asyncHandler from "../utils/asyncHandler.js";
+import { verifySignedFileUrl } from "../utils/signedFileUrl.js";
 
 /**
- * Auth for file downloads. Accepts JWT via Authorization header OR ?token= query
+ * Auth for file downloads. Accepts JWT via Authorization header or a signed URL
  * so <img src="..."> can load protected avatars without custom fetch logic.
  */
 export const protectFileAccess = asyncHandler(async (req, res, next) => {
-  let token;
+  const requestPath = `${req.baseUrl}${req.path}`;
+  const { exp, sig, uid } = req.query;
 
+  if (exp && sig) {
+    const isValid = verifySignedFileUrl(requestPath, exp, sig, uid);
+    if (!isValid) {
+      return next(new AppError("Signed URL is invalid or expired.", 401));
+    }
+
+    if (uid) {
+      req.signedUserId = uid.toString();
+    }
+
+    return next();
+  }
+
+  let token;
   if (
     req.headers.authorization &&
     req.headers.authorization.startsWith("Bearer")
   ) {
     token = req.headers.authorization.split(" ")[1];
-  } else if (typeof req.query.token === "string" && req.query.token.trim()) {
-    token = req.query.token.trim();
   }
 
   if (!token) {

--- a/server/src/modules/files/controller.js
+++ b/server/src/modules/files/controller.js
@@ -5,6 +5,7 @@ import Resume from "../../database/models/Resume.js";
 import AppError from "../../utils/AppError.js";
 import asyncHandler from "../../utils/asyncHandler.js";
 import { resolveUploadPath } from "../../utils/uploadPaths.js";
+import { buildSignedFileUrl, normalizeProtectedFilePath } from "../../utils/signedFileUrl.js";
 
 const sendFileIfExists = (res, absolutePath, filename) => {
   if (!fs.existsSync(absolutePath)) {
@@ -42,8 +43,15 @@ export const serveResume = asyncHandler(async (req, res, next) => {
     return next(new AppError("Invalid file path", 400));
   }
 
+  const ownerId = req.user?._id?.toString() || req.signedUserId;
+  if (!ownerId) {
+    return next(
+      new AppError("You are not logged in! Please log in to get access.", 401)
+    );
+  }
+
   const ownedResume = await Resume.findOne({
-    user: req.user._id,
+    user: ownerId,
     $or: [
       { "file.storedName": resolved.safeName },
       { "file.path": { $regex: resolved.safeName } },
@@ -83,4 +91,51 @@ export const serveAvatar = asyncHandler(async (req, res, next) => {
   if (!sendFileIfExists(res, resolved.absolutePath, resolved.safeName)) {
     return next(new AppError("File not found", 404));
   }
+});
+
+/**
+ * @desc    Create a signed URL for protected file access
+ * @route   POST /api/files/sign
+ */
+export const createSignedFileUrl = asyncHandler(async (req, res, next) => {
+  const { path: rawPath, ttlSeconds } = req.body;
+  const filePath = normalizeProtectedFilePath(rawPath);
+
+  if (!filePath) {
+    return next(new AppError("Invalid file path", 400));
+  }
+
+  if (filePath.startsWith("/api/files/resumes/")) {
+    const filename = filePath.split("/api/files/resumes/").pop();
+    const ownedResume = await Resume.findOne({
+      user: req.user._id,
+      $or: [
+        { "file.storedName": filename },
+        { "file.path": { $regex: filename } },
+      ],
+    }).select("_id");
+
+    if (!ownedResume) {
+      return next(
+        new AppError("You do not have permission to access this file", 403)
+      );
+    }
+  }
+
+  const ttl = Number.isFinite(Number(ttlSeconds)) ? Number(ttlSeconds) : 300;
+  const expiresAt = Math.floor(Date.now() / 1000) + Math.max(ttl, 30);
+  const signedPath = buildSignedFileUrl({
+    path: filePath,
+    expiresAt,
+    extra: req.user._id.toString(),
+  });
+
+  const baseUrl =
+    process.env.BACKEND_URL || `${req.protocol}://${req.get("host")}`;
+
+  res.status(200).json({
+    success: true,
+    url: `${baseUrl}${signedPath}`,
+    expiresAt: expiresAt * 1000,
+  });
 });

--- a/server/src/modules/files/routes.js
+++ b/server/src/modules/files/routes.js
@@ -1,11 +1,15 @@
 import express from "express";
+import { protect } from "../../middleware/authMiddleware.js";
 import { protectFileAccess } from "../../middleware/fileAuthMiddleware.js";
-import { serveResume, serveAvatar } from "./controller.js";
+import { createSignedFileUrl, serveResume, serveAvatar } from "./controller.js";
 
 const router = express.Router();
 
-// All file access requires authentication (header or ?token= for images)
+// All file access requires auth headers or a signed URL
 router.get("/resumes/:filename", protectFileAccess, serveResume);
 router.get("/avatars/:filename", protectFileAccess, serveAvatar);
+
+// Signed URL generator for protected files
+router.post("/sign", protect, createSignedFileUrl);
 
 export default router;

--- a/server/src/modules/resumes/__tests__/controller.analyze.test.js
+++ b/server/src/modules/resumes/__tests__/controller.analyze.test.js
@@ -142,6 +142,18 @@ test("analyze with jobDescription preserves legacy fields and includes evaluator
   assert.deepEqual(savedPayloads[0].evaluatorBreakdown, body.evaluatorBreakdown);
 });
 
+test("analyze rejects invalid jobSkills JSON", async () => {
+  stubControllerDependencies();
+
+  const { status, body } = await postAnalyze({
+    jobSkills: "foo",
+  });
+
+  assert.equal(status, 400);
+  assert.equal(body.success, false);
+  assert.equal(body.message, "jobSkills must be a valid JSON array");
+});
+
 test("analyze without jobDescription still works with empty optional evaluator fields", async () => {
   const savedPayloads = stubControllerDependencies();
 

--- a/server/src/modules/resumes/controller.js
+++ b/server/src/modules/resumes/controller.js
@@ -70,6 +70,27 @@ export const uploadResume = asyncHandler(async (req, res, next) => {
   });
 });
 
+const normalizeJobSkills = (rawSkills) => {
+  if (rawSkills === undefined || rawSkills === null || rawSkills === "") {
+    return [];
+  }
+
+  if (Array.isArray(rawSkills)) {
+    return rawSkills;
+  }
+
+  if (typeof rawSkills !== "string") {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawSkills);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
 export const analyzeResume = async (req, res) => {
   try {
     const file = req.file;
@@ -88,7 +109,13 @@ export const analyzeResume = async (req, res) => {
     console.timeEnd("ResumeParsing");
 
     // Parse job inputs
-    const jobSkills = JSON.parse(req.body.jobSkills || "[]");
+    const jobSkills = normalizeJobSkills(req.body.jobSkills);
+    if (jobSkills === null) {
+      return res.status(400).json({
+        success: false,
+        message: "jobSkills must be a valid JSON array",
+      });
+    }
     const jobDescription = req.body.jobDescription || "";
 
     // 🧠 RUN PIPELINE (ONLY LOGIC ENTRY)

--- a/server/src/utils/__tests__/signedFileUrl.test.js
+++ b/server/src/utils/__tests__/signedFileUrl.test.js
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildSignedFileUrl,
+  normalizeProtectedFilePath,
+  verifySignedFileUrl,
+} from "../signedFileUrl.js";
+
+process.env.FILE_URL_SIGNING_SECRET = "test-signing-secret";
+
+test("normalizeProtectedFilePath handles legacy uploads", () => {
+  assert.equal(
+    normalizeProtectedFilePath("/uploads/avatars/avatar.png"),
+    "/api/files/avatars/avatar.png",
+  );
+  assert.equal(
+    normalizeProtectedFilePath("/uploads/resume.pdf"),
+    "/api/files/resumes/resume.pdf",
+  );
+});
+
+test("buildSignedFileUrl and verifySignedFileUrl accept valid signatures", () => {
+  const path = "/api/files/avatars/avatar.png";
+  const expiresAt = Math.floor(Date.now() / 1000) + 60;
+  const signed = buildSignedFileUrl({ path, expiresAt, extra: "user123" });
+  const params = new URL(`http://localhost${signed}`).searchParams;
+
+  assert.equal(
+    verifySignedFileUrl(path, params.get("exp"), params.get("sig"), params.get("uid")),
+    true,
+  );
+});
+
+test("verifySignedFileUrl rejects expired signatures", () => {
+  const path = "/api/files/avatars/avatar.png";
+  const expiresAt = Math.floor(Date.now() / 1000) - 10;
+  const signed = buildSignedFileUrl({ path, expiresAt, extra: "user123" });
+  const params = new URL(`http://localhost${signed}`).searchParams;
+
+  assert.equal(
+    verifySignedFileUrl(path, params.get("exp"), params.get("sig"), params.get("uid")),
+    false,
+  );
+});

--- a/server/src/utils/signedFileUrl.js
+++ b/server/src/utils/signedFileUrl.js
@@ -1,0 +1,72 @@
+import crypto from "crypto";
+
+const getSigningSecret = () =>
+  process.env.FILE_URL_SIGNING_SECRET || process.env.JWT_SECRET || "";
+
+const buildSignaturePayload = (path, expiresAt, extra = "") =>
+  `${extra ? `${path}.${extra}` : path}.${expiresAt}`;
+
+export const normalizeProtectedFilePath = (input) => {
+  if (!input || typeof input !== "string") return null;
+
+  let path = input;
+
+  if (input.startsWith("http://") || input.startsWith("https://")) {
+    try {
+      const parsed = new URL(input);
+      path = parsed.pathname;
+    } catch {
+      return null;
+    }
+  }
+
+  path = path.split("?")[0];
+
+  if (path.includes("/uploads/avatars/")) {
+    const filename = path.split("/uploads/avatars/").pop();
+    path = filename ? `/api/files/avatars/${filename}` : path;
+  } else if (path.includes("/uploads/")) {
+    const filename = path.split("/uploads/").pop();
+    path = filename ? `/api/files/resumes/${filename}` : path;
+  }
+
+  if (!/^\/api\/files\/(avatars|resumes)\/[^/]+$/.test(path)) {
+    return null;
+  }
+
+  return path;
+};
+
+export const buildSignedFileUrl = ({ path, expiresAt, extra = "" }) => {
+  const secret = getSigningSecret();
+  if (!secret) {
+    throw new Error("FILE_URL_SIGNING_SECRET is not configured");
+  }
+
+  const payload = buildSignaturePayload(path, expiresAt, extra);
+  const sig = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+  const separator = path.includes("?") ? "&" : "?";
+  const extraParam = extra ? `&uid=${encodeURIComponent(extra)}` : "";
+
+  return `${path}${separator}exp=${expiresAt}&sig=${sig}${extraParam}`;
+};
+
+export const verifySignedFileUrl = (path, expiresAt, sig, extra = "") => {
+  const secret = getSigningSecret();
+  if (!secret) return false;
+
+  if (typeof sig !== "string" || sig.length === 0) return false;
+
+  const exp = Number(expiresAt);
+  if (!Number.isFinite(exp) || exp <= 0) return false;
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (exp < nowSeconds) return false;
+
+  const payload = buildSignaturePayload(path, exp, extra);
+  const expected = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+
+  if (expected.length !== sig.length) return false;
+
+  return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(sig));
+};


### PR DESCRIPTION

## Summary
- Add signed URL support for protected files (avatars/resumes).
- Remove JWT-in-query usage from client asset URLs.
- Introduce a signed URL generator endpoint and verification utilities.
- Add unit tests for signed URL helpers.

## Approach
JWTs in URLs can leak via logs, referrers, browser history, and analytics. Signed URLs prevent token exposure and enable short‑lived, scoped file access.

## Changes
- Signed URL utilities + tests.
- File auth middleware accepts signed URLs and sets `signedUserId`.
- New `POST /api/files/sign` endpoint to generate signed URLs.
- Client resolves avatar URLs using the signed URL endpoint.

## Testing
- `cd server; npm test`  
 

## Notes
- Requires `FILE_URL_SIGNING_SECRET` (falls back to `JWT_SECRET` if unset).
- Signed URLs include `exp`, `sig`, and `uid` for validation.
- this PR closes #412 