### PR TITLE
fix : use crypto.randomInt() for secure OTP generation

### DIFF
--- a/server/src/modules/auth/service.js
+++ b/server/src/modules/auth/service.js
@@ -1,4 +1,5 @@
 import bcrypt from "bcryptjs";
+import crypto from "crypto";
 import jwt from "jsonwebtoken";
 import User from "../../database/models/User.js";
 import { OAuth2Client } from "google-auth-library";
@@ -33,7 +34,7 @@ const buildAuthToken = (user) => {
 
 // 🔢 Generate OTP
 const generateOTP = () => {
-  return Math.floor(100000 + Math.random() * 900000).toString();
+  return crypto.randomInt(100000, 999999).toString();
 };
 
 // 📝 Register user


### PR DESCRIPTION


**Summary:**  
Replaced `Math.random()` with `crypto.randomInt()` for cryptographically secure
OTP generation in the authentication service.

**Changes:**  
- Added `import crypto from "crypto"` 
- Changed `generateOTP()` to use `crypto.randomInt(100000, 999999)`

**Security Impact:**  
- OTPs now use cryptographically secure random generation
- No timing side-channels that could leak OTP values
- Follows security best practices for authentication tokens

Closes #414