### PR TITLE
fix: add IP-based rate limiting for OTP verification

### DIFF
--- a/server/src/middleware/rateLimiter.js
+++ b/server/src/middleware/rateLimiter.js
@@ -39,6 +39,25 @@ export const jobCreationLimiter = rateLimit({
 });
 
 /**
+ * Rate Limiter for OTP Verification
+ * Prevents distributed brute-force attacks on OTP codes
+ */
+export const otpRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5, // 5 OTP attempts per IP per window
+  message: {
+    success: false,
+    message: "Too many OTP attempts, please try again after 15 minutes",
+    error: "RATE_LIMIT_EXCEEDED"
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res, next, options) => {
+    res.status(429).json(options.message);
+  }
+});
+
+/**
  * Rate Limiter for Resume Uploads and Analysis
  * Prevents API quota abuse and CPU starvation from excessive file processing
  */

--- a/server/src/modules/auth/routes.js
+++ b/server/src/modules/auth/routes.js
@@ -1,6 +1,6 @@
 import express from "express";
 import { protect } from "../../middleware/authMiddleware.js";
-import { authRateLimiter } from "../../middleware/rateLimiter.js";
+import { authRateLimiter, otpRateLimiter } from "../../middleware/rateLimiter.js";
 import {
   buildGoogleAuthUrl,
   GOOGLE_OAUTH_NOT_CONFIGURED_MESSAGE,
@@ -104,7 +104,7 @@ router.get("/google/callback", googleOAuthCallback);
  *         description: User registered
  */
 router.post("/register", authRateLimiter, register);
-router.post("/verify-email", authRateLimiter, verifyEmail);
+router.post("/verify-email", otpRateLimiter, authRateLimiter, verifyEmail);
 router.post("/forgot-password", authRateLimiter, forgotPassword);
 router.post("/reset-password", authRateLimiter, resetPassword);
 router.post("/resend-otp", authRateLimiter, resendOTP);


### PR DESCRIPTION

**Summary:**  
Added dedicated OTP rate limiter with stricter IP-based limits to protect
against distributed brute-force attacks on the verify-email endpoint.

**Changes:**  
- Added `otpRateLimiter` with 5 attempts per 15 minutes per IP
- Applied to `/verify-email` route before `authRateLimiter`

**Impact:**  
- Blocks distributed brute-force attacks on OTP verification
- Prevents resource exhaustion from repeated verification attempts
- Clear error message when rate limit exceeded

Closes #417 