### PR TITLE
fix: delete previous avatar disk from disk on uploadAvatar (#406)

### DIFF
--- a/server/src/modules/users/controller.js
+++ b/server/src/modules/users/controller.js
@@ -44,6 +44,18 @@ export const uploadAvatar = asyncHandler(async (req, res, next) => {
     return next(new AppError("No image file provided", 400));
   }
 
+  // Delete the old avatar from disk if it was a local upload
+  const currentUser = await User.findById(req.user._id);
+  if (
+    currentUser?.profilePic &&
+    (currentUser.profilePic.includes("/uploads/avatars/") ||
+      currentUser.profilePic.includes("/api/files/avatars/"))
+  ) {
+    const oldFilename = path.basename(currentUser.profilePic.split("?")[0]);
+    const oldPath = path.join(process.cwd(), "src", "uploads", "avatars", oldFilename);
+    if (fs.existsSync(oldPath)) fs.unlinkSync(oldPath);
+  }
+
   const baseUrl = process.env.BACKEND_URL || `http://localhost:${process.env.PORT || 5000}`;
   const profilePic = `${baseUrl}${buildAvatarFileUrl(req.file.filename)}`;
 


### PR DESCRIPTION
## Summary
When a user uploads a new profile photo, the previous avatar file was left orphaned on disk. This fix fetches the current user before saving the new avatar and deletes the old local file if one exists.

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue
Closes #406

## Changes Made
- Fetched the current user at the start of `uploadAvatar` to retrieve their existing `profilePic`
- Added logic to delete the old avatar file from disk if it is a local upload (mirrors the existing logic in `removeAvatar`)

## Validation
- [x] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)
N/A — backend-only change.

Please assign the appropriate labels so that I could get gssoc points