### PR TITLE
fix: conflicting test frameworks and dead testing code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -162,7 +162,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -659,7 +658,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1014,7 +1014,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1511,19 +1510,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1882,67 +1868,6 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
-    "node_modules/mongoose/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/mongoose/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongoose/node_modules/gaxios": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongoose/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/mongoose/node_modules/mongodb": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
@@ -1994,52 +1919,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/mongoose/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongoose/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/mongoose/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
-    },
-    "node_modules/mongoose/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/mpath": {
       "version": "0.9.0",
@@ -2989,7 +2868,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -3059,7 +2937,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server/src/modules/jobs/__tests__/controller.test.js
+++ b/server/src/modules/jobs/__tests__/controller.test.js
@@ -1,9 +1,8 @@
-import { jest } from "@jest/globals";
-import * as jobController from "../controller.js";
-import * as jobService from "../service.js";
-
-// Mock the service layer so we only test controller logic
-jest.mock("../service.js");
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import { createJobPosting } from "../controller.js";
+import JobPosting from "../../../database/models/JobPosting.js";
+import AppError from "../../../utils/AppError.js";
 
 describe("Job Controller", () => {
   let req, res, next;
@@ -12,40 +11,205 @@ describe("Job Controller", () => {
     req = {
       body: {},
       params: {},
-      user: { _id: "user123" }
+      user: { _id: "user123" },
     };
     res = {
-      status: jest.fn().mockReturnThis(),
-      json: jest.fn()
+      status: mock.fn(() => res),
+      json: mock.fn(),
     };
-    next = jest.fn();
-    jest.clearAllMocks();
+    next = mock.fn();
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
   });
 
   describe("createJobPosting", () => {
-    it("should respond with 201 and created job", async () => {
-      req.body = { title: "Test Job", skills: ["JS"] };
-      
-      const mockCreatedJob = { _id: "job123", ...req.body, recruiter: req.user._id };
-      jobService.createJob.mockResolvedValue(mockCreatedJob);
-
-      await jobController.createJobPosting(req, res, next);
-
-      expect(jobService.createJob).toHaveBeenCalledWith(req.body, req.user._id);
-      expect(res.status).toHaveBeenCalledWith(201);
-      expect(res.json).toHaveBeenCalledWith({
-        success: true,
-        job: mockCreatedJob
-      });
+    const validBody = () => ({
+      title: "Software Engineer",
+      description: "We need a skilled software engineer to join our team",
+      skills: ["React", "Node.js"],
+      location: { city: "San Francisco", state: "CA" },
+      salary: { min: 100000, max: 150000 },
     });
 
-    it("should pass errors to next()", async () => {
-      const error = new Error("Database error");
-      jobService.createJob.mockRejectedValue(error);
+    it("should respond with 201 and created job", async () => {
+      const body = validBody();
+      req.body = body;
+      const mockCreatedJob = { _id: "job123", ...body, recruiter: req.user._id };
+      mock.method(JobPosting, "create", () => mockCreatedJob);
 
-      await jobController.createJobPosting(req, res, next);
+      await createJobPosting(req, res, next);
 
-      expect(next).toHaveBeenCalledWith(error);
+      assert.equal(JobPosting.create.mock.calls.length, 1);
+      const createArg = JobPosting.create.mock.calls[0].arguments[0];
+      assert.equal(createArg.title, body.title);
+      assert.equal(createArg.description, body.description);
+      assert.deepEqual(createArg.skills, body.skills);
+      assert.deepEqual(createArg.location, body.location);
+      assert.deepEqual(createArg.salary, body.salary);
+      assert.equal(createArg.status, "draft");
+      assert.equal(createArg.recruiter, req.user._id);
+      assert.equal(res.status.mock.calls.length, 1);
+      assert.equal(res.status.mock.calls[0].arguments[0], 201);
+      assert.equal(res.json.mock.calls.length, 1);
+      assert.equal(res.json.mock.calls[0].arguments[0].success, true);
+      assert.deepEqual(res.json.mock.calls[0].arguments[0].job, mockCreatedJob);
+    });
+
+    it("should throw AppError(400) when title is missing", async () => {
+      req.body = { ...validBody() };
+      delete req.body.title;
+
+      await createJobPosting(req, res, next);
+
+      assert.equal(next.mock.calls.length, 1);
+      const error = next.mock.calls[0].arguments[0];
+      assert.ok(error instanceof AppError);
+      assert.equal(error.statusCode, 400);
+      assert.ok(error.errors.title);
+    });
+
+    it("should throw AppError(400) when description is missing", async () => {
+      req.body = { ...validBody() };
+      delete req.body.description;
+
+      await createJobPosting(req, res, next);
+
+      assert.equal(next.mock.calls.length, 1);
+      const error = next.mock.calls[0].arguments[0];
+      assert.ok(error instanceof AppError);
+      assert.equal(error.statusCode, 400);
+      assert.ok(error.errors.description);
+    });
+
+    it("should throw AppError(400) when skills are missing", async () => {
+      req.body = { ...validBody() };
+      delete req.body.skills;
+
+      await createJobPosting(req, res, next);
+
+      assert.equal(next.mock.calls.length, 1);
+      const error = next.mock.calls[0].arguments[0];
+      assert.ok(error instanceof AppError);
+      assert.equal(error.statusCode, 400);
+      assert.ok(error.errors.skills);
+    });
+
+    it("should throw AppError(400) when skills array is empty", async () => {
+      req.body = { ...validBody() };
+      req.body.skills = [];
+
+      await createJobPosting(req, res, next);
+
+      assert.equal(next.mock.calls.length, 1);
+      const error = next.mock.calls[0].arguments[0];
+      assert.ok(error instanceof AppError);
+      assert.equal(error.statusCode, 400);
+      assert.ok(error.errors.skills);
+    });
+
+    it("should throw AppError(400) when location is missing", async () => {
+      req.body = { ...validBody() };
+      delete req.body.location;
+
+      await createJobPosting(req, res, next);
+
+      assert.equal(next.mock.calls.length, 1);
+      const error = next.mock.calls[0].arguments[0];
+      assert.ok(error instanceof AppError);
+      assert.equal(error.statusCode, 400);
+      assert.ok(error.errors.location);
+    });
+
+    it("should throw AppError(400) when location.city is missing", async () => {
+      req.body = { ...validBody() };
+      delete req.body.location.city;
+
+      await createJobPosting(req, res, next);
+
+      assert.equal(next.mock.calls.length, 1);
+      const error = next.mock.calls[0].arguments[0];
+      assert.ok(error instanceof AppError);
+      assert.equal(error.statusCode, 400);
+      assert.ok(error.errors["location.city"]);
+    });
+
+    it("should throw AppError(400) when location.state is missing", async () => {
+      req.body = { ...validBody() };
+      delete req.body.location.state;
+
+      await createJobPosting(req, res, next);
+
+      assert.equal(next.mock.calls.length, 1);
+      const error = next.mock.calls[0].arguments[0];
+      assert.ok(error instanceof AppError);
+      assert.equal(error.statusCode, 400);
+      assert.ok(error.errors["location.state"]);
+    });
+
+    it("should throw AppError(400) when salary is missing", async () => {
+      req.body = { ...validBody() };
+      delete req.body.salary;
+
+      await createJobPosting(req, res, next);
+
+      assert.equal(next.mock.calls.length, 1);
+      const error = next.mock.calls[0].arguments[0];
+      assert.ok(error instanceof AppError);
+      assert.equal(error.statusCode, 400);
+      assert.ok(error.errors.salary);
+    });
+
+    it("should throw AppError(400) when salary.min is missing", async () => {
+      req.body = { ...validBody() };
+      delete req.body.salary.min;
+
+      await createJobPosting(req, res, next);
+
+      assert.equal(next.mock.calls.length, 1);
+      const error = next.mock.calls[0].arguments[0];
+      assert.ok(error instanceof AppError);
+      assert.equal(error.statusCode, 400);
+      assert.ok(error.errors["salary.min"]);
+    });
+
+    it("should throw AppError(400) when salary.max is missing", async () => {
+      req.body = { ...validBody() };
+      delete req.body.salary.max;
+
+      await createJobPosting(req, res, next);
+
+      assert.equal(next.mock.calls.length, 1);
+      const error = next.mock.calls[0].arguments[0];
+      assert.ok(error instanceof AppError);
+      assert.equal(error.statusCode, 400);
+      assert.ok(error.errors["salary.max"]);
+    });
+
+    it("should throw AppError(400) when salary.min exceeds salary.max", async () => {
+      req.body = { ...validBody() };
+      req.body.salary.min = 200000;
+      req.body.salary.max = 100000;
+
+      await createJobPosting(req, res, next);
+
+      assert.equal(next.mock.calls.length, 1);
+      const error = next.mock.calls[0].arguments[0];
+      assert.ok(error instanceof AppError);
+      assert.equal(error.statusCode, 400);
+      assert.ok(error.errors["salary.max"]);
+    });
+
+    it("should pass non-validation errors to next()", async () => {
+      req.body = validBody();
+      const dbError = new Error("DB connection failed");
+      mock.method(JobPosting, "create", () => { throw dbError; });
+
+      await createJobPosting(req, res, next);
+
+      assert.equal(next.mock.calls.length, 1);
+      assert.equal(next.mock.calls[0].arguments[0], dbError);
     });
   });
 });

--- a/server/src/modules/jobs/__tests__/service.test.js
+++ b/server/src/modules/jobs/__tests__/service.test.js
@@ -1,35 +1,31 @@
-import { jest } from "@jest/globals";
+import { describe, it, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
 import * as jobService from "../service.js";
 import JobPosting from "../../../database/models/JobPosting.js";
 import JobApplication from "../../../database/models/JobApplication.js";
 import AppError from "../../../utils/AppError.js";
 
-// Mock the models
-jest.mock("../../../database/models/JobPosting.js");
-jest.mock("../../../database/models/JobApplication.js");
-jest.mock("../../resumes/service.js");
-jest.mock("../../matching/service.js");
-
 describe("Job Service", () => {
   afterEach(() => {
-    jest.clearAllMocks();
+    mock.restoreAll();
   });
 
   describe("createJob", () => {
     it("should successfully create a job posting", async () => {
       const mockJobData = { title: "Software Engineer", skills: ["React", "Node"] };
       const mockRecruiterId = "recruiter123";
-      
+
       const mockCreatedJob = { ...mockJobData, recruiter: mockRecruiterId, _id: "job123" };
-      JobPosting.create = jest.fn().mockResolvedValue(mockCreatedJob);
+      mock.method(JobPosting, "create", () => mockCreatedJob);
 
       const result = await jobService.createJob(mockJobData, mockRecruiterId);
 
-      expect(JobPosting.create).toHaveBeenCalledWith({
+      assert.equal(JobPosting.create.mock.calls.length, 1);
+      assert.deepEqual(JobPosting.create.mock.calls[0].arguments[0], {
         ...mockJobData,
         recruiter: mockRecruiterId,
       });
-      expect(result).toEqual(mockCreatedJob);
+      assert.deepEqual(result, mockCreatedJob);
     });
   });
 
@@ -42,33 +38,47 @@ describe("Job Service", () => {
       const mockExistingJob = { _id: mockJobId, recruiter: { toString: () => mockRecruiterId } };
       const mockUpdatedJob = { ...mockExistingJob, ...mockUpdateData };
 
-      JobPosting.findById = jest.fn().mockResolvedValue(mockExistingJob);
-      JobPosting.findByIdAndUpdate = jest.fn().mockResolvedValue(mockUpdatedJob);
+      mock.method(JobPosting, "findById", () => mockExistingJob);
+      mock.method(JobPosting, "findByIdAndUpdate", () => mockUpdatedJob);
 
       const result = await jobService.updateJob(mockJobId, mockUpdateData, mockRecruiterId);
 
-      expect(JobPosting.findById).toHaveBeenCalledWith(mockJobId);
-      expect(JobPosting.findByIdAndUpdate).toHaveBeenCalledWith(
+      assert.equal(JobPosting.findById.mock.calls.length, 1);
+      assert.equal(JobPosting.findById.mock.calls[0].arguments[0], mockJobId);
+      assert.equal(JobPosting.findByIdAndUpdate.mock.calls.length, 1);
+      assert.deepEqual(JobPosting.findByIdAndUpdate.mock.calls[0].arguments, [
         mockJobId,
         mockUpdateData,
         { new: true, runValidators: true }
-      );
-      expect(result).toEqual(mockUpdatedJob);
+      ]);
+      assert.deepEqual(result, mockUpdatedJob);
     });
 
     it("should throw AppError(404) if job not found", async () => {
-      JobPosting.findById = jest.fn().mockResolvedValue(null);
+      mock.method(JobPosting, "findById", () => null);
 
-      await expect(jobService.updateJob("invalidId", {}, "recruiter123")).rejects.toThrow(AppError);
-      await expect(jobService.updateJob("invalidId", {}, "recruiter123")).rejects.toMatchObject({ statusCode: 404 });
+      await assert.rejects(
+        () => jobService.updateJob("invalidId", {}, "recruiter123"),
+        (err) => {
+          assert.ok(err instanceof AppError);
+          assert.equal(err.statusCode, 404);
+          return true;
+        }
+      );
     });
 
     it("should throw AppError(403) if recruiter is not the owner", async () => {
       const mockExistingJob = { _id: "job123", recruiter: { toString: () => "differentRecruiter" } };
-      JobPosting.findById = jest.fn().mockResolvedValue(mockExistingJob);
+      mock.method(JobPosting, "findById", () => mockExistingJob);
 
-      await expect(jobService.updateJob("job123", {}, "recruiter123")).rejects.toThrow(AppError);
-      await expect(jobService.updateJob("job123", {}, "recruiter123")).rejects.toMatchObject({ statusCode: 403 });
+      await assert.rejects(
+        () => jobService.updateJob("job123", {}, "recruiter123"),
+        (err) => {
+          assert.ok(err instanceof AppError);
+          assert.equal(err.statusCode, 403);
+          return true;
+        }
+      );
     });
   });
 
@@ -78,16 +88,46 @@ describe("Job Service", () => {
       const mockRecruiterId = "recruiter123";
 
       const mockExistingJob = { _id: mockJobId, recruiter: { toString: () => mockRecruiterId } };
-      
-      JobPosting.findById = jest.fn().mockResolvedValue(mockExistingJob);
-      JobApplication.deleteMany = jest.fn().mockResolvedValue({ deletedCount: 5 });
-      JobPosting.findByIdAndDelete = jest.fn().mockResolvedValue(mockExistingJob);
+
+      mock.method(JobPosting, "findById", () => mockExistingJob);
+      mock.method(JobApplication, "deleteMany", () => ({ deletedCount: 5 }));
+      mock.method(JobPosting, "findByIdAndDelete", () => mockExistingJob);
 
       await jobService.deleteJob(mockJobId, mockRecruiterId);
 
-      expect(JobPosting.findById).toHaveBeenCalledWith(mockJobId);
-      expect(JobApplication.deleteMany).toHaveBeenCalledWith({ job: mockJobId });
-      expect(JobPosting.findByIdAndDelete).toHaveBeenCalledWith(mockJobId);
+      assert.equal(JobPosting.findById.mock.calls.length, 1);
+      assert.equal(JobPosting.findById.mock.calls[0].arguments[0], mockJobId);
+      assert.equal(JobApplication.deleteMany.mock.calls.length, 1);
+      assert.deepEqual(JobApplication.deleteMany.mock.calls[0].arguments, [{ job: mockJobId }]);
+      assert.equal(JobPosting.findByIdAndDelete.mock.calls.length, 1);
+      assert.equal(JobPosting.findByIdAndDelete.mock.calls[0].arguments[0], mockJobId);
+    });
+
+    it("should throw AppError(404) if job not found for deletion", async () => {
+      mock.method(JobPosting, "findById", () => null);
+
+      await assert.rejects(
+        () => jobService.deleteJob("invalidId", "recruiter123"),
+        (err) => {
+          assert.ok(err instanceof AppError);
+          assert.equal(err.statusCode, 404);
+          return true;
+        }
+      );
+    });
+
+    it("should throw AppError(403) if recruiter does not own the job for deletion", async () => {
+      const mockExistingJob = { _id: "job123", recruiter: { toString: () => "differentRecruiter" } };
+      mock.method(JobPosting, "findById", () => mockExistingJob);
+
+      await assert.rejects(
+        () => jobService.deleteJob("job123", "recruiter123"),
+        (err) => {
+          assert.ok(err instanceof AppError);
+          assert.equal(err.statusCode, 403);
+          return true;
+        }
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

- Migrate two test files in the jobs module from Jest to Node's built-in `node:test` runner, fixing a test framework conflict where Jest-based tests were silently skipped by `npm test`
- Also rewrote the controller test to match the actual implementation, and added missing edge-case coverage


## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #425 

## Changes Made

- `server/src/modules/jobs/__tests__/controller.test.js` - Rewritten from Jest (`@jest/globals`, `jest.mock`, `jest.fn`, `expect`) to `node:test` (`describe`/`it`/`mock`/`assert`). Test logic was also rewritten because the old test mocked `jobService.createJob` but the controller calls `JobPosting.create` directly. Now it tests actual behavior: success path, 6 validation edge cases (missing fields, empty array, salary min > max), and error propagation
- `server/src/modules/jobs/__tests__/service.test.js` - Migrated from Jest to `node:test`. Replaced `jest.mock` with `mock.method()` on imported modules, `jest.fn()` with `mock.fn()`, and `expect()` with `assert`. Added missing 404 and 403 error tests for `deleteJob` (previously only the happy path was covered)

## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated
- [ ] Documentation updated (if needed)