### PR TITLE
security: enforce membership validation on WebRTC signals and trust p…

### DIFF
--- a/client/src/modules/classrooms/pages/ClassroomRoom.jsx
+++ b/client/src/modules/classrooms/pages/ClassroomRoom.jsx
@@ -27,6 +27,7 @@ export default function ClassroomRoom() {
   const peersRef = useRef([]); // To keep track of peer connections inside callbacks
   const socketRef = useRef();
   const localStreamRef = useRef();
+  const activeSocketIdsRef = useRef(new Set());
 
   useEffect(() => {
     // Basic auth check
@@ -53,6 +54,7 @@ export default function ClassroomRoom() {
         s.on("room-participants", (participants) => {
           const peersArr = [];
           participants.forEach(p => {
+            activeSocketIdsRef.current.add(p.socketId);
             const peer = createPeer(p.socketId, s.id, stream, user);
             peersRef.current.push({
               peerId: p.socketId,
@@ -76,11 +78,19 @@ export default function ClassroomRoom() {
         // Handle incoming user (they just joined, they will initiate the call to us)
         s.on("user-joined", (payload) => {
           console.log("User joined", payload);
+          activeSocketIdsRef.current.add(payload.socketId);
           // We don't initiate here. We wait for their offer.
         });
 
         // Receiving an offer
         s.on("webrtc-offer", (payload) => {
+          // Security check: Verify that the caller is a registered participant in this room
+          if (!activeSocketIdsRef.current.has(payload.callerSocketId)) {
+            console.error(`Blocked unauthorized WebRTC stream injection from socket: ${payload.callerSocketId}`);
+            alert("Security Warning: Blocked an unauthorized stream injection attempt from outside this classroom.");
+            return;
+          }
+
           const peer = addPeer(payload.offer, payload.callerSocketId, stream, s);
           
           const newPeerObj = {
@@ -98,10 +108,27 @@ export default function ClassroomRoom() {
 
         // Receiving an answer
         s.on("webrtc-answer", (payload) => {
+          if (!activeSocketIdsRef.current.has(payload.answererSocketId)) {
+            console.error(`Blocked unauthorized WebRTC signaling answer from socket: ${payload.answererSocketId}`);
+            return;
+          }
           const item = peersRef.current.find(p => p.peerId === payload.answererSocketId);
           if (item) {
             item.peer.signal(payload.answer);
           }
+        });
+
+        // Socket security & error handling
+        s.on("unauthorized", (payload) => {
+          console.error("Socket unauthorized action:", payload);
+          alert(`Security Warning: ${payload.message || "Unauthorized action detected."}`);
+          navigate("/classrooms");
+        });
+
+        s.on("error", (payload) => {
+          console.error("Socket error:", payload);
+          alert(`Socket Error: ${payload.message || "An error occurred."}`);
+          navigate("/classrooms");
         });
 
         // Other socket events
@@ -114,6 +141,7 @@ export default function ClassroomRoom() {
         });
 
         s.on("user-left", ({ socketId }) => {
+          activeSocketIdsRef.current.delete(socketId);
           const item = peersRef.current.find(p => p.peerId === socketId);
           if (item) {
             item.peer.destroy();

--- a/server/index.js
+++ b/server/index.js
@@ -27,6 +27,7 @@ import swaggerSpec from './src/config/swaggerConfig.js';
 import { validateEnv } from './src/config/validateEnv.js';
 import analyticsRoutes from "./src/modules/analytics/routes.js";
 const app = express();
+app.set("trust proxy", 1);
 const PORT = process.env.PORT || 5000;
 
 validateEnv();

--- a/server/src/modules/classrooms/socket.js
+++ b/server/src/modules/classrooms/socket.js
@@ -1,43 +1,86 @@
+import ClassroomSession from "../../database/models/ClassroomSession.js";
+
 export function initClassroomSockets(io) {
   io.on("connection", (socket) => {
     console.log(`Socket connected: ${socket.id}`);
 
     // Join a specific room
-    socket.on("join-room", ({ roomId, user }) => {
-      socket.join(roomId);
-      
-      // Store user info in socket instance to easily retrieve later
-      socket.data = { roomId, user };
+    socket.on("join-room", async ({ roomId, user }) => {
+      try {
+        if (!roomId) {
+          socket.emit("unauthorized", { message: "Room ID is required" });
+          socket.disconnect(true);
+          return;
+        }
 
-      console.log(`User ${user.name} (${socket.id}) joined room ${roomId}`);
+        // Validate session in database
+        const session = await ClassroomSession.findOne({ roomId, status: "active" });
+        if (!session) {
+          socket.emit("unauthorized", { message: "Classroom session not found or has already ended" });
+          socket.disconnect(true);
+          return;
+        }
 
-      // Notify others in the room that a new user joined
-      socket.to(roomId).emit("user-joined", {
-        socketId: socket.id,
-        user
-      });
+        // Use authenticated user from middleware
+        const currentUser = socket.user || user;
+        if (!currentUser) {
+          socket.emit("unauthorized", { message: "User authentication required" });
+          socket.disconnect(true);
+          return;
+        }
 
-      // Get all clients currently in the room
-      const clients = io.sockets.adapter.rooms.get(roomId);
-      const participants = [];
-      if (clients) {
-        for (const clientId of clients) {
-          const clientSocket = io.sockets.sockets.get(clientId);
-          if (clientSocket && clientSocket.data.user) {
-            participants.push({
-              socketId: clientId,
-              user: clientSocket.data.user
-            });
+        socket.join(roomId);
+        
+        // Store validated user and roomId info in socket instance
+        socket.data = { 
+          roomId, 
+          user: { 
+            id: currentUser._id || currentUser.id, 
+            name: currentUser.name || currentUser.email,
+            role: currentUser.role
+          } 
+        };
+
+        console.log(`User ${socket.data.user.name} (${socket.id}) joined room ${roomId}`);
+
+        // Notify others in the room that a new user joined
+        socket.to(roomId).emit("user-joined", {
+          socketId: socket.id,
+          user: socket.data.user
+        });
+
+        // Get all clients currently in the room
+        const clients = io.sockets.adapter.rooms.get(roomId);
+        const participants = [];
+        if (clients) {
+          for (const clientId of clients) {
+            const clientSocket = io.sockets.sockets.get(clientId);
+            if (clientSocket && clientSocket.data?.user) {
+              participants.push({
+                socketId: clientId,
+                user: clientSocket.data.user
+              });
+            }
           }
         }
-      }
 
-      // Send the current participants list to the person who just joined
-      socket.emit("room-participants", participants);
+        // Send the current participants list to the person who just joined
+        socket.emit("room-participants", participants);
+      } catch (error) {
+        console.error("Error joining classroom room:", error);
+        socket.emit("error", { message: "Internal server error during join" });
+        socket.disconnect(true);
+      }
     });
 
     // Chat Message
     socket.on("chat-message", ({ roomId, message }) => {
+      // Validate that the socket is actually joined to this roomId
+      if (!socket.data || socket.data.roomId !== roomId) {
+        socket.emit("unauthorized", { message: "Cross-classroom action detected" });
+        return;
+      }
+
       socket.to(roomId).emit("chat-message", {
         sender: socket.data.user,
         message,
@@ -47,6 +90,12 @@ export function initClassroomSockets(io) {
 
     // Toggle Hand Raise
     socket.on("toggle-hand-raise", ({ roomId, isRaised }) => {
+      // Validate that the socket is actually joined to this roomId
+      if (!socket.data || socket.data.roomId !== roomId) {
+        socket.emit("unauthorized", { message: "Cross-classroom action detected" });
+        return;
+      }
+
       // Broadcast hand raise status to others
       socket.to(roomId).emit("hand-raise-toggled", {
         socketId: socket.id,
@@ -56,14 +105,38 @@ export function initClassroomSockets(io) {
 
     // WebRTC Signaling Events
     socket.on("webrtc-offer", ({ targetSocketId, offer, callerUser }) => {
+      // Validate that both sockets exist and are in the same room
+      if (!socket.data || !socket.data.roomId) {
+        socket.emit("unauthorized", { message: "You must join a room first" });
+        return;
+      }
+
+      const targetSocket = io.sockets.sockets.get(targetSocketId);
+      if (!targetSocket || !targetSocket.data || targetSocket.data.roomId !== socket.data.roomId) {
+        socket.emit("unauthorized", { message: "Target user is not in your classroom" });
+        return;
+      }
+
       socket.to(targetSocketId).emit("webrtc-offer", {
         callerSocketId: socket.id,
-        callerUser,
+        callerUser: socket.data.user,
         offer
       });
     });
 
     socket.on("webrtc-answer", ({ targetSocketId, answer }) => {
+      // Validate that both sockets exist and are in the same room
+      if (!socket.data || !socket.data.roomId) {
+        socket.emit("unauthorized", { message: "You must join a room first" });
+        return;
+      }
+
+      const targetSocket = io.sockets.sockets.get(targetSocketId);
+      if (!targetSocket || !targetSocket.data || targetSocket.data.roomId !== socket.data.roomId) {
+        socket.emit("unauthorized", { message: "Target user is not in your classroom" });
+        return;
+      }
+
       socket.to(targetSocketId).emit("webrtc-answer", {
         answererSocketId: socket.id,
         answer


### PR DESCRIPTION

## Summary

Enforces strict authorization, database verification, and cross-classroom validation checks for the real-time layer (Socket.io and WebRTC signals). Also configures the Express backend to trust proxy headers, preventing rate limiter bypasses in production environments.

## Type of Change


- [x] Bug fix
- [x] Refactor


## Related Issue

Closes #433

## Changes Made

- **Rate Limiter Fix:** Added `app.set('trust proxy', 1)` in `server/index.js` to correctly resolve client IPs when running behind a load balancer.
- **Socket Authorization Check:** Updated the backend `join-room` event to verify that the `roomId` exists and is active in the database before allowing connections.
- **Injection Protection:** Added room membership verification to `chat-message` and `toggle-hand-raise` events in `socket.js`.
- **WebRTC Spoofing Protection:** Added checks to ensure both signaling endpoints exist and share the same classroom room ID before forwarding WebRTC offers or answers.
- **Client-Side Validation:** Maintained a client-side registry of active participant socket IDs to automatically filter, ignore, and warn about unauthorized WebRTC stream injections.
- **Graceful Error Handling:** Implemented UI alerts and navigation redirection for socket `"unauthorized"` and `"error"` events.

## Validation

- [x] Build passes locally


