### PR TITLE
fix : added unit tests for socketIO.js utility

### DIFF
--- a/server/src/utils/__tests__/socketIO.test.js
+++ b/server/src/utils/__tests__/socketIO.test.js
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { setIO, getIO } from "../socketIO.js";
+
+test("socketIO - sets and gets the Socket.io Server instance correctly", () => {
+  // Initially undefined/null or unset
+  assert.equal(getIO(), undefined);
+
+  // Mock instance
+  const mockIOInstance = {
+    emit: () => "emitted",
+    on: () => "on"
+  };
+
+  setIO(mockIOInstance);
+
+  const retrieved = getIO();
+  assert.ok(retrieved);
+  assert.equal(retrieved, mockIOInstance);
+  assert.equal(retrieved.emit(), "emitted");
+});


### PR DESCRIPTION
Closes #473.

Summary of What Has Been Done:
Added unit tests to verify the set/get operations of Socket.io Server instance in the socketIO.js helper.

Changes Made:
1. Created Test Suite: Added server/src/utils/__tests__/socketIO.test.js validating getters and setters under mock socket instances.
2. Verified getters and setters:

```javascript
test("socketIO - sets and gets the Socket.io Server instance correctly", () => {
  setIO(mockIOInstance);
  assert.equal(getIO(), mockIOInstance);
});
```

Impact it Made:
* Application Integrity: Confirms standard reactive client communication components (whiteboards, coding editors) have unified access to socket.io servers.