### PR TITLE
fix : added sanitized resume upload filenames

### DIFF
--- a/server/src/middleware/__tests__/uploadResume.filename.test.js
+++ b/server/src/middleware/__tests__/uploadResume.filename.test.js
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildStoredFilename,
+  sanitizeResumeFilenameStem,
+} from "../uploadResume.js";
+
+test("sanitizeResumeFilenameStem strips traversal and unsafe punctuation", () => {
+  assert.equal(
+    sanitizeResumeFilenameStem("../../../../Jane Doe Resume (Final)!?.PDF"),
+    "Jane-Doe-Resume-Final"
+  );
+});
+
+test("sanitizeResumeFilenameStem removes diacritics and control characters", () => {
+  assert.equal(
+    sanitizeResumeFilenameStem("Ren\u00e9e\n\tSenior Resume.docx"),
+    "Renee-Senior-Resume"
+  );
+});
+
+test("sanitizeResumeFilenameStem falls back when the stem is empty", () => {
+  assert.equal(sanitizeResumeFilenameStem("....pdf"), "resume");
+  assert.equal(sanitizeResumeFilenameStem(""), "resume");
+});
+
+test("sanitizeResumeFilenameStem caps long names for portable filenames", () => {
+  const stem = sanitizeResumeFilenameStem(`${"a".repeat(120)}.pdf`);
+
+  assert.equal(stem.length, 80);
+  assert.match(stem, /^[a-zA-Z0-9._-]+$/);
+});
+
+test("buildStoredFilename preserves a safe stem and lowercases extension", () => {
+  const originalNow = Date.now;
+  Date.now = () => 1710000000000;
+
+  try {
+    assert.equal(
+      buildStoredFilename("../../../My Resume.PDF"),
+      "1710000000000-My-Resume.pdf"
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});

--- a/server/src/middleware/uploadResume.js
+++ b/server/src/middleware/uploadResume.js
@@ -49,9 +49,22 @@ export const removeUploadedFile = (filePath) => {
   }
 };
 
-const buildStoredFilename = (originalName) => {
-  const ext = path.extname(originalName);
-  const name = originalName.replace(ext, "").replace(/\s+/g, "-");
+export const sanitizeResumeFilenameStem = (originalName = "") => {
+  const { name } = path.parse(path.basename(originalName));
+  const safeName = name
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "")
+    .slice(0, 80);
+
+  return safeName || "resume";
+};
+
+export const buildStoredFilename = (originalName) => {
+  const ext = path.extname(originalName).toLowerCase();
+  const name = sanitizeResumeFilenameStem(originalName);
   return `${Date.now()}-${name}${ext}`;
 };
 


### PR DESCRIPTION
Closes #504.

Summary of What Has Been Done:
Hardened resume upload persistence by sanitizing client-provided filenames before writing validated files to disk.

Changes Made:
Updated server/src/middleware/uploadResume.js to export sanitizeResumeFilenameStem and buildStoredFilename. The filename builder now uses a basename-derived stem, removes diacritics, replaces unsafe characters with hyphens, trims leading punctuation, caps the stem at 80 characters, falls back to resume when needed, and lowercases the extension.

Core behavior:
```js
export const sanitizeResumeFilenameStem = (originalName = "") => {
  const { name } = path.parse(path.basename(originalName));
  const safeName = name
    .normalize("NFKD")
    .replace(/[̀-ͯ]/g, "")
    .replace(/[^a-zA-Z0-9._-]+/g, "-")
    .replace(/-+/g, "-")
    .replace(/^[-.]+|[-.]+$/g, "")
    .slice(0, 80);

  return safeName || "resume";
};
```

Added server/src/middleware/__tests__/uploadResume.filename.test.js with Node native tests covering traversal-like names, unsafe punctuation, diacritics, control characters, empty stems, long stems, and lowercased extensions.

Impact it Made:
This reduces filename-based path confusion, improves cross-platform filename safety, and gives regression coverage for the upload persistence boundary. Verification passed with:
```bash
node --test src/middleware/__tests__/uploadResume.filename.test.js
```
Result: 5 tests passed.