### PR TITLE
fix : added extension-preserving avatar uploads

### DIFF
--- a/server/src/middleware/__tests__/uploadAvatar.extension.test.js
+++ b/server/src/middleware/__tests__/uploadAvatar.extension.test.js
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getAvatarExtension } from "../uploadAvatar.js";
+
+test("getAvatarExtension maps accepted image MIME types to canonical extensions", () => {
+  assert.equal(getAvatarExtension("image/jpeg"), ".jpg");
+  assert.equal(getAvatarExtension("image/png"), ".png");
+  assert.equal(getAvatarExtension("image/webp"), ".webp");
+  assert.equal(getAvatarExtension("image/gif"), ".gif");
+});
+
+test("getAvatarExtension rejects unsupported or missing MIME types", () => {
+  assert.equal(getAvatarExtension("image/svg+xml"), null);
+  assert.equal(getAvatarExtension("application/octet-stream"), null);
+  assert.equal(getAvatarExtension(undefined), null);
+});

--- a/server/src/middleware/uploadAvatar.js
+++ b/server/src/middleware/uploadAvatar.js
@@ -4,21 +4,30 @@ import path from "path";
 
 const uploadDirectory = path.join(process.cwd(), "src", "uploads", "avatars");
 
+const avatarExtensionByMimeType = {
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+  "image/gif": ".gif",
+};
+
+export const getAvatarExtension = (mimetype) =>
+  avatarExtensionByMimeType[mimetype] || null;
+
 if (!fs.existsSync(uploadDirectory)) {
   fs.mkdirSync(uploadDirectory, { recursive: true });
 }
 
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, uploadDirectory),
-  filename: (req, _file, cb) => {
-    // One avatar per user — overwrite by using userId as filename
-    cb(null, `avatar-${req.user._id}.jpg`);
+  filename: (req, file, cb) => {
+    // One avatar per user per image type, with an extension that matches content.
+    cb(null, `avatar-${req.user._id}${getAvatarExtension(file.mimetype)}`);
   },
 });
 
 const fileFilter = (_req, file, cb) => {
-  const allowed = ["image/jpeg", "image/png", "image/webp", "image/gif"];
-  if (allowed.includes(file.mimetype)) {
+  if (getAvatarExtension(file.mimetype)) {
     cb(null, true);
   } else {
     const err = new Error("Only JPEG, PNG, WebP, or GIF images are allowed");


### PR DESCRIPTION
Closes #506.

Summary of What Has Been Done:
Updated avatar upload persistence so accepted PNG, WebP, GIF, and JPEG files keep a filename extension that matches their validated MIME type.

Changes Made:
Changed server/src/middleware/uploadAvatar.js to centralize accepted avatar MIME types in getAvatarExtension and use that helper in both file filtering and stored filename generation.

Core behavior:
```js
const avatarExtensionByMimeType = {
  "image/jpeg": ".jpg",
  "image/png": ".png",
  "image/webp": ".webp",
  "image/gif": ".gif",
};

export const getAvatarExtension = (mimetype) =>
  avatarExtensionByMimeType[mimetype] || null;
```

Added server/src/middleware/__tests__/uploadAvatar.extension.test.js using node:test and node:assert/strict to cover supported MIME mappings and unsupported MIME rejection.

Impact it Made:
Avatar file names now accurately reflect accepted image content, reducing metadata confusion during storage, serving, and browser rendering. Verification passed with:
```bash
node --test src/middleware/__tests__/uploadAvatar.extension.test.js
```
Result: 2 tests passed.