### PR TITLE
fix : added origin validation for protected asset URL resolution

### DIFF
--- a/client/src/utils/protectedAssetUrl.js
+++ b/client/src/utils/protectedAssetUrl.js
@@ -3,34 +3,56 @@ const TOKEN_KEY = "skillssphere.auth.token";
 export const getAuthToken = () =>
   localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY) || "";
 
+const getTrustedAssetOrigins = () => {
+  const origins = new Set();
+
+  if (typeof window !== "undefined" && window.location?.origin) {
+    origins.add(window.location.origin);
+  }
+
+  const apiUrl = import.meta.env?.VITE_API_URL;
+  if (apiUrl) {
+    try {
+      origins.add(new URL(apiUrl).origin);
+    } catch {
+      // Ignore invalid build-time API URL values.
+    }
+  }
+
+  return origins;
+};
+
+export const isTrustedProtectedAssetOrigin = (url) => {
+  const parsedUrl = url instanceof URL ? url : new URL(url);
+  return getTrustedAssetOrigins().has(parsedUrl.origin);
+};
+
 export const resolveProtectedFilePath = (url) => {
   if (!url || typeof url !== "string") return null;
 
-  // Skip third-party URLs
-  if (/^https?:\/\//i.test(url) && !url.includes("/uploads/") && !url.includes("/api/files/")) {
-    return null;
-  }
+  let candidateUrl = url;
 
-  let apiPath = url;
-
-  // Legacy public static paths → protected API routes
-  if (url.includes("/uploads/avatars/")) {
-    const filename = url.split("/uploads/avatars/").pop()?.split("?")[0];
-    apiPath = filename ? `/api/files/avatars/${filename}` : url;
-  } else if (url.includes("/uploads/")) {
-    const filename = url.split("/uploads/").pop()?.split("?")[0];
-    apiPath = filename ? `/api/files/resumes/${filename}` : url;
-  } else if (url.startsWith("/api/files/")) {
-    apiPath = url.split("?")[0];
-  } else if (url.startsWith("http")) {
+  if (/^https?:\/\//i.test(url)) {
     try {
       const parsed = new URL(url);
-      if (parsed.pathname.startsWith("/api/files/")) {
-        apiPath = parsed.pathname;
-      }
+      if (!isTrustedProtectedAssetOrigin(parsed)) return null;
+      candidateUrl = parsed.pathname;
     } catch {
       return null;
     }
+  }
+
+  let apiPath = candidateUrl;
+
+  // Legacy public static paths → protected API routes
+  if (candidateUrl.includes("/uploads/avatars/")) {
+    const filename = candidateUrl.split("/uploads/avatars/").pop()?.split("?")[0];
+    apiPath = filename ? `/api/files/avatars/${filename}` : candidateUrl;
+  } else if (candidateUrl.includes("/uploads/")) {
+    const filename = candidateUrl.split("/uploads/").pop()?.split("?")[0];
+    apiPath = filename ? `/api/files/resumes/${filename}` : candidateUrl;
+  } else if (candidateUrl.startsWith("/api/files/")) {
+    apiPath = candidateUrl.split("?")[0];
   }
 
   if (!apiPath.startsWith("/api/files/")) return null;

--- a/client/src/utils/protectedAssetUrl.test.js
+++ b/client/src/utils/protectedAssetUrl.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isTrustedProtectedAssetOrigin,
+  resolveProtectedFilePath,
+} from "./protectedAssetUrl";
+
+describe("resolveProtectedFilePath", () => {
+  it("keeps relative protected API paths", () => {
+    expect(resolveProtectedFilePath("/api/files/resumes/resume.pdf?download=1")).toBe(
+      "/api/files/resumes/resume.pdf"
+    );
+  });
+
+  it("maps relative legacy upload paths to protected API routes", () => {
+    expect(resolveProtectedFilePath("/uploads/avatars/avatar-user.png")).toBe(
+      "/api/files/avatars/avatar-user.png"
+    );
+    expect(resolveProtectedFilePath("/uploads/resume.pdf")).toBe(
+      "/api/files/resumes/resume.pdf"
+    );
+  });
+
+  it("rejects third-party URLs that contain protected file path segments", () => {
+    expect(resolveProtectedFilePath("https://evil.example/uploads/resume.pdf")).toBeNull();
+    expect(resolveProtectedFilePath("https://evil.example/api/files/resumes/resume.pdf")).toBeNull();
+  });
+
+  it("accepts same-origin absolute protected file URLs", () => {
+    expect(
+      resolveProtectedFilePath(`${window.location.origin}/api/files/avatars/avatar.png`)
+    ).toBe("/api/files/avatars/avatar.png");
+  });
+});
+
+describe("isTrustedProtectedAssetOrigin", () => {
+  it("trusts the browser origin", () => {
+    expect(isTrustedProtectedAssetOrigin(`${window.location.origin}/api/files/resumes/a.pdf`)).toBe(
+      true
+    );
+  });
+
+  it("does not trust unrelated origins", () => {
+    expect(isTrustedProtectedAssetOrigin("https://cdn.example/api/files/resumes/a.pdf")).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
Closes #508.

Summary of What Has Been Done:
Hardened protected asset URL resolution so absolute external URLs are rejected before any /uploads or /api/files path normalization occurs.

Changes Made:
Updated client/src/utils/protectedAssetUrl.js to parse absolute HTTP and HTTPS URLs first, verify their origin against trusted application origins, and normalize only the trusted pathname.

Core behavior:
```js
export const isTrustedProtectedAssetOrigin = (url) => {
  const parsedUrl = url instanceof URL ? url : new URL(url);
  return getTrustedAssetOrigins().has(parsedUrl.origin);
};
```

Added client/src/utils/protectedAssetUrl.test.js with Vitest coverage for relative protected routes, legacy upload conversion, third-party URL rejection, and same-origin absolute URL acceptance.

Impact it Made:
This prevents third-party URLs from being treated as authenticated local protected assets and keeps asset access resolution scoped to trusted origins. Verification passed with:
```bash
npm run test:run -- src/utils/protectedAssetUrl.test.js
```
Result: 6 tests passed.