### PR TITLE
fix : added token-boundary skill extraction for resume parsing

### DIFF
--- a/server/src/utils/__tests__/parseResume.skills.test.js
+++ b/server/src/utils/__tests__/parseResume.skills.test.js
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { hasSkillToken, parseResume } from "../parseResume.js";
+
+test("hasSkillToken matches standalone technical skills", () => {
+  assert.equal(hasSkillToken("Built dashboards with React and Node.js.", "react"), true);
+  assert.equal(hasSkillToken("Built dashboards with React and Node.js.", "node.js"), true);
+});
+
+test("hasSkillToken ignores embedded word false positives", () => {
+  assert.equal(hasSkillToken("Built reactive user interfaces.", "react"), false);
+  assert.equal(hasSkillToken("Experience with JavaScript applications.", "java"), false);
+});
+
+test("parseResume extracts standalone skills from TXT content without embedded false positives", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "resume-skills-"));
+  const resumePath = path.join(tempDir, "resume.txt");
+
+  await fs.writeFile(
+    resumePath,
+    [
+      "Jane Candidate",
+      "jane@example.com",
+      "Skills",
+      "React, Node.js, JavaScript",
+      "Summary",
+      "Builds reactive interfaces and JVM-adjacent tooling.",
+    ].join("\n"),
+    "utf8"
+  );
+
+  try {
+    const parsed = await parseResume(resumePath);
+
+    assert.ok(parsed.skills.includes("react"));
+    assert.ok(parsed.skills.includes("node.js"));
+    assert.ok(parsed.skills.includes("javascript"));
+    assert.equal(parsed.skills.includes("java"), false);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/server/src/utils/parseResume.js
+++ b/server/src/utils/parseResume.js
@@ -42,6 +42,17 @@ const isLikelyPortfolioUrl = (url) => {
 
 const toUniqueList = (items) => [...new Set(items.filter(Boolean).map((item) => item.trim()))];
 
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export const hasSkillToken = (text, skill) => {
+  if (!text || !skill) return false;
+  const regex = new RegExp(
+    `(^|[^a-zA-Z0-9])${escapeRegex(skill)}(?=$|[^a-zA-Z0-9])`,
+    "i"
+  );
+  return regex.test(text);
+};
+
 const extractSectionLines = (lines, headerKeys) => {
   const startIndex = lines.findIndex((line) => {
     const normalized = line.trim().toLowerCase();
@@ -80,8 +91,7 @@ const extractName = (lines) => {
 };
 
 const extractSkills = (text) => {
-  const lowerText = text.toLowerCase();
-  return skillKeywords.filter((skill) => lowerText.includes(skill.toLowerCase()));
+  return skillKeywords.filter((skill) => hasSkillToken(text, skill));
 };
 
 export const parseResume = async (filePath) => {


### PR DESCRIPTION
Closes #510.

Summary of What Has Been Done:
Improved resume skill extraction so skills are matched as standalone technical tokens rather than raw substrings.

Changes Made:
Updated server/src/utils/parseResume.js with escaped regex token matching through hasSkillToken, then routed extractSkills through that helper.

Core behavior:
```js
export const hasSkillToken = (text, skill) => {
  if (!text || !skill) return false;
  const regex = new RegExp(
    `(^|[^a-zA-Z0-9])${escapeRegex(skill)}(?=$|[^a-zA-Z0-9])`,
    "i"
  );
  return regex.test(text);
};
```

Added server/src/utils/__tests__/parseResume.skills.test.js using node:test and node:assert/strict. The tests verify standalone React and Node.js detection, prevent embedded matches such as reactive and JavaScript triggering React or Java, and parse a TXT resume fixture end to end.

Impact it Made:
Resume analysis now avoids inflated skill matches from embedded words, making downstream scoring, job matching, and recommendations more reliable. Verification passed with:
```bash
node --test src/utils/__tests__/parseResume.skills.test.js
```
Result: 3 tests passed.