### PR TITLE
fix : added special-character safe skill matching for job description parsing

### DIFF
--- a/server/src/utils/__tests__/parseJD.skills.test.js
+++ b/server/src/utils/__tests__/parseJD.skills.test.js
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { extractDataFromJD, hasSkillToken } from "../parseJD.js";
+
+test("hasSkillToken matches punctuation-heavy technical skills", () => {
+  assert.equal(hasSkillToken("Experience with Node.js, Express, and C#.", "node.js"), true);
+  assert.equal(hasSkillToken("Experience with Node.js, Express, and C#.", "c#"), true);
+});
+
+test("hasSkillToken rejects embedded word matches", () => {
+  assert.equal(hasSkillToken("Build reactive interfaces.", "react"), false);
+  assert.equal(hasSkillToken("JavaScript experience required.", "java"), false);
+});
+
+test("extractDataFromJD extracts special-character skills", () => {
+  const result = extractDataFromJD(
+    "We need 3-5 years of experience with Node.js, Express, C#, and JavaScript."
+  );
+
+  assert.ok(result.skills.includes("node.js"));
+  assert.ok(result.skills.includes("express"));
+  assert.ok(result.skills.includes("c#"));
+  assert.ok(result.skills.includes("javascript"));
+  assert.equal(result.skills.includes("java"), false);
+  assert.equal(result.yearsOfExperience > 0, true);
+});

--- a/server/src/utils/parseJD.js
+++ b/server/src/utils/parseJD.js
@@ -4,6 +4,17 @@ const techKeywords = require("../../../ai-ml/data/techKeywords.json");
 
 const skillKeywords = Object.values(techKeywords).flat();
 
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export const hasSkillToken = (text, skill) => {
+  if (!text || !skill) return false;
+  const regex = new RegExp(
+    `(^|[^a-zA-Z0-9])${escapeRegex(skill)}(?=$|[^a-zA-Z0-9])`,
+    "i"
+  );
+  return regex.test(text);
+};
+
 /**
  * Extracts skills and years of experience from raw job description text.
  * @param {string} jdText - The raw job description text.
@@ -17,10 +28,7 @@ export const extractDataFromJD = (jdText) => {
   // 1. Extract Skills
   const extractedSkills = [];
   skillKeywords.forEach(skill => {
-    // Escape special characters in skill (like . in node.js)
-    const escapedSkill = skill.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const regex = new RegExp(`\\b${escapedSkill}\\b`, "gi");
-    if (regex.test(normalizedJD)) {
+    if (hasSkillToken(normalizedJD, skill)) {
       extractedSkills.push(skill);
     }
   });


### PR DESCRIPTION
Closes #512.

Summary of What Has Been Done:
Improved job description skill extraction so punctuation-heavy technical skills are detected reliably without reintroducing embedded-word false positives.

Changes Made:
Updated server/src/utils/parseJD.js to use an exported hasSkillToken helper instead of wrapping every escaped skill with word-boundary markers.

Core behavior:
```js
export const hasSkillToken = (text, skill) => {
  if (!text || !skill) return false;
  const regex = new RegExp(
    `(^|[^a-zA-Z0-9])${escapeRegex(skill)}(?=$|[^a-zA-Z0-9])`,
    "i"
  );
  return regex.test(text);
};
```

Added server/src/utils/__tests__/parseJD.skills.test.js with Node native tests for Node.js and C# detection, embedded react and Java false-positive prevention, and end-to-end extractDataFromJD skill extraction.

Impact it Made:
Job descriptions now detect common technical requirements containing punctuation while keeping noisy embedded-word matches out of parsed skill lists. Verification passed with:
```bash
node --test src/utils/__tests__/parseJD.skills.test.js
```
Result: 3 tests passed.