### PR TITLE
fix: resolve async/await syntax error in classroom socket handler

### DIFF
--- a/server/src/modules/classrooms/socket.js
+++ b/server/src/modules/classrooms/socket.js
@@ -5,12 +5,13 @@ export function initClassroomSockets(io) {
     console.log(`Socket connected: ${socket.id}`);
 
     // Join a specific room
-    socket.on("join-room", ({ roomId }) => {
-      socket.join(roomId);
-      
-      // Store user info in socket instance to easily retrieve later
-      const user = socket.user; // Secure, derived from JWT
-      socket.data = { roomId, user };
+    socket.on("join-room", async ({ roomId }) => {
+      try {
+        socket.join(roomId);
+        
+        // Store user info in socket instance to easily retrieve later
+        const user = socket.user; // Secure, derived from JWT
+        socket.data = { roomId, user };
 
         // Validate session in database
         const session = await ClassroomSession.findOne({ roomId, status: "active" });


### PR DESCRIPTION
### Overview

This PR fixes a critical backend startup issue caused by incorrect usage of `await` inside a non-async Socket.IO event handler.

The issue prevented the Node.js server from starting successfully and blocked development/testing workflows.

---

## Problem

The backend crashed during startup with:

```bash
SyntaxError: Unexpected reserved word
```

Originating from:

```text
server/src/modules/classrooms/socket.js
```

Root cause:
`await` was being used inside a synchronous socket callback.

Example:

```js
socket.on("join-room", ({ roomId }) => {
  const session = await ClassroomSession.findOne(...);
});
```

Since the callback was not marked `async`, Node.js failed during module parsing.

---

## Fix Applied

Updated the socket event handler to use an async callback.

### Before

```js
socket.on("join-room", ({ roomId }) => {
```

### After

```js
socket.on("join-room", async ({ roomId }) => {
```

---

## Verification

Tested:

* backend startup using `npm run dev`
* classroom socket initialization
* async database session retrieval flow


---

## Related Issue

Closes #530 

