### PR TITLE
Improve roadmap light mode and navbar navigation

### DIFF
--- a/client/src/modules/roadmap/pages/RoadmapPage.jsx
+++ b/client/src/modules/roadmap/pages/RoadmapPage.jsx
@@ -50,7 +50,7 @@ const RoadmapPage = () => {
 
   if (!roadmap) {
     return (
-      <div className="min-h-screen bg-dark-bg text-white">
+      <div className="min-h-screen bg-[var(--background)] text-[var(--text-main)]">
         <Navbar />
         <div className="pt-40 flex flex-col items-center justify-center text-center px-4">
           <div className="p-6 bg-primary/10 rounded-full mb-6">
@@ -69,7 +69,7 @@ const RoadmapPage = () => {
   }
 
   return (
-    <div className="min-h-screen bg-dark-bg text-white font-sans">
+    <div className="min-h-screen bg-[var(--background)] text-[var(--text-main)] font-sans">
       <Navbar />
       <div className="max-w-4xl mx-auto pt-32 pb-20 px-4">
         {/* Header section */}
@@ -86,10 +86,10 @@ const RoadmapPage = () => {
             </h1>
           </div>
           
-          <div className="bg-surface/50 border border-border p-4 rounded-2xl flex items-center gap-4 shadow-xl">
+           <div className="bg-[var(--surface)] border border-[var(--border)] p-4 rounded-2xl flex items-center gap-4 shadow-xl">
              <div className="relative w-16 h-16 flex items-center justify-center">
                 <svg className="w-full h-full transform -rotate-90">
-                  <circle cx="32" cy="32" r="28" fill="transparent" stroke="currentColor" strokeWidth="4" className="text-white/5" />
+                  <circle cx="32" cy="32" r="28" fill="transparent" stroke="currentColor" strokeWidth="4" className="text-[var(--border)] opacity-40" />
                   <circle cx="32" cy="32" r="28" fill="transparent" stroke="currentColor" strokeWidth="4" strokeDasharray={175.9} strokeDashoffset={175.9 * (1 - roadmap.overallProgress / 100)} className="text-primary transition-all duration-1000" />
                 </svg>
                 <span className="absolute text-sm font-black">{roadmap.overallProgress}%</span>
@@ -114,19 +114,19 @@ const RoadmapPage = () => {
               <div key={topic._id} className={`relative flex items-center gap-8 ${isLeft ? "md:flex-row" : "md:flex-row-reverse"} animate-slide-up`} style={{ animationDelay: `${index * 100}ms` }}>
                 
                 {/* Visual Dot on the line */}
-                <div className={`absolute left-[19px] md:left-1/2 md:-ml-3 w-6 h-6 rounded-full border-4 ${isCompleted ? 'bg-primary border-primary shadow-[0_0_15px_rgba(99,102,241,0.5)]' : 'bg-dark-bg border-border'} z-20 transition-all duration-500`}>
+                 <div className={`absolute left-[19px] md:left-1/2 md:-ml-3 w-6 h-6 rounded-full border-4 ${isCompleted ? 'bg-primary border-primary shadow-[0_0_15px_rgba(99,102,241,0.5)]' : 'bg-[var(--background)] border-[var(--border)]'} z-20 transition-all duration-500`}>
                    {isCompleted && <CheckCircle2 className="w-full h-full text-white p-0.5" />}
                 </div>
 
                 {/* Content Card */}
                 <div className={`w-full md:w-1/2 ${isLeft ? "md:pr-16" : "md:pl-16"}`}>
-                  <div className={`group p-6 bg-surface/40 border ${isCompleted ? 'border-primary/30' : 'border-border'} rounded-[2rem] hover:border-primary/50 transition-all hover:bg-surface/60 shadow-lg relative overflow-hidden`}>
+                  <div className={`group p-6 bg-[var(--surface)] border ${isCompleted ? 'border-primary/30' : 'border-[var(--border)]'} rounded-[2rem] hover:border-primary/50 transition-all hover:bg-[var(--surface-hover)] shadow-lg relative overflow-hidden`}>
                     
                     {/* Background Glow */}
                     {isCompleted && <div className="absolute -top-12 -right-12 w-24 h-24 bg-primary/10 rounded-full blur-[40px] pointer-events-none"></div>}
 
                     <div className="flex items-start justify-between mb-4">
-                       <span className="text-[10px] font-black uppercase tracking-widest text-text-muted">{index + 1}. Milestone</span>
+                       <span className="text-[10px] font-black uppercase tracking-widest text-[var(--text-muted)]">{index + 1}. Milestone</span>
                        <div className="flex items-center gap-1.5">
                          {topic.isVerified && (
                            <div className="px-2 py-1 bg-indigo-500/10 text-indigo-400 rounded-lg text-[8px] font-black uppercase tracking-tighter border border-indigo-500/20 flex items-center gap-1 animate-pulse">
@@ -145,27 +145,27 @@ const RoadmapPage = () => {
                        </div>
                     </div>
 
-                    <h3 className="text-xl font-bold text-white mb-4 group-hover:text-primary transition-colors">
+                    <h3 className="text-xl font-bold text-[var(--text-main)] mb-4 group-hover:text-primary transition-colors">
                       {topic.topicName}
                     </h3>
 
                     {topic.resources && topic.resources.length > 0 && (
-                      <div className="mt-2 mb-4 space-y-2 border-t border-border/30 pt-3">
-                        <p className="text-[10px] font-black text-text-muted uppercase tracking-wider mb-1">Study Resources:</p>
+                      <div className="mt-2 mb-4 space-y-2 border-t border-[var(--border)] border-opacity-30 pt-3">
+                        <p className="text-[10px] font-black text-[var(--text-muted)] uppercase tracking-wider mb-1">Study Resources:</p>
                         {topic.resources.map((res, rIdx) => (
                           <a 
                             key={res._id || rIdx} 
                             href={res.url} 
                             target="_blank" 
                             rel="noopener noreferrer" 
-                            className={`flex items-center justify-between p-2 rounded-xl text-xs font-semibold transition-all border ${res.tutorAssigned ? 'bg-indigo-500/10 border-indigo-500/20 text-indigo-300 hover:bg-indigo-500/20' : 'bg-slate-800/40 border-slate-700/30 hover:bg-slate-800/70 text-slate-300'}`}
+                            className={`flex items-center justify-between p-2 rounded-xl text-xs font-semibold transition-all border ${res.tutorAssigned ? 'bg-indigo-500/10 border-indigo-500/20 text-indigo-700 dark:text-indigo-300 hover:bg-indigo-500/20' : 'bg-[var(--surface-soft)] border-[var(--border)] border-opacity-30 hover:bg-[var(--surface-hover)] text-[var(--text-main)]'}`}
                           >
                             <span className="truncate max-w-[200px]">{res.title}</span>
                             <div className="flex items-center gap-1.5 flex-shrink-0 ml-2">
                               {res.tutorAssigned && (
                                 <span className="px-1.5 py-0.5 bg-indigo-500 text-white rounded text-[8px] font-black uppercase tracking-tighter">Tutor</span>
                               )}
-                              <span className="text-[10px] uppercase tracking-tighter text-text-muted opacity-80">{res.type}</span>
+                              <span className="text-[10px] uppercase tracking-tighter text-[var(--text-muted)] opacity-80">{res.type}</span>
                             </div>
                           </a>
                         ))}
@@ -189,7 +189,7 @@ const RoadmapPage = () => {
                          )}
                        </button>
 
-                       <button className="p-2 text-text-muted hover:text-white transition-colors">
+                       <button className="p-2 text-[var(--text-muted)] hover:text-[var(--text-main)] transition-colors">
                          <ArrowRight className="w-5 h-5" />
                        </button>
                     </div>
@@ -209,10 +209,10 @@ const RoadmapPage = () => {
            <div className="relative z-10">
               <Award className="w-16 h-16 text-yellow-400 mx-auto mb-6 drop-shadow-[0_0_15px_rgba(250,204,21,0.5)]" />
               <h2 className="text-3xl font-black mb-4 uppercase tracking-tighter">Career Readiness Goal</h2>
-              <p className="text-text-muted max-w-lg mx-auto mb-8 font-medium italic">
-                "Complete this roadmap to reach top-tier competency for <span className="text-white font-bold">{roadmap.targetRole}</span> roles. Your progress is synced across recruiters and mentors."
+              <p className="text-[var(--text-muted)] max-w-lg mx-auto mb-8 font-medium italic">
+                "Complete this roadmap to reach top-tier competency for <span className="text-[var(--text-main)] font-bold">{roadmap.targetRole}</span> roles. Your progress is synced across recruiters and mentors."
               </p>
-              <div className="h-2 w-full bg-white/5 rounded-full overflow-hidden max-w-md mx-auto">
+              <div className="h-2 w-full bg-[var(--border)]/20 rounded-full overflow-hidden max-w-md mx-auto">
                 <div className="h-full bg-primary transition-all duration-1000" style={{ width: `${roadmap.overallProgress}%` }}></div>
               </div>
            </div>

--- a/client/src/shared/landing/Navbar.jsx
+++ b/client/src/shared/landing/Navbar.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { Home, FileText, LayoutDashboard, MessageSquare, LogIn, UserPlus, X, Menu, LogOut, User, ChevronDown, Briefcase, Moon, Sun, Sparkles, Rocket, Video } from 'lucide-react';
@@ -13,6 +13,7 @@ const Navbar = () => {
   const navigate = useNavigate();
   
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isNavMenuOpen, setIsNavMenuOpen] = useState(false);
   const [isProfileOpen, setIsProfileOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const [theme, setTheme] = useState(() => {
@@ -20,6 +21,7 @@ const Navbar = () => {
     return window.localStorage.getItem('skillssphere.theme') || 'light';
   });
   const location = useLocation();
+  const navMenuRef = useRef(null);
 
   const handleLogout = () => {
     dispatch(logout());
@@ -40,7 +42,23 @@ const Navbar = () => {
 
   useEffect(() => {
     setIsMenuOpen(false);
+    setIsNavMenuOpen(false);
+    setIsProfileOpen(false);
   }, [location.pathname]);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (navMenuRef.current && !navMenuRef.current.contains(event.target)) {
+        setIsNavMenuOpen(false);
+      }
+    };
+
+    if (isNavMenuOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isNavMenuOpen]);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -74,6 +92,14 @@ const Navbar = () => {
     ),
   ];
 
+  const homeNavLink = navLinks.find((link) => link.path === '/');
+  const dashboardNavLink = navLinks.find((link) => link.path === '/dashboard');
+  const roadmapNavLink = navLinks.find((link) => link.path === '/roadmap');
+  const visibleNavLinks = [homeNavLink, dashboardNavLink, roadmapNavLink].filter(Boolean);
+  const overflowNavLinks = navLinks.filter(
+    (link) => !visibleNavLinks.some((visibleLink) => visibleLink.path === link.path)
+  );
+
   const isActive = (path) => location.pathname === path;
 
   return (
@@ -85,22 +111,22 @@ const Navbar = () => {
       ${isMenuOpen ? '' : ''}
       max-sm:py-3`}>
 
-      <div className="container flex justify-between items-center px-4 sm:px-3">
+      <div className="container relative flex justify-between items-center px-4 sm:px-3">
         <Link to="/" className="font-heading text-2xl font-extrabold tracking-normal text-[var(--text-main)] z-[1001] flex items-center min-h-[44px] sm:text-xl max-sm:text-lg">
           <span className="text-gradient">SkillSphere</span>&nbsp;AI
         </Link>
 
         {/* Desktop Navigation */}
-        <div className="hidden lg:flex gap-10 items-center">
-          {navLinks.map((link) => (
+        <div className="hidden lg:flex items-center gap-12 absolute left-1/2 -translate-x-1/2">
+          {visibleNavLinks.map((link) => (
             <Link
               key={link.path}
               to={link.path}
-              className={`relative font-medium transition-all duration-300 py-2
-                ${isActive(link.path)
-                  ? 'text-[var(--text-main)] font-semibold'
-                  : 'text-[var(--text-muted)] hover:text-[var(--text-main)]'
-                }`}
+              className={`relative font-medium transition-all duration-300 py-2 px-1
+              ${isActive(link.path)
+                ? 'text-[var(--text-main)] font-semibold'
+                : 'text-[var(--text-muted)] hover:text-[var(--text-main)]'
+              }`}
             >
               {link.name}
               {isActive(link.path) && (
@@ -108,6 +134,48 @@ const Navbar = () => {
               )}
             </Link>
           ))}
+
+          <div className="relative" ref={navMenuRef}>
+            <button
+              type="button"
+              onClick={() => setIsNavMenuOpen((current) => !current)}
+              className="inline-flex items-center gap-1 relative font-medium transition-all duration-300 py-2 px-1 text-[var(--text-muted)] hover:text-[var(--text-main)]"
+              aria-expanded={isNavMenuOpen}
+              aria-haspopup="menu"
+            >
+              More
+              <ChevronDown size={16} className={`transition-transform duration-200 ${isNavMenuOpen ? 'rotate-180' : ''}`} />
+            </button>
+
+            {isNavMenuOpen && (
+              <div className="absolute left-0 top-full mt-3 w-64 overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-[var(--shadow-soft)] z-[1002]">
+                <div className="px-4 py-3 border-b border-[var(--border)]">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">Explore</p>
+                </div>
+                <div className="py-2">
+                  {overflowNavLinks.map((link) => (
+                    <Link
+                      key={link.path}
+                      to={link.path}
+                      onClick={() => setIsNavMenuOpen(false)}
+                      className={`flex items-center gap-3 px-4 py-3 text-sm font-medium transition-colors duration-200 hover:bg-[var(--surface-hover)] ${
+                        isActive(link.path)
+                          ? 'text-[var(--text-main)] bg-[var(--surface-hover)]'
+                          : 'text-[var(--text-muted)] hover:text-[var(--text-main)]'
+                      }`}
+                    >
+                      <span className={`flex h-8 w-8 items-center justify-center rounded-lg ${
+                        isActive(link.path) ? 'bg-[var(--primary)] text-white' : 'bg-[var(--surface-soft)]'
+                      }`}>
+                        {link.icon}
+                      </span>
+                      <span>{link.name}</span>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
         </div>
 
         <div className="hidden lg:flex gap-5 items-center">


### PR DESCRIPTION
## Summary
This PR improves the navbar layout and fixes the Roadmap page light mode styling for issue #528.

**What changed**
- Collapsed the desktop navbar into a cleaner centered layout.
- Moved extra navigation items into a compact More dropdown.
- Kept Home, Dashboard, and Roadmap visible in the navbar.
- Normalized the More trigger so it matches the other navbar items.
- Updated the Roadmap page to use theme-aware colors instead of hardcoded dark styles.
- Ensured the Roadmap page renders correctly in light mode.

## Type of Change

- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #528 


## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated
- [x] Documentation updated (if needed)

## Screenshots (if UI change)
<img width="1901" height="542" alt="image" src="https://github.com/user-attachments/assets/1c0fda6d-c54b-41ef-9384-7215acffb67b" />
