### PR TITLE
feat: implement cross-role notifications for skill gaps

### DIFF
--- a/client/src/shared/components/SocketNotificationListener.jsx
+++ b/client/src/shared/components/SocketNotificationListener.jsx
@@ -59,6 +59,14 @@ const SocketNotificationListener = () => {
         }
       });
 
+      socketRef.current.on("new-notification", (notif) => {
+        if (notif.type === "skill_gap_alert") {
+          toast.error(notif.message, notif.title || "Skill Gap Alert");
+        } else {
+          toast.success(notif.message, notif.title || "Notification");
+        }
+      });
+
       socketRef.current.on("disconnect", (reason) => {
         // Handled
       });

--- a/server/index.js
+++ b/server/index.js
@@ -14,6 +14,7 @@ import matchingRoutes from "./src/modules/matching/routes.js";
 import dashboardRoutes from "./src/modules/dashboard/routes.js";
 import coverLetterRoutes from "./src/modules/coverLetters/routes.js";
 import classroomRoutes from "./src/modules/classrooms/routes.js";
+import notificationRoutes from "./src/modules/notifications/routes.js";
 import userRoutes from "./src/modules/users/routes.js";
 import interviewRoutes from "./src/modules/interviews/routes.js";
 import fileRoutes from "./src/modules/files/routes.js";
@@ -109,6 +110,7 @@ app.use("/api/classrooms", classroomRoutes);
 app.use("/api/users", userRoutes);
 app.use("/api/interviews", interviewRoutes);
 app.use("/api/files", fileRoutes);
+app.use("/api/notifications", notificationRoutes);
 app.use("/api/analytics", analyticsRoutes);
 
 initClassroomSockets(io);

--- a/server/src/database/models/Notification.js
+++ b/server/src/database/models/Notification.js
@@ -1,0 +1,36 @@
+import mongoose from "mongoose";
+
+const notificationSchema = new mongoose.Schema(
+  {
+    recipient: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+    type: {
+      type: String,
+      enum: ["skill_gap_alert", "general", "system"],
+      default: "general",
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    message: {
+      type: String,
+      required: true,
+    },
+    isRead: {
+      type: Boolean,
+      default: false,
+    },
+    relatedData: {
+      jobId: { type: mongoose.Schema.Types.ObjectId, ref: "JobPosting" },
+      studentId: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
+      score: Number,
+    }
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model("Notification", notificationSchema);

--- a/server/src/modules/matching/service.js
+++ b/server/src/modules/matching/service.js
@@ -1,6 +1,9 @@
 import JobPosting from "../../database/models/JobPosting.js";
 import MatchResult from "../../database/models/MatchResult.js";
+import Notification from "../../database/models/Notification.js";
+import User from "../../database/models/User.js";
 import { runPipeline } from "../../../../ai-ml/pipeline/runPipeline.js";
+import { getIO } from "../../utils/socketIO.js";
 
 /**
  * Evaluate a resume against all open jobs and return ranked recommendations.
@@ -66,6 +69,43 @@ export const evaluateMatches = async (user, resume, preFilteredJobs = null) => {
 
   // 3. Sort by score (highest first)
   recommendations.sort((a, b) => b.score - a.score);
+
+  // Cross-Role Notification System for Job Matching Skill Gaps
+  // If a candidate matches poorly (< 60%), generate alerts for Tutors and Recruiters
+  const io = getIO();
+  for (const rec of recommendations) {
+    if (rec.score > 0 && rec.score < 60) {
+      const jobFull = openJobs.find(j => j._id.toString() === rec.job.toString());
+      
+      if (jobFull) {
+        // 1. Notify Recruiter (if known)
+        if (jobFull.postedBy) {
+          const notif = await Notification.create({
+            recipient: jobFull.postedBy,
+            type: "skill_gap_alert",
+            title: "Candidate Skill Gap Alert",
+            message: `${user.name || "A candidate"} showed interest but has a skill gap for ${jobFull.title} (Score: ${rec.score}%).`,
+            relatedData: { jobId: jobFull._id, studentId: user._id, score: rec.score }
+          });
+          if (io) io.to(`user_${jobFull.postedBy}`).emit("new-notification", notif);
+        }
+
+        // 2. Notify a Tutor to intervene
+        // In a real system, find the specifically assigned tutor. Here we find any available tutor.
+        const tutor = await User.findOne({ role: "tutor" });
+        if (tutor) {
+          const tutorNotif = await Notification.create({
+            recipient: tutor._id,
+            type: "skill_gap_alert",
+            title: "Student Needs Mentoring Intervention",
+            message: `${user.name || "A student"} scored ${rec.score}% for ${jobFull.title}. They need guidance to bridge this gap.`,
+            relatedData: { jobId: jobFull._id, studentId: user._id, score: rec.score }
+          });
+          if (io) io.to(`user_${tutor._id}`).emit("new-notification", tutorNotif);
+        }
+      }
+    }
+  }
 
   // 4. Persist MatchResult for analytics and retrieval
   const matchResult = await MatchResult.create({

--- a/server/src/modules/notifications/controller.js
+++ b/server/src/modules/notifications/controller.js
@@ -1,0 +1,20 @@
+import Notification from "../../database/models/Notification.js";
+import asyncHandler from "../../utils/asyncHandler.js";
+
+export const getNotifications = asyncHandler(async (req, res) => {
+  const notifications = await Notification.find({ recipient: req.user._id })
+    .sort({ createdAt: -1 })
+    .limit(50)
+    .populate("relatedData.jobId", "title company")
+    .populate("relatedData.studentId", "name email profilePic");
+    
+  res.json({ success: true, data: notifications });
+});
+
+export const markAsRead = asyncHandler(async (req, res) => {
+  await Notification.updateMany(
+    { recipient: req.user._id, isRead: false },
+    { isRead: true }
+  );
+  res.json({ success: true, message: "Notifications marked as read" });
+});

--- a/server/src/modules/notifications/routes.js
+++ b/server/src/modules/notifications/routes.js
@@ -1,0 +1,11 @@
+import express from "express";
+import { protect } from "../../middleware/authMiddleware.js";
+import { getNotifications, markAsRead } from "./controller.js";
+
+const router = express.Router();
+
+router.use(protect);
+router.get("/", getNotifications);
+router.post("/read", markAsRead);
+
+export default router;


### PR DESCRIPTION
Here are your git commands to stage, commit, and push the notification system:

```bash
# 1. Stage the files we touched (server and client changes)
git add server/src/database/models/Notification.js server/src/modules/notifications/ server/src/modules/matching/service.js server/index.js client/src/shared/components/SocketNotificationListener.jsx

# 2. Commit the changes
git commit -m "feat: implement cross-role notifications for skill gaps"

# 3. Push to the new branch
git push -u origin feat/cross-role-notifications
```

***

And here is the Pull Request summary for your repository:

## Summary

This PR implements a real-time, cross-role notification system designed to bridge the gap between Students, Tutors, and Recruiters. When a student evaluates their resume against an open job posting and scores poorly (<60%), the platform now automatically generates an intervention alert. 

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #546 

## Changes Made

- **Database Model (`Notification.js`)**: Created a persistent schema for notifications, supporting recipient targeting and dynamic metadata (e.g. `jobId`, `score`).
- **Notification API (`controller.js` & `routes.js`)**: Built and registered standard CRUD endpoints for fetching user notification history and marking alerts as read.
- **AI Matching Engine Hook (`matching/service.js`)**: Integrated trigger logic directly into the resume evaluation pipeline. If a skill gap is detected, it generates a database alert and simultaneously fires a real-time `new-notification` WebSocket event to the job's recruiter and available tutors.
- **Frontend Real-time Delivery (`SocketNotificationListener.jsx`)**: Updated our global socket listener to catch the new event type, ensuring online Tutors and Recruiters instantly receive a toast warning the moment a skill gap is calculated.

## Validation

- [x] Build passes locally
