### PR TITLE
feat: add socket connection status indicator to interview session

### DIFF
--- a/client/src/modules/mock-interview/pages/InterviewSession.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewSession.jsx
@@ -45,6 +45,7 @@ const InterviewSession = () => {
   const [socket, setSocket] = useState(null);
   const [participants, setParticipants] = useState([]);
   const [liveTyping, setLiveTyping] = useState("");
+  const [socketStatus, setSocketStatus] = useState("connecting");
 
   const isObserver = user && session && user._id !== session.userId;
 
@@ -100,7 +101,16 @@ const InterviewSession = () => {
     const newSocket = io(socketUrl, { auth: { token } });
 
     newSocket.on("connect", () => {
+      setSocketStatus("connected");
       newSocket.emit("join-interview", { sessionId });
+    });
+
+    newSocket.on("disconnect", () => {
+      setSocketStatus("disconnected");
+    });
+
+    newSocket.on("reconnect_attempt", () => {
+      setSocketStatus("reconnecting");
     });
 
     newSocket.on("interview-participants", (pts) => {
@@ -247,6 +257,15 @@ const InterviewSession = () => {
         <div className="session-timer">
           <Clock size={16} />
           {formatTime(elapsedTime)}
+        </div>
+        <div className="socket-status">
+          <span className={`status-dot status-${socketStatus}`} />
+          <span className="status-text">
+            {socketStatus === "connected" && "Connected"}
+            {socketStatus === "disconnected" && "Disconnected"}
+            {socketStatus === "reconnecting" && "Reconnecting"}
+            {socketStatus === "connecting" && "Connecting..."}
+          </span>
         </div>
       </div>
 

--- a/client/src/modules/mock-interview/styles/mock-interview.css
+++ b/client/src/modules/mock-interview/styles/mock-interview.css
@@ -277,3 +277,32 @@
   .score-breakdown { flex-direction: column; align-items: center; }
   .answer-scores-row { flex-direction: column; }
 }
+
+.socket-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  animation: pulse 2s infinite;
+}
+
+.status-dot.status-connected { background: #10b981; }
+.status-dot.status-disconnected { background: #ef4444; }
+.status-dot.status-reconnecting { background: #f59e0b; }
+.status-dot.status-connecting { background: #94a3b8;}
+.status-text { color: #94a3b8; }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}


### PR DESCRIPTION
### Closes #555 

### Description
Interview session had no visual feedback for socket connection state.

### What I did
- Added socketStatus state to track connection (connecting, connected, disconnected, reconnecting)
- Added disconnect and reconnect_attempt socket event handlers
- Added status badge in session header showing current connection state with color coded dot
- Added CSS for the badge and pulse animation

### Files Changed
- client/src/modules/mock-interview/pages/InterviewSession.jsx
- client/src/modules/mock-interview/styles/mock-interview.css

### Checklist
- [x] My changes follow the project's contribution guidelines
- [x] I have linked the related issue
- [x] No unrelated files changed