### PR TITLE
feat: integrate recruiter company profile details in dashboard and jo…

### DIFF
--- a/client/src/modules/profile/ProfilePage.jsx
+++ b/client/src/modules/profile/ProfilePage.jsx
@@ -4,7 +4,8 @@ import ProfileSkeleton from "./components/ProfileSkeleton";
 import {
   User, Mail, Shield, Calendar, Clock, Pencil, X, Check,
   ChevronLeft, BadgeCheck, AlertCircle, Trash2, LogOut,
-  Info, Lock, Sparkles, Activity, Camera, Upload, MapPin
+  Info, Lock, Sparkles, Activity, Camera, Upload, MapPin,
+  Briefcase, Globe, ExternalLink
 } from "lucide-react";
 import Input from "../../shared/components/Input";
 import Button from "../../shared/components/Button";
@@ -188,7 +189,11 @@ const ProfilePage = () => {
 
   const [activeTab, setActiveTab] = useState("info");
   const [isEditing, setIsEditing] = useState(false);
-  const [formData, setFormData] = useState({ name: user?.name || "" });
+  const [formData, setFormData] = useState({
+    name: user?.name || "",
+    company: user?.company || "",
+    companyWebsite: user?.companyWebsite || "",
+  });
   const [errors, setErrors] = useState({});
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -247,7 +252,11 @@ const ProfilePage = () => {
   };
 
   const handleEditClick = () => {
-    setFormData({ name: user?.name || "" });
+    setFormData({
+      name: user?.name || "",
+      company: user?.company || "",
+      companyWebsite: user?.companyWebsite || "",
+    });
     setErrors({});
     setSaveSuccess(false);
     setApiError("");
@@ -255,7 +264,11 @@ const ProfilePage = () => {
   };
 
   const handleCancel = () => {
-    setFormData({ name: user?.name || "" });
+    setFormData({
+      name: user?.name || "",
+      company: user?.company || "",
+      companyWebsite: user?.companyWebsite || "",
+    });
     setErrors({});
     setApiError("");
     setIsEditing(false);
@@ -277,7 +290,12 @@ const ProfilePage = () => {
     setIsSaving(true);
     try {
       setApiError("");
-      const response = await updateProfile({ name: trimmed }, token);
+      const payload = { name: trimmed };
+      if (user.role === "recruiter") {
+        payload.company = formData.company ? formData.company.trim() : "";
+        payload.companyWebsite = formData.companyWebsite ? formData.companyWebsite.trim() : "";
+      }
+      const response = await updateProfile(payload, token);
       dispatch(updateUserProfile(response.user));
       setSaveSuccess(true);
       setIsEditing(false);
@@ -488,23 +506,74 @@ const ProfilePage = () => {
                         <Shield size={15} /><span>{roleConfig.label}</span>
                       </div>
                     </div>
+                    {user.role === "recruiter" && (
+                      <>
+                        <Input
+                          id="company"
+                          label="Company Name"
+                          placeholder="Enter company name"
+                          value={formData.company}
+                          onChange={handleChange}
+                          leftIcon={<Briefcase size={16} />}
+                        />
+                        <Input
+                          id="companyWebsite"
+                          label="Company Website"
+                          placeholder="e.g. www.mycompany.com"
+                          value={formData.companyWebsite}
+                          onChange={handleChange}
+                          leftIcon={<Globe size={16} />}
+                          helperText="Link to your company's official website."
+                        />
+                      </>
+                    )}
                   </form>
                 ) : (
                   <div className="flex flex-col divide-y divide-slate-100 dark:divide-white/5">
-                    {[
-                      { icon: <User size={15} />, label: "Full Name", value: user.name },
-                      { icon: <Mail size={15} />, label: "Email", value: user.email },
-                      { icon: <Shield size={15} />, label: "Role", value: `${roleConfig.icon} ${roleConfig.label}` },
-                      { icon: <BadgeCheck size={15} />, label: "Verification", value: verificationBadge },
-                    ].map((row, i) => (
-                      <div key={i} className="flex items-start gap-3 py-3.5">
-                        <span className="mt-0.5 text-slate-400 dark:text-slate-500 flex-shrink-0">{row.icon}</span>
-                        <div className="flex-1 min-w-0">
-                          <p className="text-[11px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-0.5">{row.label}</p>
-                          <div className="text-sm text-slate-700 dark:text-slate-200">{row.value}</div>
+                    {(() => {
+                      const infoRows = [
+                        { icon: <User size={15} />, label: "Full Name", value: user.name },
+                        { icon: <Mail size={15} />, label: "Email", value: user.email },
+                        { icon: <Shield size={15} />, label: "Role", value: `${roleConfig.icon} ${roleConfig.label}` },
+                        { icon: <BadgeCheck size={15} />, label: "Verification", value: verificationBadge },
+                      ];
+
+                      if (user.role === "recruiter") {
+                        infoRows.push(
+                          {
+                            icon: <Briefcase size={15} />,
+                            label: "Company",
+                            value: user.company || <span className="text-slate-400 italic">Not set</span>
+                          },
+                          {
+                            icon: <Globe size={15} />,
+                            label: "Company Website",
+                            value: user.companyWebsite ? (
+                              <a
+                                href={user.companyWebsite}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-indigo-600 dark:text-indigo-400 hover:underline inline-flex items-center gap-1"
+                              >
+                                {user.companyWebsite} <ExternalLink size={12} />
+                              </a>
+                            ) : (
+                              <span className="text-slate-400 italic">Not set</span>
+                            )
+                          }
+                        );
+                      }
+
+                      return infoRows.map((row, i) => (
+                        <div key={i} className="flex items-start gap-3 py-3.5">
+                          <span className="mt-0.5 text-slate-400 dark:text-slate-500 flex-shrink-0">{row.icon}</span>
+                          <div className="flex-1 min-w-0">
+                            <p className="text-[11px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-0.5">{row.label}</p>
+                            <div className="text-sm text-slate-700 dark:text-slate-200">{row.value}</div>
+                          </div>
                         </div>
-                      </div>
-                    ))}
+                      ));
+                    })()}
                   </div>
                 )}
               </div>

--- a/client/src/shared/components/JobViewerCard.jsx
+++ b/client/src/shared/components/JobViewerCard.jsx
@@ -151,6 +151,9 @@ const JobViewerCard = ({
     openings,
   } = job;
 
+  const companyName = recruiter?.company || job.company || "SkillSphere Partner";
+  const companyWebsite = recruiter?.companyWebsite || job.companyWebsite;
+
   const canApply = status === "open" && !isApplied;
 
   return (
@@ -210,7 +213,19 @@ const JobViewerCard = ({
                   )}
                 </div>
                 <p className="text-slate-400 font-medium mt-0.5 truncate">
-                  {recruiter?.company || job.company || "SkillSphere Partner"}
+                  {companyWebsite ? (
+                    <a
+                      href={companyWebsite}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-400 hover:text-blue-300 hover:underline inline-flex items-center gap-1.5"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {companyName} <ExternalLink size={14} className="shrink-0" />
+                    </a>
+                  ) : (
+                    companyName
+                  )}
                 </p>
               </div>
               <div className="text-slate-500 group-hover:text-blue-400 transition-colors shrink-0 mt-1">
@@ -532,10 +547,12 @@ JobViewerCard.propTypes = {
       name: PropTypes.string,
       email: PropTypes.string,
       company: PropTypes.string,
+      companyWebsite: PropTypes.string,
     }),
     createdAt: PropTypes.string,
     // Legacy / optional fields some views may pass
     company: PropTypes.string,
+    companyWebsite: PropTypes.string,
     type: PropTypes.string,
     openings: PropTypes.number,
   }).isRequired,

--- a/server/src/database/models/User.js
+++ b/server/src/database/models/User.js
@@ -50,6 +50,16 @@ const userSchema = new mongoose.Schema(
       type: Number,
       default: 0,
     },
+
+    company: {
+      type: String,
+      default: null,
+    },
+
+    companyWebsite: {
+      type: String,
+      default: null,
+    },
   },
   { timestamps: true }
 );

--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -77,7 +77,7 @@ export const getAllJobs = async (queryParams = {}) => {
 
   const [jobs, totalCount] = await Promise.all([
     JobPosting.find(filters)
-      .populate("recruiter", "name email company")
+      .populate("recruiter", "name email company companyWebsite")
       .sort("-createdAt")
       .skip(skip)
       .limit(limit),
@@ -98,7 +98,7 @@ export const getAllJobs = async (queryParams = {}) => {
  * @returns {Promise<Object>} - Job details
  */
 export const getJobById = async (id) => {
-  const job = await JobPosting.findById(id).populate("recruiter", "name email company");
+  const job = await JobPosting.findById(id).populate("recruiter", "name email company companyWebsite");
 
   if (!job) {
     throw new AppError("Job not found", 404);

--- a/server/src/modules/users/controller.js
+++ b/server/src/modules/users/controller.js
@@ -21,15 +21,30 @@ import { cascadeDeleteUser } from "../../utils/cascadeDelete.js";
  * @access  Private
  */
 export const updateProfile = asyncHandler(async (req, res, next) => {
-  const { name } = req.body;
+  const { name, company, companyWebsite } = req.body;
 
   if (!name || name.trim().length < 2) {
     return next(new AppError("Please provide a valid name (at least 2 characters)", 400));
   }
 
+  const updateData = { name: name.trim() };
+
+  if (req.user.role === "recruiter") {
+    if (company !== undefined) {
+      updateData.company = company ? company.trim() : null;
+    }
+    if (companyWebsite !== undefined) {
+      let web = companyWebsite ? companyWebsite.trim() : null;
+      if (web && !/^https?:\/\//i.test(web)) {
+        web = `https://${web}`;
+      }
+      updateData.companyWebsite = web;
+    }
+  }
+
   const updatedUser = await User.findByIdAndUpdate(
     req.user._id,
-    { name: name.trim() },
+    updateData,
     { new: true, runValidators: true }
   ).select("-password -__v");
 


### PR DESCRIPTION

## Summary

Adds support for recruiters to configure their company name and website directly on their profile page. These company details are dynamically retrieved and displayed as clickable external links on job postings on the Job Board.

## Type of Change

- [x] Feature


## Related Issue

Closes #570 

## Changes Made

- **Database Schema**: Added `company` and `companyWebsite` fields to the `User` schema in `server/src/database/models/User.js`.
- **Backend Controller**: Updated the profile update handler in `server/src/modules/users/controller.js` to allow recruiters to update company fields (with auto-prepending of `https://`).
- **Job Service**: Populated `companyWebsite` along with other recruiter details when querying jobs in `server/src/modules/jobs/service.js`.
- **Profile UI**: Added inputs and display rows for company fields in the recruiter's profile page inside `client/src/modules/profile/ProfilePage.jsx`.
- **Job Card UI**: Rendered the company name as an external clickable link (with propagation stopped so it doesn't expand/collapse the card) in `client/src/shared/components/JobViewerCard.jsx`.

## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated

## Screenshots
<img width="874" height="386" alt="Screenshot 2026-05-22 155845" src="https://github.com/user-attachments/assets/5176ac9d-2070-4d7d-9b36-bdeb445426a6" />

<img width="952" height="588" alt="Screenshot 2026-05-22 155641" src="https://github.com/user-attachments/assets/08a46519-ec09-4e1e-b244-413ad50e7cc5" />