### PR TITLE
fix: removed unused evaluator imports and dead array construction in controller.js

### DIFF
--- a/server/src/modules/resumes/controller.js
+++ b/server/src/modules/resumes/controller.js
@@ -4,12 +4,6 @@ import { parseResume } from "../../utils/parseResume.js";
 import Resume from "../../database/models/Resume.js";
 import asyncHandler from "../../utils/asyncHandler.js";
 import AppError from "../../utils/AppError.js";
-import {
-  experienceMatchEvaluator,
-  keywordMatchEvaluator,
-  skillMatchEvaluator,
-  semanticMatchEvaluator,
-} from "./evaluatorAdapters.js";
 import { runPipeline } from "../../../../ai-ml/pipeline/runPipeline.js";
 import {
   normalizeResumeData,
@@ -121,17 +115,7 @@ export const analyzeResume = asyncHandler(async (req, res, next) => {
     jobDescription: req.body.jobDescription,
   });
   console.timeEnd("PipelineExecution");
-
-  const evaluators = [];
-  if (parsedData.skills?.length && jobSkills.length) {
-    evaluators.push(skillMatchEvaluator);
-  }
-  if (req.body.jobDescription && parsedData.resumeText) {
-    evaluators.push(keywordMatchEvaluator);
-    evaluators.push(semanticMatchEvaluator);
-  }
-  evaluators.push(experienceMatchEvaluator);
-
+  
   // 🔗 LINK VERIFICATION: Check if extracted links are alive
   console.time("LinkVerification");
   const linksToVerify = [


### PR DESCRIPTION
## Purpose / Description

Removes unused evaluator adapter imports and dead array construction code from `controller.js`. The `evaluators` array was constructed but never referenced anywhere. Actual analysis runs via `runPipeline()` which was already handling everything.

## Fixes

* Closes #575 

## Approach

* Removed unused imports of `experienceMatchEvaluator`, `keywordMatchEvaluator`, `skillMatchEvaluator`, `semanticMatchEvaluator` from `controller.js`
* Removed dead `evaluators` array construction block from `controller.js`

## Also

* Resume analysis functionality unchanged
* `runPipeline()` still runs all evaluators as before
* No breaking changes
