### PR TITLE
Fix: Secure OTP storage by hashing tokens in the database

### DIFF
--- a/server/src/modules/auth/service.js
+++ b/server/src/modules/auth/service.js
@@ -51,13 +51,14 @@ export const registerUserAndIssueToken = async ({ name, email, password, role })
 
   const otp = generateOTP();
   const otpExpiry = new Date(Date.now() + OTP_EXPIRY_MINUTES * 60 * 1000);
+  const hashedOtp = await bcrypt.hash(otp, SALT_ROUNDS);
 
   const user = await User.create({
     name,
     email,
     password: hashedPassword,
     role,
-    verificationToken: skipVerification ? undefined : otp,
+    verificationToken: skipVerification ? undefined : hashedOtp,
     verificationTokenExpires: skipVerification ? undefined : otpExpiry,
     isVerified: skipVerification,
   });
@@ -94,7 +95,7 @@ export const verifyUserEmail = async (email, otp) => {
     throw new AppError("Too many attempts. Please request a new OTP.", 429);
   }
 
-  const isMatch = user.verificationToken === otp;
+  const isMatch = await bcrypt.compare(otp, user.verificationToken);
   const isExpired = user.verificationTokenExpires < Date.now();
 
   if (!isMatch || isExpired) {
@@ -122,8 +123,9 @@ export const forgotPasswordRequest = async (email) => {
 
   const otp = generateOTP();
   const otpExpiry = new Date(Date.now() + OTP_EXPIRY_MINUTES * 60 * 1000);
+  const hashedOtp = await bcrypt.hash(otp, SALT_ROUNDS);
 
-  user.resetPasswordToken = otp;
+  user.resetPasswordToken = hashedOtp;
   user.resetPasswordExpires = otpExpiry;
   user.otpAttempts = 0;
   await user.save();
@@ -145,7 +147,7 @@ export const resetUserPassword = async (email, otp, newPassword) => {
     throw new AppError("Too many attempts. Please request a new code.", 429);
   }
 
-  const isMatch = user.resetPasswordToken === otp;
+  const isMatch = await bcrypt.compare(otp, user.resetPasswordToken);
   const isExpired = user.resetPasswordExpires < Date.now();
 
   if (!isMatch || isExpired) {
@@ -179,8 +181,9 @@ export const resendUserOTP = async (email) => {
 
   const otp = generateOTP();
   const otpExpiry = new Date(Date.now() + OTP_EXPIRY_MINUTES * 60 * 1000);
+  const hashedOtp = await bcrypt.hash(otp, SALT_ROUNDS);
 
-  user.verificationToken = otp;
+  user.verificationToken = hashedOtp;
   user.verificationTokenExpires = otpExpiry;
   user.otpAttempts = 0;
   await user.save();


### PR DESCRIPTION
## Description
This PR resolves a critical security vulnerability where 6-digit OTP tokens were being stored in plain text within the `User` model (`verificationToken` and `resetPasswordToken` fields). By leveraging `bcrypt`, we now securely hash these tokens before saving them to the database, ensuring that active tokens cannot be exploited in the event of unauthorized database access.

## Changes Made
- **Token Generation:** Updated `registerUserAndIssueToken`, `forgotPasswordRequest`, and `resendUserOTP` in the authentication service to hash the OTP before assigning it to the user object.
- **Token Validation:** Updated `verifyUserEmail` and `resetUserPassword` to utilize asynchronous `bcrypt.compare()` for secure validation of user-submitted OTPs against the hashed values.
- **Unchanged Functionality:** Users will still accurately receive the 6-digit plain-text OTP securely via their registered email address. 

## Related Issues
Fixes #589

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security patch

## Testing Done
- Verified that `bcrypt.hash()` and `bcrypt.compare()` properly handle OTP encryption and verification asynchronously.
- Syntax verification executed correctly without blocking the event loop.

## Labels
- `backend`
- `bug`
- `level:critical`
