### PR TITLE
fix: convert classrooms dashboard ui to proper light mode styling

### DIFF
--- a/client/src/modules/classrooms/pages/ClassroomsDashboard.jsx
+++ b/client/src/modules/classrooms/pages/ClassroomsDashboard.jsx
@@ -130,7 +130,7 @@ export default function ClassroomsDashboard() {
   };
 
   return (
-    <div className="min-h-screen bg-[#020617] text-white pt-24 pb-16 px-6">
+    <div className="min-h-screen bg-white dark:bg-[#020617] text-gray-900 dark:text-white pt-24 pb-16 px-6">
       <div className="max-w-6xl mx-auto">
         
         {/* Header section */}
@@ -141,7 +141,7 @@ export default function ClassroomsDashboard() {
           <h1 className="text-4xl md:text-5xl font-extrabold mb-4 bg-gradient-to-r from-indigo-400 via-purple-400 to-pink-400 bg-clip-text text-transparent">
             Live Interactive Classrooms
           </h1>
-          <p className="text-slate-400 text-lg max-w-2xl mx-auto">
+          <p className="text-gray-600 dark:text-slate-400 text-lg max-w-2xl mx-auto">
             {isTutor 
               ? "Host live interactive lessons, chat with peers, and share your screen in real-time."
               : "Enter unique session IDs provided by your tutor to join active learning rooms."
@@ -163,18 +163,18 @@ export default function ClassroomsDashboard() {
             
             {isTutor ? (
               // Tutor View: Session Form
-              <div className="bg-slate-900/60 backdrop-blur-md border border-slate-800/80 rounded-2xl p-6 shadow-xl">
+              <div className="bg-gray-100 dark:bg-slate-900/60 backdrop-blur-md border border-gray-200 dark:border-slate-800/80 rounded-2xl p-6 shadow-xl">
                 <div className="bg-indigo-500/10 w-12 h-12 rounded-xl flex items-center justify-center text-indigo-400 border border-indigo-500/20 mb-6">
                   <Video size={24} />
                 </div>
                 <h2 className="text-2xl font-bold mb-1">Create a Session</h2>
-                <p className="text-slate-400 text-sm mb-6">
+                <p className="text-gray-600 dark:text-slate-400 text-sm mb-6">
                   Launch a secure, high-quality audio and video learning room.
                 </p>
 
                 <form onSubmit={handleStartSession} className="space-y-4">
                   <div>
-                    <label className="block text-slate-300 text-xs font-semibold uppercase tracking-wider mb-2">
+                    <label className="block text-gray-700 dark:text-slate-300 text-xs font-semibold uppercase tracking-wider mb-2">
                       Session Title
                     </label>
                     <input
@@ -182,13 +182,13 @@ export default function ClassroomsDashboard() {
                       placeholder="e.g. Advanced JS Concepts"
                       value={title}
                       onChange={(e) => setTitle(e.target.value)}
-                      className="w-full bg-slate-950/80 border border-slate-800 rounded-xl px-4 py-3 text-white placeholder-slate-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
+                      className="w-full bg-white dark:bg-slate-950/80 border border-gray-200 dark:border-slate-800 rounded-xl px-4 py-3 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-slate-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
                       required
                     />
                   </div>
 
                   <div>
-                    <label className="block text-slate-300 text-xs font-semibold uppercase tracking-wider mb-2">
+                    <label className="block text-gray-700 dark:text-slate-300 text-xs font-semibold uppercase tracking-wider mb-2">
                       Subject / Topic
                     </label>
                     <input
@@ -196,12 +196,12 @@ export default function ClassroomsDashboard() {
                       placeholder="e.g. Computer Science"
                       value={subject}
                       onChange={(e) => setSubject(e.target.value)}
-                      className="w-full bg-slate-950/80 border border-slate-800 rounded-xl px-4 py-3 text-white placeholder-slate-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
+                      className="w-full bg-white dark:bg-slate-950/80 border border-gray-200 dark:border-slate-800 rounded-xl px-4 py-3 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-slate-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
                     />
                   </div>
 
                   <div>
-                    <label className="block text-slate-300 text-xs font-semibold uppercase tracking-wider mb-2">
+                    <label className="block text-gray-700 dark:text-slate-300 text-xs font-semibold uppercase tracking-wider mb-2">
                       Max Participants ({maxParticipants})
                     </label>
                     <input
@@ -212,7 +212,7 @@ export default function ClassroomsDashboard() {
                       onChange={(e) => setMaxParticipants(Number(e.target.value))}
                       className="w-full h-1 bg-slate-800 rounded-lg appearance-none cursor-pointer accent-indigo-500"
                     />
-                    <div className="flex justify-between text-[10px] text-slate-500 font-mono mt-1">
+                    <div className="flex justify-between text-[10px] text-gray-500 dark:text-slate-500 font-mono mt-1">
                       <span>2</span>
                       <span>50</span>
                       <span>100</span>
@@ -237,12 +237,12 @@ export default function ClassroomsDashboard() {
               </div>
             ) : (
               // Student View: Join Module
-              <div className="bg-slate-900/60 backdrop-blur-md border border-slate-800/80 rounded-2xl p-8 shadow-xl">
+              <div className="bg-gray-100 dark:bg-slate-900/60 backdrop-blur-md border border-gray-200 dark:border-slate-800/80 rounded-2xl p-8 shadow-xl">
                 <div className="bg-purple-500/10 w-12 h-12 rounded-xl flex items-center justify-center text-purple-400 border border-purple-500/20 mb-6">
                   <Users size={24} />
                 </div>
                 <h2 className="text-2xl font-bold mb-1">Join a Session</h2>
-                <p className="text-slate-400 text-sm mb-6">
+                <p className="text-gray-600 dark:text-slate-400 text-sm mb-6">
                   Paste the unique Room ID provided by your tutor to join an ongoing classroom.
                 </p>
 
@@ -252,7 +252,7 @@ export default function ClassroomsDashboard() {
                     placeholder="e.g. 123e4567-e89b-12d3..."
                     value={joinRoomId}
                     onChange={(e) => setJoinRoomId(e.target.value)}
-                    className="w-full bg-slate-950/80 border border-slate-800 rounded-xl px-4 py-4 text-white placeholder-slate-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors font-mono text-sm"
+                    className="w-full bg-white dark:bg-slate-950/80 border border-gray-200 dark:border-slate-800 rounded-xl px-4 py-4 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-slate-600 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors font-mono text-sm"
                     required
                   />
                   <button
@@ -271,8 +271,8 @@ export default function ClassroomsDashboard() {
           <div className="lg:col-span-3">
             {isTutor ? (
               // Tutor View: Sessions History List
-              <div className="bg-slate-900/40 backdrop-blur-md border border-slate-800/80 rounded-2xl p-6 shadow-xl min-h-[400px] flex flex-col">
-                <div className="flex justify-between items-center mb-6 border-b border-slate-800/80 pb-4">
+              <div className="bg-gray-50 dark:bg-slate-900/40 backdrop-blur-md border border-gray-200 dark:border-slate-800/80 rounded-2xl p-6 shadow-xl min-h-[400px] flex flex-col">
+                <div className="flex justify-between items-center mb-6 border-b border-gray-200 dark:border-slate-800/80 pb-4">
                   <h3 className="text-xl font-bold flex items-center space-x-2">
                     <span>Your Classroom Sessions</span>
                     <span className="bg-indigo-500/10 text-indigo-400 text-xs px-2.5 py-0.5 rounded-full border border-indigo-500/20 font-mono">
@@ -289,15 +289,15 @@ export default function ClassroomsDashboard() {
                 </div>
 
                 {isListLoading ? (
-                  <div className="flex-grow flex flex-col items-center justify-center text-slate-500 py-12">
+                  <div className="flex-grow flex flex-col items-center justify-center text-gray-500 dark:text-slate-500 py-12">
                     <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500 mb-3"></div>
                     <p className="text-sm">Loading session history...</p>
                   </div>
                 ) : sessions.length === 0 ? (
-                  <div className="flex-grow flex flex-col items-center justify-center text-slate-500 py-12 text-center">
-                    <BookOpen size={48} className="text-slate-700 mb-4" />
-                    <p className="font-semibold text-slate-400">No session history</p>
-                    <p className="text-xs text-slate-600 max-w-xs mt-1">
+                  <div className="flex-grow flex flex-col items-center justify-center text-gray-500 dark:text-slate-500 py-12 text-center">
+                    <BookOpen size={48} className="text-gray-400 dark:text-slate-700 mb-4" />
+                    <p className="font-semibold text-gray-600 dark:text-slate-400">No session history</p>
+                    <p className="text-xs text-gray-500 dark:text-slate-600 max-w-xs mt-1">
                       Your created sessions will be saved here so you can easily enter or manage them.
                     </p>
                   </div>
@@ -306,28 +306,28 @@ export default function ClassroomsDashboard() {
                     {sessions.map((session) => (
                       <div 
                         key={session.roomId}
-                        className="bg-slate-950/60 border border-slate-850 hover:border-slate-800 rounded-xl p-4 transition-all flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 group"
+                        className="bg-gray-100 dark:bg-slate-950/60 border border-gray-200 dark:border-slate-800 hover:border-gray-300 dark:hover:border-slate-700 rounded-xl p-4 transition-all flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 group"
                       >
                         <div className="space-y-1 max-w-[70%]">
                           <div className="flex items-center space-x-2">
-                            <h4 className="font-semibold text-slate-200 truncate">{session.title}</h4>
+                            <h4 className="font-semibold text-gray-800 dark:text-slate-200 truncate">{session.title}</h4>
                             <span className={`text-[10px] uppercase tracking-wider font-bold px-2 py-0.5 rounded ${
                               session.status === "active" 
                                 ? "bg-emerald-500/10 text-emerald-400 border border-emerald-500/20" 
-                                : "bg-slate-800 text-slate-400 border border-slate-700/50"
+                                : "bg-slate-800 text-gray-600 dark:text-slate-400 border border-slate-700/50"
                             }`}>
                               {session.status}
                             </span>
                           </div>
-                          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-slate-500 font-mono">
+                          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500 dark:text-slate-500 font-mono">
                             {session.subject && (
                               <span className="flex items-center space-x-1">
-                                <BookOpen size={12} className="text-slate-600" />
+                                <BookOpen size={12} className="text-gray-500 dark:text-slate-600" />
                                 <span>{session.subject}</span>
                               </span>
                             )}
                             <span className="flex items-center space-x-1">
-                              <Calendar size={12} className="text-slate-600" />
+                              <Calendar size={12} className="text-gray-500 dark:text-slate-600" />
                               <span>{formatDate(session.createdAt)}</span>
                             </span>
                           </div>
@@ -351,7 +351,7 @@ export default function ClassroomsDashboard() {
                               </button>
                             </>
                           ) : (
-                            <span className="text-slate-600 text-xs font-semibold px-3 py-1.5 flex items-center space-x-1 font-mono">
+                            <span className="text-gray-500 dark:text-slate-600 text-xs font-semibold px-3 py-1.5 flex items-center space-x-1 font-mono">
                               <Clock size={12} />
                               <span>Ended</span>
                             </span>
@@ -364,8 +364,8 @@ export default function ClassroomsDashboard() {
               </div>
             ) : (
               // Student View: Active Sessions List
-              <div className="bg-slate-900/40 backdrop-blur-md border border-slate-800/80 rounded-2xl p-6 shadow-xl min-h-[400px] flex flex-col">
-                <div className="flex justify-between items-center mb-6 border-b border-slate-800/80 pb-4">
+              <div className="bg-gray-50 dark:bg-slate-900/40 backdrop-blur-md border border-gray-200 dark:border-slate-800/80 rounded-2xl p-6 shadow-xl min-h-[400px] flex flex-col">
+                <div className="flex justify-between items-center mb-6 border-b border-gray-200 dark:border-slate-800/80 pb-4">
                   <h3 className="text-xl font-bold flex items-center space-x-2">
                     <span>Active Live Classrooms</span>
                     <span className="bg-indigo-500/10 text-indigo-400 text-xs px-2.5 py-0.5 rounded-full border border-indigo-500/20 font-mono animate-[pulse_2s_infinite]">
@@ -382,23 +382,23 @@ export default function ClassroomsDashboard() {
                 </div>
 
                 {isListLoading ? (
-                  <div className="flex-grow flex flex-col items-center justify-center text-slate-500 py-12">
+                  <div className="flex-grow flex flex-col items-center justify-center text-gray-500 dark:text-slate-500 py-12">
                     <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500 mb-3"></div>
                     <p className="text-sm">Scanning for active learning rooms...</p>
                   </div>
                 ) : sessions.length === 0 ? (
                   <div className="flex-grow flex flex-col space-y-6">
-                    <div className="flex flex-col items-center justify-center text-slate-500 py-6 text-center">
-                      <BookOpen size={48} className="text-slate-700 mb-4" />
-                      <p className="font-semibold text-slate-400">No active classrooms right now</p>
-                      <p className="text-xs text-slate-600 max-w-xs mt-1">
+                    <div className="flex flex-col items-center justify-center text-gray-500 dark:text-slate-500 py-6 text-center">
+                      <BookOpen size={48} className="text-gray-400 dark:text-slate-700 mb-4" />
+                      <p className="font-semibold text-gray-600 dark:text-slate-400">No active classrooms right now</p>
+                      <p className="text-xs text-gray-500 dark:text-slate-600 max-w-xs mt-1">
                         Tutors haven't started any public classes yet. Check out the guidelines below on how to join a custom room.
                       </p>
                     </div>
                     
                     {/* Fallback guidelines */}
-                    <div className="border-t border-slate-800/60 pt-6 space-y-4">
-                      <h4 className="text-sm font-bold text-slate-300 uppercase tracking-wider">How to Join a Session</h4>
+                    <div className="border-t border-gray-200 dark:border-slate-800/60 pt-6 space-y-4">
+                      <h4 className="text-sm font-bold text-gray-700 dark:text-slate-300 uppercase tracking-wider">How to Join a Session</h4>
                       
                       <div className="space-y-4">
                         <div className="flex gap-3">
@@ -406,8 +406,8 @@ export default function ClassroomsDashboard() {
                             1
                           </div>
                           <div>
-                            <h5 className="text-xs font-semibold text-slate-200">Get the Room ID</h5>
-                            <p className="text-[11px] text-slate-400 mt-0.5 leading-relaxed">
+                            <h5 className="text-xs font-semibold text-gray-800 dark:text-slate-200">Get the Room ID</h5>
+                            <p className="text-[11px] text-gray-600 dark:text-slate-400 mt-0.5 leading-relaxed">
                               Ask your tutor for the unique, secure session UUID. They can copy this directly from their dashboard.
                             </p>
                           </div>
@@ -418,8 +418,8 @@ export default function ClassroomsDashboard() {
                             2
                           </div>
                           <div>
-                            <h5 className="text-xs font-semibold text-slate-200">Paste & Connect</h5>
-                            <p className="text-[11px] text-slate-400 mt-0.5 leading-relaxed">
+                            <h5 className="text-xs font-semibold text-gray-800 dark:text-slate-200">Paste & Connect</h5>
+                            <p className="text-[11px] text-gray-600 dark:text-slate-400 mt-0.5 leading-relaxed">
                               Enter the UUID in the input form on the left, then click "Join Classroom" to connect your camera/mic.
                             </p>
                           </div>
@@ -432,7 +432,7 @@ export default function ClassroomsDashboard() {
                     {sessions.map((session) => (
                       <div 
                         key={session.roomId}
-                        className="bg-slate-950/60 border border-slate-850 hover:border-slate-800 rounded-xl p-4 transition-all flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 group hover:shadow-[0_0_15px_rgba(99,102,241,0.1)]"
+                        className="bg-gray-100 dark:bg-slate-950/60 border border-gray-200 dark:border-slate-800 hover:border-gray-300 dark:hover:border-slate-700 rounded-xl p-4 transition-all flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 group hover:shadow-[0_0_15px_rgba(99,102,241,0.1)]"
                       >
                         <div className="space-y-2 max-w-[70%] text-left">
                           <div className="flex items-center space-x-2">
@@ -440,18 +440,18 @@ export default function ClassroomsDashboard() {
                               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
                               <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500"></span>
                             </span>
-                            <h4 className="font-semibold text-slate-200 truncate">{session.title}</h4>
+                            <h4 className="font-semibold text-gray-800 dark:text-slate-200 truncate">{session.title}</h4>
                           </div>
 
-                          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-slate-500 font-mono">
+                          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500 dark:text-slate-500 font-mono">
                             {session.subject && (
                               <span className="flex items-center space-x-1">
-                                <BookOpen size={12} className="text-slate-600" />
+                                <BookOpen size={12} className="text-gray-500 dark:text-slate-600" />
                                 <span>{session.subject}</span>
                               </span>
                             )}
                             <span className="flex items-center space-x-1">
-                              <Users size={12} className="text-slate-600" />
+                              <Users size={12} className="text-gray-500 dark:text-slate-600" />
                               <span>Max {session.maxParticipants} students</span>
                             </span>
                           </div>
@@ -463,7 +463,7 @@ export default function ClassroomsDashboard() {
                                 <img 
                                   src={session.host.profilePic} 
                                   alt={session.host.name} 
-                                  className="w-5 h-5 rounded-full object-cover border border-slate-800"
+                                  className="w-5 h-5 rounded-full object-cover border border-gray-200 dark:border-slate-800"
                                   onError={(e) => {
                                     e.target.onerror = null;
                                     e.target.src = `https://api.dicebear.com/7.x/initials/svg?seed=${encodeURIComponent(session.host.name)}`;
@@ -474,8 +474,8 @@ export default function ClassroomsDashboard() {
                                   {session.host.name?.charAt(0).toUpperCase()}
                                 </div>
                               )}
-                              <span className="text-xs text-slate-400">
-                                Hosted by <span className="text-slate-300 font-medium">{session.host.name}</span>
+                              <span className="text-xs text-gray-600 dark:text-slate-400">
+                                Hosted by <span className="text-gray-700 dark:text-slate-300 font-medium">{session.host.name}</span>
                               </span>
                               <span className="text-[9px] bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 px-1.5 py-0.2 rounded uppercase tracking-wider font-semibold font-mono scale-90 origin-left">
                                 Tutor


### PR DESCRIPTION
Closes #599 

## Description

Converted hardcoded dark theme styles in the classrooms dashboard to proper theme-aware light mode styling.

## Changes made

- converted dashboard containers to light mode compatible backgrounds
- updated session cards and list sections
- fixed borders and divider contrast
- improved muted text readability
- updated input and placeholder styling
- improved empty state visibility
- preserved existing dark mode behavior using `dark:` variants

## File updated

- `ClassroomsDashboard.jsx`

## Screenshot
<br>
<img width="1918" height="1021" alt="Screenshot 2026-05-22 233836" src="https://github.com/user-attachments/assets/e26efbbb-56bf-4172-8ad1-76459d275a56" />
