### PR TITLE
fix: Prevent Critical Server-Side Request Forgery (SSRF) in Link Verification

### DIFF
--- a/server/src/utils/linkVerifier.js
+++ b/server/src/utils/linkVerifier.js
@@ -1,4 +1,51 @@
 import axios from "axios";
+import dns from "dns";
+
+const isPrivateIP = (ip) => {
+  if (ip.includes(":")) {
+    // IPv6 (loopback, link-local, unique local)
+    return ip === "::1" || ip.startsWith("fe80:") || ip.startsWith("fc00:") || ip.startsWith("fd00:");
+  }
+
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4) return true;
+
+  const [a, b] = parts;
+  if (
+    a === 10 || // 10.0.0.0/8
+    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
+    (a === 192 && b === 168) || // 192.168.0.0/16
+    a === 127 || // 127.0.0.0/8
+    a === 169 || // 169.254.0.0/16
+    a === 0 // 0.0.0.0/8
+  ) {
+    return true;
+  }
+  return false;
+};
+
+const validateAndResolveUrl = async (urlString) => {
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(urlString);
+  } catch (err) {
+    throw new Error("Invalid URL format");
+  }
+
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw new Error("Invalid protocol");
+  }
+
+  const hostname = parsedUrl.hostname;
+
+  return new Promise((resolve, reject) => {
+    dns.lookup(hostname, (err, address) => {
+      if (err) return reject(new Error("DNS resolution failed"));
+      if (isPrivateIP(address)) return reject(new Error("URL resolves to a private IP address"));
+      resolve(address);
+    });
+  });
+};
 
 /**
  * Verifies if a URL is active and reachable.
@@ -9,13 +56,17 @@ export const verifyLink = async (url) => {
   if (!url) return { url, isValid: false, status: null };
 
   try {
+    // 1. SSRF Mitigation: Validate and resolve the URL to check for private IPs
+    await validateAndResolveUrl(url);
+
+    // 2. Perform the GET request securely
     const response = await axios.get(url, {
       timeout: 5000,
-      maxRedirects: 5,
+      maxRedirects: 0, // SSRF Mitigation: Prevent attacker from returning a 302 redirect to a private IP
+      validateStatus: (status) => status >= 200 && status < 400, // Treat redirects (3xx) as a valid reachable link
       headers: {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
       },
-      // We only care about headers, but some sites block HEAD requests
       method: "GET", 
     });
 


### PR DESCRIPTION
## Description

This PR resolves a **Critical Server-Side Request Forgery (SSRF)** vulnerability located in the `verifyLinks` utility (`server/src/utils/linkVerifier.js`). 

Previously, URLs parsed from uploaded resumes were passed directly into `axios.get()` without any sanitization or validation. This allowed malicious actors to upload resumes containing internal network endpoints (e.g., `http://localhost:27017` or AWS EC2 Metadata `http://169.254.169.254/latest/meta-data/`). By reading the HTTP status codes returned by the backend server, attackers could port-scan the internal network or interact with unsecured internal APIs.

This implementation securely neutralizes the vulnerability using robust DNS validation and strict redirect configurations.

## Changes Included

- **DNS Resolution & IP Validation:** Added a `validateAndResolveUrl` function that extracts the hostname and resolves it via Node's `dns.lookup`. 
- **Private IP Blocking:** Implemented an `isPrivateIP` check that immediately rejects any URL attempting to access internal subnets, loopbacks, or cloud metadata IP ranges (`10.x.x.x`, `127.x.x.x`, `169.254.x.x`, `192.168.x.x`, `172.16.x.x`, `0.x.x.x`, and IPv6 equivalents).
- **Redirect Attack Prevention:** Updated the `axios` configuration to use `maxRedirects: 0`. This stops attackers from bypassing the initial IP check by hosting an external domain that immediately returns a `302 Redirect` to a protected internal IP.
- **Valid Link Support:** Modified the `validateStatus` config to accept `3xx` HTTP status codes. This ensures legitimate URLs that utilize safe redirects (such as `bit.ly` shortened links) are still recognized as "active" and valid without the server needing to follow the redirect.

## Labels
`bug` `security` `critical` `high-priority`

## Related Issues

- Resolves #603 

## Testing Performed

- Manually verified that public links (e.g., `https://github.com`) correctly resolve and return `isValid: true`.
- Ensured synthetic payloads targeting localhost (`http://127.0.0.1`) and cloud metadata (`http://169.254.169.254`) are intercepted and rejected before making an HTTP request.
- Confirmed `maxRedirects: 0` accurately prevents chained redirect attacks while keeping genuine redirect URLs categorized as valid.