### PR TITLE
fix: Prevent Arbitrary File Write via Path Traversal in Resume Uploads

### DIFF
--- a/server/src/middleware/uploadResume.js
+++ b/server/src/middleware/uploadResume.js
@@ -50,8 +50,9 @@ export const removeUploadedFile = (filePath) => {
 };
 
 const buildStoredFilename = (originalName) => {
-  const ext = path.extname(originalName);
-  const name = originalName.replace(ext, "").replace(/\s+/g, "-");
+  const safeName = path.basename(originalName);
+  const ext = path.extname(safeName);
+  const name = safeName.replace(ext, "").replace(/\s+/g, "-");
   return `${Date.now()}-${name}${ext}`;
 };
 


### PR DESCRIPTION
## Description

This PR resolves a **Critical Path Traversal** vulnerability in the `server/src/middleware/uploadResume.js` file.

Previously, the `buildStoredFilename` function directly incorporated the user-controlled `file.originalname` property into the file path on disk without sanitizing directory traversal characters (e.g., `../`). This allowed an attacker to break out of the `uploads` directory and arbitrarily overwrite `.txt`, `.pdf`, or `.doc(x)` files anywhere on the server filesystem that the Node process had access to.

## Changes Included

- **Filename Sanitization:** Integrated `path.basename(originalName)` inside `buildStoredFilename` to securely strip any directory paths and traversal payloads from the uploaded file's name before parsing its extension and storing it on disk.

## Labels
`bug` `security` `critical` `high-priority`

## Related Issues

- Resolves #605 

## Testing Performed

- Validated Node.js syntax after implementation.
- Verified that legitimate uploads still correctly generate safe names formatted as `${Date.now()}-filename.ext`.
- Confirmed that payloads attempting directory traversal (e.g., `../../../../etc/passwd.txt`) are securely reduced to safe filenames (e.g., `${Date.now()}-passwd.txt`).