### PR TITLE
fix: Prevent Catastrophic ReDoS and NoSQL Injection in Job Filters

### DIFF
--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -35,8 +35,9 @@ export const getAllJobs = async (queryParams = {}) => {
   const filters = { status: "open" };
 
   // Filter by designation (case-insensitive regex search on title)
-  if (designation) {
-    filters.title = { $regex: designation, $options: "i" };
+  if (designation && typeof designation === "string") {
+    const escapeRegex = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    filters.title = { $regex: escapeRegex(designation), $options: "i" };
   }
 
   // Filter by Salary Range


### PR DESCRIPTION
## Description

This PR resolves a **Critical Regular Expression Denial of Service (ReDoS)** and **NoSQL Injection** vulnerability in `server/src/modules/jobs/service.js`.

Previously, the `getAllJobs` endpoint accepted raw user input via the `designation` query parameter and blindly injected it into a MongoDB `$regex` operator. This allowed malicious users to crash the entire application database by sending deeply nested "evil regex" payloads (e.g., `^(((a+)+)+)+$`), which triggered exponential catastrophic backtracking in the MongoDB PCRE engine.

It also permitted NoSQL operator injections (e.g., passing objects like `designation[$ne]=abc`), leading to unhandled server exceptions.

## Changes Included

- **Regex Escaping:** Integrated an `escapeRegex` sanitization function to strip all special regular expression tokens `[.*+?^${}()|[\]\\]` from the user input before evaluating it in the database.
- **Type Safety:** Added a strict `typeof designation === "string"` condition to guarantee that MongoDB `$regex` only processes primitive strings, inherently preventing NoSQL object injection attacks.

## Labels
`bug` `security` `critical` `database`

## Related Issues

- Resolves #607 

## Testing Performed

- Validated Node.js syntax after implementation.
- Verified that legitimate job title searches continue to function exactly as expected.
- Sent synthetic ReDoS payloads to confirm they are safely escaped and evaluated literally rather than triggering exponential DB load.
- Simulated NoSQL object injections to ensure they gracefully bypass the `$regex` block without throwing 500 server errors.