### PR TITLE
fix: Prevent Broken Object Level Authorization via Mass Assignment in Job Updates

### DIFF
--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -128,6 +128,13 @@ export const updateJob = async (id, updateData, recruiterId) => {
     throw new AppError("You do not have permission to update this job", 403);
   }
 
+  // Prevent Mass Assignment: Remove protected fields
+  delete updateData.recruiter;
+  delete updateData._id;
+  delete updateData.createdAt;
+  delete updateData.updatedAt;
+  delete updateData.__v;
+
   const updatedJob = await JobPosting.findByIdAndUpdate(id, updateData, {
     new: true,
     runValidators: true,


### PR DESCRIPTION
## Description

This PR resolves a **High Severity Broken Object Level Authorization (BOLA) / Mass Assignment** vulnerability in `server/src/modules/jobs/service.js`.

Previously, the `updateJob` function blindly passed the user-controlled `req.body` directly into Mongoose's `JobPosting.findByIdAndUpdate()` method without filtering the payload. While an initial ownership check was performed, an attacker who owned a job could still supply an unauthorized payload like `{ "recruiter": "target_user_id" }`. Because the payload was trusted, Mongoose would instantly overwrite the `recruiter` field, transferring ownership of the job posting to an arbitrary user and bypassing authorization boundaries.

## Changes Included

- **Payload Sanitization:** Implemented explicit filtering inside `updateJob` to permanently delete `recruiter`, `_id`, `createdAt`, `updatedAt`, and `__v` from the update payload before it touches the database layer. This ensures core system and ownership fields are completely immutable during standard updates.

## Labels
`bug` `security` `high-priority` `authorization`

## Related Issues

- Resolves #610 

## Testing Performed

- Validated Node.js syntax after implementation.
- Verified that legitimate job updates (e.g., updating title or description) continue to function perfectly.
- Attempted to pass `{ "recruiter": "some_other_id" }` in the payload; confirmed that ownership remains unchanged and the malicious field is safely discarded.