### PR TITLE
feature: Implement In-Memory Caching to Optimize Heavy Analytical Aggregations

### DIFF
--- a/server/src/modules/interviews/service.js
+++ b/server/src/modules/interviews/service.js
@@ -7,6 +7,7 @@ import {
   transcribeAudio,
   evaluateAnswer,
 } from "../../integrations/aiInterviewService.js";
+import cache from "../../utils/cache.js";
 
 /**
  * Select random questions from the bank for a given topic and difficulty.
@@ -368,6 +369,10 @@ export const getSessionResults = async (sessionId, userId) => {
  * List all available interview topics from the question bank.
  */
 export const listAvailableTopics = async () => {
+  const CACHE_KEY = "interview_topics";
+  const cachedData = cache.get(CACHE_KEY);
+  if (cachedData) return cachedData;
+
   const topics = await QuestionBank.aggregate([
     {
       $group: {
@@ -387,6 +392,7 @@ export const listAvailableTopics = async () => {
     { $sort: { topic: 1 } },
   ]);
 
+  cache.set(CACHE_KEY, topics, 1800); // Cache for 30 minutes
   return topics;
 };
 

--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -8,6 +8,7 @@ import { generateRecommendations } from "../../../../ai-ml/pipeline/recommendati
 import AppError from "../../utils/AppError.js";
 import { getIO } from "../../utils/socketIO.js";
 import recruiterIntelligenceService from "../recruiterIntelligence/service.js";
+import cache from "../../utils/cache.js";
 
 /**
  * Create a new job posting
@@ -141,6 +142,10 @@ export const updateJob = async (id, updateData, recruiterId) => {
  * @returns {Promise<Array>} Array of { skill: string, count: number }
  */
 export const getSkillTrends = async () => {
+  const CACHE_KEY = "global_skill_trends";
+  const cachedData = cache.get(CACHE_KEY);
+  if (cachedData) return cachedData;
+
   const trends = await JobPosting.aggregate([
     { $match: { status: "open" } },
     { $unwind: "$skills" },
@@ -160,6 +165,8 @@ export const getSkillTrends = async () => {
       },
     },
   ]);
+  
+  cache.set(CACHE_KEY, trends, 900); // Cache for 15 minutes
   return trends;
 };
 
@@ -279,6 +286,10 @@ export const getJobRecommendations = async (user) => {
  * @returns {Promise<Object>} - Analytics data
  */
 export const getRecruiterAnalytics = async (recruiterId) => {
+  const CACHE_KEY = `recruiter_analytics_${recruiterId.toString()}`;
+  const cachedData = cache.get(CACHE_KEY);
+  if (cachedData) return cachedData;
+
   // Get all jobs for this recruiter
   const allJobs = await JobPosting.find({ recruiter: recruiterId })
     .sort({ createdAt: -1 })
@@ -347,13 +358,16 @@ export const getRecruiterAnalytics = async (recruiterId) => {
     createdAt: job.createdAt,
   }));
 
-  return {
+  const result = {
     totalJobs: allJobs.length,
     statusBreakdown,
     jobsByMonth,
     topSkills,
     recentJobs,
   };
+
+  cache.set(CACHE_KEY, result, 300); // Cache for 5 minutes
+  return result;
 };
 
 /**

--- a/server/src/utils/cache.js
+++ b/server/src/utils/cache.js
@@ -1,0 +1,51 @@
+class SimpleCache {
+  constructor() {
+    this.cache = new Map();
+  }
+
+  /**
+   * Set a value in the cache with a Time-To-Live (TTL)
+   * @param {string} key - The cache key
+   * @param {any} value - The value to store
+   * @param {number} ttlSeconds - Time to live in seconds
+   */
+  set(key, value, ttlSeconds) {
+    const expiresAt = Date.now() + ttlSeconds * 1000;
+    this.cache.set(key, { value, expiresAt });
+  }
+
+  /**
+   * Retrieve a value from the cache. Returns null if missing or expired.
+   * @param {string} key - The cache key
+   * @returns {any|null} The cached value or null
+   */
+  get(key) {
+    const item = this.cache.get(key);
+    if (!item) return null;
+
+    if (Date.now() > item.expiresAt) {
+      this.cache.delete(key);
+      return null;
+    }
+    return item.value;
+  }
+
+  /**
+   * Manually delete an item from the cache
+   * @param {string} key - The cache key
+   */
+  delete(key) {
+    this.cache.delete(key);
+  }
+
+  /**
+   * Clear the entire cache
+   */
+  clear() {
+    this.cache.clear();
+  }
+}
+
+// Export a singleton instance
+const cache = new SimpleCache();
+export default cache;


### PR DESCRIPTION
## Description

This PR introduces a substantial **Performance Enhancement** by implementing an in-memory caching layer across the platform's heaviest analytical endpoints.

Previously, dashboards and trend features relied on complex MongoDB aggregations (such as `$unwind`, `$group`, and cross-collection scans) executing in real-time on every single `GET` request. As the platform scales, this approach would lead to severe database CPU strain and sluggish UI rendering.

## Changes Included

- **`SimpleCache` Utility:** Created a lightweight, dependency-free caching class (`server/src/utils/cache.js`) utilizing a native JavaScript `Map` with automatic Time-To-Live (TTL) expiration logic.
- **Job Analytics Caching:** Wrapped `getSkillTrends` with a 15-minute TTL cache and `getRecruiterAnalytics` with a 5-minute TTL cache.
- **Interview Topics Caching:** Wrapped `listAvailableTopics` with a 30-minute TTL cache, completely bypassing the database for subsequent requests.

## Labels
`enhancement` `performance` `database`

## Related Issues

- Resolves #612 

## Testing Performed

- Validated Node.js syntax and build integrity across all modified services.
- Confirmed that caching logic seamlessly intercepts requests before hitting Mongoose.
- Verified that stale cache entries correctly evaporate after their respective TTLs expire.