### PR TITLE
Integrate Gemini into chat endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,9 @@ EMAIL_FROM="SkillsSphere AI" <no-reply@skillssphere.ai>
 # Get your free token at: https://huggingface.co/settings/tokens
 HF_API_TOKEN=your_hugging_face_token_here
 
+# Gemini API key used by cover-letter generation and the AI chat assistant
+GEMINI_API_KEY=your_gemini_api_key_here
+
 # ==========================================
 # Interview AI Service Configuration
 # ==========================================

--- a/server/index.js
+++ b/server/index.js
@@ -29,6 +29,7 @@ import swaggerUi from 'swagger-ui-express';
 import swaggerSpec from './src/config/swaggerConfig.js';
 import { validateEnv } from './src/config/validateEnv.js';
 import analyticsRoutes from "./src/modules/analytics/routes.js";
+import { generateCareerAssistantReply } from "./src/utils/geminiService.js";
 const app = express();
 app.set("trust proxy", 1);
 const PORT = process.env.PORT || 5000;
@@ -86,22 +87,37 @@ app.get("/health", (req, res) => {
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
-app.post("/api/chat", (req, res) => {
+const getStaticChatReply = (message) => {
+  const msg = message.toLowerCase();
+  if (msg.includes("hello") || msg.includes("hi")) {
+    return "Hi! How can I help you?";
+  }
+  if (msg.includes("help")) {
+    return "Sure! Tell me what you need help with.";
+  }
+  if (msg.includes("resume")) {
+    return "You can upload or manage your resumes here.";
+  }
+  return "I can help with resumes, interviews, career planning, and skill development.";
+};
+
+app.post("/api/chat", async (req, res) => {
   try {
     const { message } = req.body;
-    if (!message) {
+    if (!message || typeof message !== "string") {
       return res.status(400).json({ error: "Message required" });
     }
-    let reply = "I didn't understand that.";
-    const msg = message.toLowerCase();
-    if (msg.includes("hello") || msg.includes("hi")) {
-      reply = "Hi! How can I help you?";
-    } else if (msg.includes("help")) {
-      reply = "Sure! Tell me what you need help with.";
-    } else if (msg.includes("resume")) {
-      reply = "You can upload or manage your resumes here.";
+
+    const result = await generateCareerAssistantReply(message);
+    if (result.success) {
+      return res.json({ reply: result.text });
     }
-    res.json({ reply });
+
+    return res.json({
+      reply: getStaticChatReply(message),
+      fallback: true,
+      reason: result.error,
+    });
   } catch (error) {
     res.status(500).json({ error: "Server error" });
   }

--- a/server/src/utils/geminiService.js
+++ b/server/src/utils/geminiService.js
@@ -72,3 +72,70 @@ export const generateCoverLetter = async (prompt) => {
     };
   }
 };
+
+/**
+ * Generates a scoped SkillsSphere career-assistant reply for the chat widget.
+ *
+ * @param {string} message - User message from the chat endpoint.
+ * @returns {Promise<{success: boolean, text?: string, error?: string}>}
+ */
+export const generateCareerAssistantReply = async (message) => {
+  if (!message || typeof message !== "string") {
+    return {
+      success: false,
+      error: "Invalid or empty message provided.",
+    };
+  }
+
+  const prompt = `
+You are the SkillsSphere Career Assistant.
+
+Help users with career guidance, resume optimization, recruitment workflows,
+technical interview preparation, learning plans, and skill-gap analysis.
+
+If a user asks for something unrelated to careers, hiring, learning, resumes,
+interviews, or SkillsSphere workflows, politely redirect them back to those
+topics. Keep the response practical, concise, and action-oriented.
+
+User message:
+${message.trim()}
+`;
+
+  try {
+    const aiClient = initializeGemini();
+    const model = aiClient.getGenerativeModel({ model: "gemini-1.5-flash" });
+
+    const result = await model.generateContent(prompt);
+    const response = await result.response;
+    const text = response.text();
+
+    if (!text) {
+      return {
+        success: false,
+        error: "Gemini API returned an empty response.",
+      };
+    }
+
+    return {
+      success: true,
+      text: text.trim(),
+    };
+  } catch (error) {
+    console.error("Gemini Chatbot Error:", error.message || error);
+
+    let errorMessage = "Failed to generate a chatbot response due to an API error.";
+
+    if (error.message && error.message.includes("GEMINI_API_KEY is missing")) {
+      errorMessage = "Gemini API key is not configured on the server.";
+    } else if (error.status === 429 || (error.message && error.message.includes("quota"))) {
+      errorMessage = "Gemini API rate limit or quota exceeded. Please try again later.";
+    } else if (error.message && (error.message.includes("fetch failed") || error.message.includes("timeout"))) {
+      errorMessage = "Network error or timeout while contacting the Gemini API.";
+    }
+
+    return {
+      success: false,
+      error: errorMessage,
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `/api/chat` keyword branch with an async Gemini-backed SkillsSphere Career Assistant.
- Reuses the existing lazy Gemini client pattern so the server still starts without a configured key.
- Keeps a static career-focused fallback response and documents `GEMINI_API_KEY` in `.env.example`.

## Verification
- `node --check server/index.js`
- `node --check server/src/utils/geminiService.js`
- `git diff --check`

Note: `npm --prefix server test` and a targeted `node --test ...` run did not complete locally within the timeout, so I stopped the spawned Node processes and kept verification to terminating syntax/diff checks.

Closes #614