### PR TITLE
fix: Prevent Broken Access Control in Classroom WebRTC Signaling

### DIFF
--- a/server/src/modules/classrooms/socket.js
+++ b/server/src/modules/classrooms/socket.js
@@ -118,6 +118,24 @@ export function initClassroomSockets(io) {
 
     // WebRTC Signaling Events
     socket.on("webrtc-offer", ({ targetSocketId, offer }) => {
+      // Validate that both sockets exist and are in the same room
+      if (!socket.data || !socket.data.roomId) {
+        socket.emit("unauthorized", { message: "You must join a room first" });
+        return;
+      }
+
+      const targetSocket = io.sockets.sockets.get(targetSocketId);
+      if (
+        !targetSocket ||
+        !targetSocket.data ||
+        targetSocket.data.roomId !== socket.data.roomId
+      ) {
+        socket.emit("unauthorized", {
+          message: "Target user is not in your classroom",
+        });
+        return;
+      }
+
       socket.to(targetSocketId).emit("webrtc-offer", {
         callerSocketId: socket.id,
         callerUser: socket.data ? socket.data.user : socket.user,


### PR DESCRIPTION
## Description

This PR resolves a **High Severity Broken Access Control** vulnerability in `server/src/modules/classrooms/socket.js`.

Previously, while most WebSocket events securely validated that users were communicating within their designated classroom boundaries, the `webrtc-offer` event omitted this check entirely. This allowed a malicious actor connected to the WebSocket server to blindly emit P2P connection offers to any target socket ID across the platform, potentially harassing users in completely isolated, private classrooms.

## Changes Included

- **Socket Authorization Check:** Implemented strict validation logic in the `webrtc-offer` handler to ensure `socket.data.roomId` strictly matches `targetSocket.data.roomId`. 
- If a cross-room injection is attempted, the payload is immediately dropped and an `unauthorized` error is emitted back to the attacker.

## Labels
`bug` `security` `high-priority` `authorization` `websockets`

## Related Issues

- Resolves #617 

## Testing Performed

- Validated Node.js syntax after implementation.
- Verified that legitimate WebRTC offers within the same classroom continue to establish P2P connections seamlessly.
- Simulated a cross-room attack payload; confirmed that the server now successfully drops the offer and emits the `Target user is not in your classroom` error.