### PR TITLE
fix: Prevent Denial of Service (DoS) in Roadmap Sync via Unbounded Arrays

### DIFF
--- a/server/src/modules/roadmap/controller.js
+++ b/server/src/modules/roadmap/controller.js
@@ -32,6 +32,10 @@ export const syncRoadmap = asyncHandler(async (req, res) => {
     throw new AppError("Target role and topics are required", 400);
   }
 
+  if (topics.length > 50) {
+    throw new AppError("Roadmap topics exceed the maximum allowed limit of 50", 413);
+  }
+
   let progress = await LearningProgress.findOne({ user: req.user._id });
 
   const roadmapData = topics.map(topic => {


### PR DESCRIPTION
## Description

This PR resolves a **High Severity Security/Performance** issue in `server/src/modules/roadmap/controller.js`.

Previously, the `syncRoadmap` endpoint blindly iterated over the incoming `topics` array from the request body without any length validation. This allowed an authenticated attacker to submit a massive JSON payload containing tens of thousands of nested topics. Parsing and mapping this massive array caused severe synchronous memory allocations on the V8 heap, blocking the event loop and potentially crashing both the Node.js instance (OOM) and the MongoDB connection pool.

## Changes Included

- **Array Bounds Validation:** Implemented a strict check (`topics.length > 50`) immediately after confirming the payload is an array.
- If the threshold is exceeded, the server instantly aborts processing and throws a `413 Payload Too Large` error back to the client, keeping memory usage flat.

## Labels
`bug` `security` `performance` `high-priority`

## Related Issues

- Resolves #619 

## Testing Performed

- Validated Node.js syntax after implementation.
- Verified that standard roadmap syncs (e.g., 5-20 topics) continue to process and merge into the database correctly.
- Simulated a massive payload attack; confirmed that the server now successfully drops the request and emits the `Roadmap topics exceed the maximum allowed limit of 50` error.