### PR TITLE
fix: Resolve cross-module notification schema mismatches and transaction failures

### DIFF
--- a/server/src/database/models/Notification.js
+++ b/server/src/database/models/Notification.js
@@ -34,6 +34,8 @@ const notificationSchema = new mongoose.Schema(
         "job-update",
         "interview",
         "application",
+        "new_application",
+        "skill_gap_alert",
       ],
       default: "info",
       required: [true, "Notification type is required"],
@@ -60,6 +62,15 @@ const notificationSchema = new mongoose.Schema(
         default: null,
       },
       _id: false,
+    },
+
+    /**
+     * Flexible field for cross-module notification context.
+     * Used by jobs (jobId, applicationId, studentId) and matching (jobId, studentId, score).
+     */
+    relatedData: {
+      type: mongoose.Schema.Types.Mixed,
+      default: null,
     },
   },
   { timestamps: true },

--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -441,7 +441,7 @@ export const applyToJob = async (jobId, applicantId, options = {}) => {
     application = appDocs[0];
 
     const notifDocs = await Notification.create([{
-      recipient: job.recruiter,
+      userId: job.recruiter,
       type: "new_application",
       title: "New Job Application",
       message: `A new candidate has applied for ${job.title}.`,

--- a/server/src/modules/matching/service.js
+++ b/server/src/modules/matching/service.js
@@ -95,7 +95,7 @@ export const evaluateMatches = async (user, resume, preFilteredJobs = null) => {
           // 1. Notify Recruiter (if known)
           if (jobFull.postedBy) {
             const notif = await Notification.create([{
-              recipient: jobFull.postedBy,
+              userId: jobFull.postedBy,
               type: "skill_gap_alert",
               title: "Candidate Skill Gap Alert",
               message: `${user.name || "A candidate"} showed interest but has a skill gap for ${jobFull.title} (Score: ${rec.score}%).`,
@@ -109,7 +109,7 @@ export const evaluateMatches = async (user, resume, preFilteredJobs = null) => {
           const tutor = await User.findOne({ role: "tutor" }).session(session);
           if (tutor) {
             const tutorNotif = await Notification.create([{
-              recipient: tutor._id,
+              userId: tutor._id,
               type: "skill_gap_alert",
               title: "Student Needs Mentoring Intervention",
               message: `${user.name || "A student"} scored ${rec.score}% for ${jobFull.title}. They need guidance to bridge this gap.`,

--- a/server/src/modules/notifications/controller.js
+++ b/server/src/modules/notifications/controller.js
@@ -72,6 +72,8 @@ export const createNotification = asyncHandler(async (req, res) => {
       "job-update",
       "interview",
       "application",
+      "new_application",
+      "skill_gap_alert",
     ];
     if (!validTypes.includes(type)) {
       validationErrors.type = `Type must be one of: ${validTypes.join(", ")}`;


### PR DESCRIPTION
**Labels:** `bug` `help wanted` `level:hard` `type:performance`

## Description
This PR addresses a critical bug where cross-module notifications created by the `jobs` and `matching` services were silently failing Mongoose validation and aborting transactions. This resulted in phantom notifications and silent failures for job applications and AI recommendation generation.

### Changes Made
- **Schema Update:** Extended the `Notification` model to officially support `"new_application"` and `"skill_gap_alert"` in the `type` enum.
- **Flexible Context:** Added a `relatedData` (`mongoose.Schema.Types.Mixed`) field to the Notification schema to properly persist cross-module context.
- **Service Fixes:** Fixed `Notification.create()` payload mappings in `server/src/modules/jobs/service.js` and `server/src/modules/matching/service.js` to correctly use `userId` instead of the non-existent `recipient` field.
- **Controller Sync:** Updated the `validTypes` array in `server/src/modules/notifications/controller.js` to reflect the updated schema.

## Related Issues
Resolves #649 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement (prevents aborted database transactions)