### PR TITLE
feat: implement redis caching for jobs and topics #647

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ NODE_ENV=development
 # Database Configuration
 MONGO_URI=mongodb://localhost:27017/skillssphere
 
+# Redis Configuration
+REDIS_URL=redis://localhost:6379
+
 # Auth Configuration
 JWT_SECRET=replace_with_a_long_random_secret
 JWT_EXPIRES_IN=7d

--- a/README.md
+++ b/README.md
@@ -333,10 +333,14 @@ cp .env.example .env
 - `GOOGLE_CLIENT_ID`
 - `GOOGLE_CLIENT_SECRET`
 - `GEMINI_API_KEY` (Required for AI Cover Letter Generation)
+- `REDIS_URL` (Required for caching API responses, e.g., redis://localhost:6379)
 
 ```env
 # AI/ML Configuration (Required for semantic matching — free tier)
 HF_API_TOKEN=your_hugging_face_token
+
+# Redis Configuration
+REDIS_URL=redis://localhost:6379
 
 # Email Setup (if using console/smtp directly in server)
 EMAIL_SERVICE_MODE=console

--- a/package-lock.json
+++ b/package-lock.json
@@ -1359,6 +1359,78 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+      "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+      "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+      "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+      "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+      "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
@@ -3348,6 +3420,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/color-convert": {
@@ -8251,6 +8332,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/redis": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+      "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "5.12.1",
+        "@redis/client": "5.12.1",
+        "@redis/json": "5.12.1",
+        "@redis/search": "5.12.1",
+        "@redis/time-series": "5.12.1"
+      },
+      "engines": {
+        "node": ">= 18.19.0"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -10537,6 +10634,7 @@
         "nodemailer": "^8.0.5",
         "openai": "^4.104.0",
         "pdf-parse": "^2.4.5",
+        "redis": "^5.12.1",
         "socket.io": "^4.8.3",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",

--- a/server/index.js
+++ b/server/index.js
@@ -23,6 +23,7 @@ import { initInterviewSockets } from "./src/modules/interviews/socket.js";
 import globalErrorHandler from "./src/middleware/errorMiddleware.js";
 import { logEvaluatorConfig } from "./src/config/evaluatorConfig.js";
 import { setIO } from "./src/utils/socketIO.js";
+import { connectRedis } from "./src/config/redis.js";
 import { initNotificationSockets } from "./src/modules/notifications/socket.js";
 import { verifySocketToken } from "./src/middleware/authMiddleware.js";
 import swaggerUi from "swagger-ui-express";
@@ -77,6 +78,7 @@ app.use((req, res, next) => {
   next();
 });
 
+await connectRedis();
 await connectDB();
 logEvaluatorConfig();
 

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,7 @@
     "nodemailer": "^8.0.5",
     "openai": "^4.104.0",
     "pdf-parse": "^2.4.5",
+    "redis": "^5.12.1",
     "socket.io": "^4.8.3",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",

--- a/server/src/config/redis.js
+++ b/server/src/config/redis.js
@@ -1,0 +1,21 @@
+import { createClient } from "redis";
+import dotenv from "dotenv";
+
+dotenv.config({ override: true });
+
+const redisClient = createClient({
+  url: process.env.REDIS_URL || "redis://localhost:6379",
+});
+
+redisClient.on("error", (err) => console.log("Redis Client Error", err));
+redisClient.on("connect", () => console.log("Redis Client Connected"));
+
+export const connectRedis = async () => {
+  try {
+    await redisClient.connect();
+  } catch (error) {
+    console.error("Could not connect to Redis:", error);
+  }
+};
+
+export default redisClient;

--- a/server/src/middleware/cacheMiddleware.js
+++ b/server/src/middleware/cacheMiddleware.js
@@ -1,0 +1,39 @@
+import redisClient from "../config/redis.js";
+
+const cacheMiddleware = (prefix, ttlSeconds) => {
+  return async (req, res, next) => {
+    if (req.method !== "GET") {
+      return next();
+    }
+
+    try {
+      if (!redisClient.isReady) {
+        return next();
+      }
+
+      const key = `${prefix}:${req.originalUrl}`;
+      const cachedData = await redisClient.get(key);
+
+      if (cachedData) {
+        return res.json(JSON.parse(cachedData));
+      }
+
+      const originalJson = res.json.bind(res);
+      res.json = (body) => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          redisClient.setEx(key, ttlSeconds, JSON.stringify(body)).catch((err) => {
+            console.error("Redis set error:", err);
+          });
+        }
+        return originalJson(body);
+      };
+
+      next();
+    } catch (error) {
+      console.error("Cache middleware error:", error);
+      next();
+    }
+  };
+};
+
+export default cacheMiddleware;

--- a/server/src/modules/interviews/routes.js
+++ b/server/src/modules/interviews/routes.js
@@ -1,6 +1,7 @@
 import express from "express";
 import multer from "multer";
 import { authorizeRoles, protect } from "../../middleware/authMiddleware.js";
+import cacheMiddleware from "../../middleware/cacheMiddleware.js";
 import {
   startInterview,
   getSession,
@@ -56,7 +57,7 @@ router.use(protect);
  *       200:
  *         description: List of topics
  */
-router.get("/topics", getAvailableTopics);
+router.get("/topics", cacheMiddleware("topics", 600), getAvailableTopics);
 
 // AI service status (for debugging)
 router.get("/ai-status", getAIServiceStatus);

--- a/server/src/modules/jobs/controller.js
+++ b/server/src/modules/jobs/controller.js
@@ -16,6 +16,7 @@ import {
 } from "./service.js";
 import AppError from "../../utils/AppError.js";
 import asyncHandler from "../../utils/asyncHandler.js";
+import { invalidateCacheByPrefix } from "../../utils/cacheHelpers.js";
 
 /**
  * @desc    Create a new job posting
@@ -85,6 +86,9 @@ export const createJobPosting = asyncHandler(async (req, res) => {
     keywords,
     recruiter: req.user._id,
   });
+
+  // Invalidate jobs cache
+  await invalidateCacheByPrefix("jobs");
 
   res.status(201).json({
     success: true,

--- a/server/src/modules/jobs/routes.js
+++ b/server/src/modules/jobs/routes.js
@@ -1,6 +1,7 @@
 import express from "express";
 import { protect, authorizeRoles } from "../../middleware/authMiddleware.js";
 import { jobCreationLimiter } from "../../middleware/rateLimiter.js";
+import cacheMiddleware from "../../middleware/cacheMiddleware.js";
 import {
   createJobPosting,
   getRecruiterJobs,
@@ -37,7 +38,7 @@ router.use(protect);
  *       200:
  *         description: List of jobs
  */
-router.get("/", getJobs);
+router.get("/", cacheMiddleware("jobs", 300), getJobs);
 /**
  * @openapi
  * /api/jobs/recommendations:

--- a/server/src/utils/cacheHelpers.js
+++ b/server/src/utils/cacheHelpers.js
@@ -1,0 +1,13 @@
+import redisClient from "../config/redis.js";
+
+export const invalidateCacheByPrefix = async (prefix) => {
+  try {
+    const keys = await redisClient.keys(`${prefix}:*`);
+    if (keys.length > 0) {
+      await redisClient.del(keys);
+      console.log(`Cache invalidated for keys matching: ${prefix}:*`);
+    }
+  } catch (error) {
+    console.error(`Failed to invalidate cache for prefix: ${prefix}`, error);
+  }
+};


### PR DESCRIPTION
## 📋 Description
This PR addresses issue #647 by implementing Redis caching for frequently accessed, read-heavy endpoints. As the platform grows, repeatedly querying MongoDB for the exact same job filters and static interview topics causes unnecessary database load. This caching layer significantly reduces latency and database hits.

Fixes #647

## 🎯 Goals Achieved
- Integrated `redis` client into the Node.js backend.
- Caches `GET /api/jobs` responses based on query parameters using a dynamic prefix key strategy.
- Caches `GET /api/interviews/topics` responses.
- Implemented a cache invalidation helper which automatically clears stale `jobs:*` cache entries whenever a recruiter successfully posts a new job (`POST /api/jobs`).
- Updated `README.md` and `.env.example` with instructions on how to configure the `REDIS_URL` environment variable.

## 🛠️ Changes Made
- Added `redis` package as a dependency.
- Created `src/config/redis.js` to handle connection setup (defaults to `redis://localhost:6379`).
- Created `src/middleware/cacheMiddleware.js` for intercepting GET requests, checking Redis, and caching outbound responses.
- Created `src/utils/cacheHelpers.js` for invalidating cache keys by prefix.
- Updated `/api/jobs` and `/api/interviews/topics` routes to utilize the new caching middleware with 5-minute and 10-minute TTLs respectively.
- Hooked `invalidateCacheByPrefix("jobs")` into the `createJobPosting` controller.

## ✅ Verification
- Verified that hitting the jobs and topics endpoints populates Redis via `redis-cli`.
- Verified that subsequent hits on the same URLs serve cached data (significantly faster response times).
- Verified that creating a new job flushes the `jobs:*` cache, ensuring the new data is loaded properly on the next request.

## ⚠️ Notes for Reviewer
- You will need a running Redis instance to fully test this locally (or it will gracefully bypass caching if the connection fails).
- Please ensure you set `REDIS_URL` in your `.env` file as documented.
