### PR TITLE
fix: replace process.exit(1) with graceful degraded mode on DB failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,4 +449,3 @@ For local development and testing without configuring an SMTP provider:
 1. Set `EMAIL_SERVICE_MODE=console` in `server/.env`.
 2. When registering a user, the server will output the 6-digit OTP directly to your terminal console instead of sending an email.
 3. Retrieve this OTP from the server command line logs and enter it in the frontend verification modal to complete the registration flow.
-

--- a/docs/API_NOTIFICATIONS.md
+++ b/docs/API_NOTIFICATIONS.md
@@ -8,7 +8,7 @@ This document provides comprehensive guidance on the Notifications REST API syst
 
 ### Directory Structure
 
-```
+```bash
 server/src/modules/notifications/
 ├── controller.js          # HTTP request handlers
 ├── service.js             # Business logic layer
@@ -21,7 +21,7 @@ server/src/modules/notifications/
 
 ### Database Model
 
-```
+```bash
 server/src/database/models/Notification.js
 ```
 
@@ -330,7 +330,7 @@ io.to(`user_${userId}`).emit("new-notification", notificationData);
 
 #### 1. Get All Notifications
 
-```
+```bash
 GET http://localhost:5000/api/notifications?page=1&limit=20
 Headers:
   Authorization: Bearer <YOUR_JWT_TOKEN>
@@ -339,7 +339,7 @@ Headers:
 
 #### 2. Create a Notification
 
-```
+```bash
 POST http://localhost:5000/api/notifications
 Headers:
   Authorization: Bearer <YOUR_JWT_TOKEN>
@@ -359,7 +359,7 @@ Body:
 
 #### 3. Get Unread Count
 
-```
+```bash
 GET http://localhost:5000/api/notifications/unread-count
 Headers:
   Authorization: Bearer <YOUR_JWT_TOKEN>
@@ -367,7 +367,7 @@ Headers:
 
 #### 4. Mark as Read
 
-```
+```bash
 PATCH http://localhost:5000/api/notifications/notif-id/read
 Headers:
   Authorization: Bearer <YOUR_JWT_TOKEN>
@@ -375,7 +375,7 @@ Headers:
 
 #### 5. Mark All as Read
 
-```
+```bash
 PATCH http://localhost:5000/api/notifications/mark-all/read
 Headers:
   Authorization: Bearer <YOUR_JWT_TOKEN>
@@ -383,7 +383,7 @@ Headers:
 
 #### 6. Delete Notification
 
-```
+```bash
 DELETE http://localhost:5000/api/notifications/notif-id
 Headers:
   Authorization: Bearer <YOUR_JWT_TOKEN>
@@ -391,7 +391,7 @@ Headers:
 
 #### 7. Delete All Notifications
 
-```
+```bash
 DELETE http://localhost:5000/api/notifications
 Headers:
   Authorization: Bearer <YOUR_JWT_TOKEN>

--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,8 @@ dotenv.config({ override: true });
 
 import http from "http";
 import { Server } from "socket.io";
-import connectDB from "./src/database/db.js";
+import connectDB, { isConnected } from "./src/database/db.js";
+import requireDB from "./src/middleware/requireDB.js";
 import authRoutes from "./src/modules/auth/routes.js";
 import resumeRoutes from "./src/modules/resumes/routes.js";
 import jobRoutes from "./src/modules/jobs/routes.js";
@@ -79,11 +80,11 @@ app.use((req, res, next) => {
 });
 
 await connectRedis();
-await connectDB();
+connectDB();
 logEvaluatorConfig();
 
 app.get("/health", (req, res) => {
-  res.json({ status: "OK" });
+  res.json({ status: "OK", db: isConnected ? "connected" : "disconnected" });
 });
 
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
@@ -109,19 +110,19 @@ app.post("/api/chat", (req, res) => {
   }
 });
 
-app.use("/api/auth", authRoutes);
-app.use("/api/resume", resumeRoutes);
-app.use("/api/jobs", jobRoutes);
-app.use("/api/roadmap", roadmapRoutes);
-app.use("/api/matching", matchingRoutes);
-app.use("/api/dashboard", dashboardRoutes);
-app.use("/api/cover-letters", coverLetterRoutes);
-app.use("/api/classrooms", classroomRoutes);
-app.use("/api/users", userRoutes);
-app.use("/api/interviews", interviewRoutes);
-app.use("/api/files", fileRoutes);
-app.use("/api/notifications", notificationRoutes);
-app.use("/api/analytics", analyticsRoutes);
+app.use("/api/auth", requireDB, authRoutes);
+app.use("/api/resume", requireDB, resumeRoutes);
+app.use("/api/jobs", requireDB, jobRoutes);
+app.use("/api/roadmap", requireDB, roadmapRoutes);
+app.use("/api/matching", requireDB, matchingRoutes);
+app.use("/api/dashboard", requireDB, dashboardRoutes);
+app.use("/api/cover-letters", requireDB, coverLetterRoutes);
+app.use("/api/classrooms", requireDB, classroomRoutes);
+app.use("/api/users", requireDB, userRoutes);
+app.use("/api/interviews", requireDB, interviewRoutes);
+app.use("/api/files", requireDB, fileRoutes);
+app.use("/api/notifications", requireDB, notificationRoutes);
+app.use("/api/analytics", requireDB, analyticsRoutes);
 
 initClassroomSockets(io);
 initNotificationSockets(io);

--- a/server/src/config/validateEnv.js
+++ b/server/src/config/validateEnv.js
@@ -1,6 +1,5 @@
 const requiredVars = [
   { name: "JWT_SECRET", description: "Secret key for signing JWT tokens" },
-  { name: "MONGO_URI", altName: "MONGODB_URI", description: "MongoDB connection string" },
 ];
 
 export const validateEnv = () => {

--- a/server/src/database/db.js
+++ b/server/src/database/db.js
@@ -1,20 +1,16 @@
 import dns from "node:dns";
 import mongoose from "mongoose";
 
+export let isConnected = false;
+
 const connectDB = async () => {
   const mongoUri = process.env.MONGO_URI || process.env.MONGODB_URI;
 
   if (!mongoUri) {
-    console.error(
-      "MongoDB Connection Error: Missing MONGO_URI (or MONGODB_URI) in environment variables."
-    );
-    console.error(
-      "Create `server/.env` and set MONGO_URI=<your_mongodb_connection_string>."
-    );
-    process.exit(1);
+    console.warn("MONGO_URI not set — running in degraded mode (DB unavailable)");
+    return;
   }
 
-  // Some Windows/corporate DNS resolvers fail SRV lookups for mongodb+srv (querySrv ECONNREFUSED).
   if (mongoUri.startsWith("mongodb+srv://") && process.platform === "win32") {
     dns.setServers(["8.8.8.8", "8.8.4.4"]);
     dns.setDefaultResultOrder("ipv4first");
@@ -24,11 +20,22 @@ const connectDB = async () => {
     const conn = await mongoose.connect(mongoUri, {
       serverSelectionTimeoutMS: 15000,
     });
+    isConnected = true;
     console.log(`MongoDB Connected Successfully! : ${conn.connection.host}`);
   } catch (error) {
-    console.error(`MongoDB Connection Error: ${error.message}`);
-    process.exit(1);
+    console.warn(`MongoDB Connection Error: ${error.message}`);
+    console.warn("Server will continue in degraded mode — DB-dependent features will return 503");
   }
 };
+
+mongoose.connection.on("disconnected", () => {
+  isConnected = false;
+  console.warn("MongoDB disconnected — entering degraded mode");
+});
+
+mongoose.connection.on("reconnected", () => {
+  isConnected = true;
+  console.log("MongoDB reconnected — restored full functionality");
+});
 
 export default connectDB;

--- a/server/src/middleware/requireDB.js
+++ b/server/src/middleware/requireDB.js
@@ -1,0 +1,14 @@
+import { isConnected } from "../database/db.js";
+
+const requireDB = (req, res, next) => {
+  if (!isConnected) {
+    return res.status(503).json({
+      success: false,
+      status: "error",
+      message: "Database is currently unavailable — please try again later",
+    });
+  }
+  next();
+};
+
+export default requireDB;


### PR DESCRIPTION
#641 
## Description

Removes `process.exit(1)` calls from `server/src/database/db.js` that cause container crash loops in Docker/K8s deployments when MongoDB is unavailable.

## Changes

1. **server/src/database/db.js** — Replaced both `process.exit(1)` calls with warnings and graceful fallback. Exported `isConnected` flag. Added connection event listeners for `disconnected`/ `reconnected` to toggle the flag at runtime.

2. **server/src/middleware/requireDB.js** (new) — Middleware that checks `isConnected` and returns 503 when the database is unavailable.

3. **server/index.js** — Applied `requireDB` to all DB-dependent routes. Removed `await` from `connectDB()` so the server starts regardless of DB state. Health endpoint now reports DB status.

4. **server/src/config/validateEnv.js** — Removed `MONGO_URI` from the required-vars list so the server can start in degraded mode when no URI is configured (matching the lazy-init pattern in geminiService.js).

## Impact

- No more crash loops — the server stays up during DB outages or configuration gaps
- DB-dependent routes return HTTP 503 with a clear message
- Non-DB endpoints (/health, /api-docs, /api/chat) remain fully functional
- Automatic recovery when MongoDB reconnects