### PR TITLE
fix : use dynamic extension for avatar uploads based on actual MIME type

### DIFF
--- a/server/src/middleware/uploadAvatar.js
+++ b/server/src/middleware/uploadAvatar.js
@@ -10,9 +10,15 @@ if (!fs.existsSync(uploadDirectory)) {
 
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, uploadDirectory),
-  filename: (req, _file, cb) => {
-    // One avatar per user — overwrite by using userId as filename
-    cb(null, `avatar-${req.user._id}.jpg`);
+  filename: (req, file, cb) => {
+    const extMap = {
+      "image/jpeg": ".jpg",
+      "image/png": ".png",
+      "image/webp": ".webp",
+      "image/gif": ".gif",
+    };
+    const extension = extMap[file.mimetype] || path.extname(file.originalname).toLowerCase() || ".jpg";
+    cb(null, `avatar-${req.user._id}${extension}`);
   },
 });
 


### PR DESCRIPTION
Closes #665.

Summary of What Has Been Done:
Fixed the hardcoded .jpg extension issue in avatar uploads. Files are now saved with the correct extension matching their actual MIME type.

Changes Made:
server/src/middleware/uploadAvatar.js - disk storage filename function:
- Added extMap dictionary mapping MIME types to file extensions (image/jpeg -> .jpg, image/png -> .png, image/webp -> .webp, image/gif -> .gif)
- Uses file.mimetype to determine the correct extension dynamically
- Falls back to path.extname(file.originalname) or .jpg if MIME type is not in the map

Impact it Made:
Ensures avatar files are saved with extensions matching their actual format, preventing browser rendering issues, CDN cache warnings, and downstream image processor failures.