### PR TITLE
fix: remove OTP from email subject line to prevent credential leak

### DIFF
--- a/server/src/utils/emailService.js
+++ b/server/src/utils/emailService.js
@@ -60,8 +60,8 @@ export const sendEmail = async (to, subject, text, html) => {
 export const sendOTP = async (email, otp, type) => {
   const isVerification = type === "verification";
   const subject = isVerification 
-    ? `[SkillsSphere AI] Verify Your Account - ${otp}` 
-    : `[SkillsSphere AI] Password Reset Request - ${otp}`;
+    ? "[SkillsSphere AI] Verify Your Account" 
+    : "[SkillsSphere AI] Password Reset Request";
     
   const title = isVerification ? "Verify Your Email Address" : "Reset Your Password";
   const actionText = isVerification 


### PR DESCRIPTION
## Description

Removes the OTP from email subject lines in the `sendOTP` function in `server/src/utils/emailService.js`. The OTP was previously appended to the subject line, making it visible on lock screen notifications, email preview panes, delivery service logs, and forwarded/archived emails.

## Impact

**Before (vulnerable):**
- Verification subject: `[SkillsSphere AI] Verify Your Account - 123456`
- Reset subject: `[SkillsSphere AI] Password Reset Request - 123456`

**After (fixed):**
- Verification subject: `[SkillsSphere AI] Verify Your Account`
- Reset subject: `[SkillsSphere AI] Password Reset Request`

The OTP remains in the email body (both text and HTML) where it belongs — accessible only after opening the email.

## Approach

1. Identified the leak in `server/src/utils/emailService.js:62-64` where `${otp}` was interpolated into the subject string for both verification and password reset emails
2. Removed the OTP interpolation from both subject lines while keeping all branding and purpose information intact
3. Verified no other location in the codebase constructs email subjects with sensitive data (searched for `subject:` across `server/src/utils/`)
4. Verified the OTP is still correctly delivered in the email body (both plain text and HTML templates remain unchanged)

## References

Closes #639