### PR TITLE
fix: restrict CORS to allowed origins for all REST API routes

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -69,7 +69,10 @@ io.use(async (socket, next) => {
 
 setIO(io);
 
-app.use(cors());
+app.use(cors({
+  origin: ALLOWED_ORIGINS,
+  credentials: true,
+}));
 app.use(express.json());
 
 // Security headers


### PR DESCRIPTION
## Description

Fixes a critical CORS misconfiguration where `app.use(cors())` was called with no options at `server/index.js:72`, defaulting to `Access-Control-Allow-Origin: *` on all REST API routes — including login, register, forgot-password, and reset-password endpoints.

**Before (vulnerable):**
```js
app.use(cors()); // allows any origin
```

**After (fixed):**
```js
app.use(cors({
  origin: ALLOWED_ORIGINS,
  credentials: true,
}));
```

## Impact

Login, register, forgot-password, and reset-password endpoints are no longer callable from arbitrary third-party websites. An attacker cannot embed hidden forms on `evil.com` that silently submit to auth endpoints and read responses.

## Approach

1. Identified the bare `app.use(cors())` call at `server/index.js:72` with no origin restrictions
2. Found that `ALLOWED_ORIGINS` was already defined (lines 42-45) and used by Socket.io with proper restrictions — the REST API simply was not using it
3. Reused the existing `ALLOWED_ORIGINS` array for the REST API CORS configuration
4. Added `credentials: true` to ensure authenticated requests work correctly from allowed origins

## Why this is sufficient

- The `ALLOWED_ORIGINS` variable is configured via `FRONTEND_URL` env var (documented in `.env.example`) with fallback to `localhost:5174` and `localhost:5173` for development
- Socket.io was already correctly configured with the same origins — this was an oversight that the REST API was not
- All REST API routes are registered after the CORS middleware (lines 113-125), so they all inherit the same protection
- No additional configuration needed — existing `FRONTEND_URL` env var is sufficient

Closes #638