### PR TITLE
feat: Implement real-time state synchronization and persistence for Classrooms

### DIFF
--- a/server/src/modules/classrooms/service.js
+++ b/server/src/modules/classrooms/service.js
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import ClassroomSession from "../../database/models/ClassroomSession.js";
 import AppError from "../../utils/AppError.js";
+import { clearRoomState } from "./socket.js";
 
 /**
  * Create a new live classroom session
@@ -79,6 +80,9 @@ export const endSession = async (roomId, hostId) => {
   session.status = "ended";
   session.endedAt = new Date();
   await session.save();
+
+  // Clear in-memory room state to prevent memory leaks
+  clearRoomState(roomId);
 
   return session;
 };

--- a/server/src/modules/classrooms/socket.js
+++ b/server/src/modules/classrooms/socket.js
@@ -1,5 +1,22 @@
 import ClassroomSession from "../../database/models/ClassroomSession.js";
 
+const roomStates = new Map();
+
+function getOrCreateRoomState(roomId) {
+  if (!roomStates.has(roomId)) {
+    roomStates.set(roomId, {
+      chatHistory: [],
+      code: "",
+      whiteboard: []
+    });
+  }
+  return roomStates.get(roomId);
+}
+
+export function clearRoomState(roomId) {
+  roomStates.delete(roomId);
+}
+
 export function initClassroomSockets(io) {
   io.on("connection", (socket) => {
     console.log(`Socket connected: ${socket.id}`);
@@ -75,6 +92,10 @@ export function initClassroomSockets(io) {
 
         // Send the current participants list to the person who just joined
         socket.emit("room-participants", participants);
+
+        // Sync the current room state (chat, code, whiteboard)
+        const state = getOrCreateRoomState(roomId);
+        socket.emit("sync-state", state);
       } catch (error) {
         console.error("Error joining classroom room:", error);
         socket.emit("error", { message: "Internal server error during join" });
@@ -92,11 +113,19 @@ export function initClassroomSockets(io) {
         return;
       }
 
-      socket.to(roomId).emit("chat-message", {
+      const msgObj = {
         sender: socket.data.user,
         message,
         timestamp: new Date().toISOString(),
-      });
+      };
+
+      const state = getOrCreateRoomState(roomId);
+      state.chatHistory.push(msgObj);
+      if (state.chatHistory.length > 100) {
+        state.chatHistory.shift();
+      }
+
+      socket.to(roomId).emit("chat-message", msgObj);
     });
 
     // Toggle Hand Raise
@@ -160,10 +189,15 @@ export function initClassroomSockets(io) {
         });
         return;
       }
-      socket.to(roomId).emit("draw-stroke", {
+      const payload = {
         strokeData,
         sender: socket.data.user,
-      });
+      };
+
+      const state = getOrCreateRoomState(roomId);
+      state.whiteboard.push(payload);
+
+      socket.to(roomId).emit("draw-stroke", payload);
     });
 
     // Clear canvas event
@@ -174,6 +208,8 @@ export function initClassroomSockets(io) {
         });
         return;
       }
+      const state = getOrCreateRoomState(roomId);
+      state.whiteboard = [];
       socket.to(roomId).emit("clear-canvas");
     });
 
@@ -185,6 +221,8 @@ export function initClassroomSockets(io) {
         });
         return;
       }
+      const state = getOrCreateRoomState(roomId);
+      state.code = code;
       socket.to(roomId).emit("code-change", { code });
     });
 


### PR DESCRIPTION
**Labels:** `enhancement` `feature` `help wanted` `level:hard` `type:performance`

## Description
This PR addresses a major UX limitation in the Classrooms module where late-joining participants (or users who refreshed their page) would enter a blank room without seeing prior chat history, code, or whiteboard strokes. 

By introducing an in-memory state tracker on the Socket.io layer, the backend now serves as the authoritative source of truth for active classroom sessions.

### Changes Made
- **State Store:** Added a `roomStates` Map in `socket.js` to buffer live activity.
- **State Synchronization:** Added logic in the `join-room` listener to emit a custom `sync-state` event to newly connected clients, instantly providing them with the chat history, current code string, and active whiteboard strokes.
- **Event Listeners:** Updated `chat-message`, `draw-stroke`, `clear-canvas`, and `code-change` to write to the memory buffer before broadcasting.
- **Memory Leak Prevention:** Exported `clearRoomState` from the socket module and integrated it into the `endSession` function within `classrooms/service.js`, ensuring the garbage collector reclaims the room's memory as soon as the tutor officially ends the session.

## Related Issues
Resolves #675 

## Type of change
- [x] Enhancement (New feature that greatly improves UX/Collaboration)
- [x] Performance (Proper memory cleanup hook established)