### PR TITLE
feat: Implement Full-Stack Pagination for Job Applications

### DIFF
--- a/client/src/modules/recruiter-jobs/pages/RecruiterApplicantsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterApplicantsPage.jsx
@@ -96,6 +96,11 @@ const RecruiterApplicantsPage = () => {
   // Smart Preset Tracker
   const [activePreset, setActivePreset] = useState('');
   const [isExportDropdownOpen, setIsExportDropdownOpen] = useState(false);
+  
+  // Pagination State
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
 
   const handleExportPDF = () => {
     setIsExportDropdownOpen(false);
@@ -115,6 +120,8 @@ const RecruiterApplicantsPage = () => {
         specialization: specialization || undefined,
         contributorOnly: contributorOnly ? 'true' : undefined,
         careerReadiness: careerReadiness || undefined,
+        page,
+        limit: 20
       };
 
       const [jobData, appsData] = await Promise.all([
@@ -123,6 +130,8 @@ const RecruiterApplicantsPage = () => {
       ]);
       setJob(jobData.job);
       setApplicants(appsData.applications || []);
+      setTotalPages(appsData.totalPages || 1);
+      setTotalCount(appsData.totalCount || 0);
     } catch (err) {
       setError(err.message || "Failed to load applicant data.");
     } finally {
@@ -138,7 +147,8 @@ const RecruiterApplicantsPage = () => {
     selectedCategories, 
     specialization, 
     contributorOnly, 
-    careerReadiness
+    careerReadiness,
+    page
   ]);
 
   useEffect(() => {
@@ -219,7 +229,16 @@ const RecruiterApplicantsPage = () => {
     setStatusFilter('');
     setSortBy('matchScore');
     setActivePreset('');
+    setPage(1);
   };
+
+  // Reset page when filters change (except when page itself changes)
+  useEffect(() => {
+    setPage(1);
+  }, [
+    statusFilter, sortBy, minScore, minAtsScore, selectedCategories, 
+    specialization, contributorOnly, careerReadiness
+  ]);
 
   const isAnyFilterActive = 
     statusFilter !== '' ||
@@ -764,6 +783,36 @@ const RecruiterApplicantsPage = () => {
                 })}
               </div>
             )}
+            
+            {/* Pagination Controls */}
+            {!loading && !error && applicants.length > 0 && totalPages > 1 && (
+              <div className="flex items-center justify-between bg-slate-900/40 border border-white/5 rounded-2xl p-4 mt-6">
+                <div className="text-sm text-slate-400 font-medium">
+                  Showing <span className="text-white">{(page - 1) * 20 + 1}</span> to <span className="text-white">{Math.min(page * 20, totalCount)}</span> of <span className="text-white">{totalCount}</span> candidates
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage(p => Math.max(1, p - 1))}
+                    disabled={page === 1}
+                    className="bg-slate-900 hover:bg-slate-800 border-white/10"
+                  >
+                    Previous
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                    disabled={page === totalPages}
+                    className="bg-slate-900 hover:bg-slate-800 border-white/10"
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            )}
+            
           </div>
         </div>
       </div>

--- a/server/src/modules/jobs/controller.js
+++ b/server/src/modules/jobs/controller.js
@@ -283,12 +283,19 @@ export const applyToJobPosting = asyncHandler(async (req, res) => {
  * @access  Private (Recruiters only)
  */
 export const getApplications = asyncHandler(async (req, res) => {
-  const applications = await getJobAppsService(req.params.id, req.user._id, req.query);
+  const result = await getJobAppsService(req.params.id, req.user._id, {
+    ...req.query,
+    page: Math.max(1, parseInt(req.query.page) || 1),
+    limit: Math.min(100, Math.max(1, parseInt(req.query.limit) || 20))
+  });
 
   res.status(200).json({
     success: true,
-    count: applications.length,
-    applications,
+    count: result.applications.length,
+    totalCount: result.totalCount,
+    totalPages: result.totalPages,
+    currentPage: result.currentPage,
+    applications: result.applications,
   });
 });
 

--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -630,12 +630,26 @@ export const getJobApplications = async (jobId, recruiterId, statusOrParams, sor
     sortConfig = { createdAt: 1 };
   }
 
-  const applications = await JobApplication.find(query)
-    .populate("applicant", "name email")
-    .populate("resume", "fileName")
-    .sort(sortConfig);
+  const page = Math.max(1, parseInt(filters.page) || 1);
+  const limit = Math.min(100, Math.max(1, parseInt(filters.limit) || 20));
+  const skip = (page - 1) * limit;
 
-  return applications;
+  const [applications, totalCount] = await Promise.all([
+    JobApplication.find(query)
+      .populate("applicant", "name email")
+      .populate("resume", "fileName")
+      .sort(sortConfig)
+      .skip(skip)
+      .limit(limit),
+    JobApplication.countDocuments(query)
+  ]);
+
+  return {
+    applications,
+    totalCount,
+    totalPages: Math.ceil(totalCount / limit),
+    currentPage: page
+  };
 };
 
 /**


### PR DESCRIPTION
## Labels

`backend` `enhancement` `level:intermediate` `help wanted` `good first issue` `gssoc:approved` `nsoc26`

## Resolved Issue

Resolves #722 

## Description

This PR addresses a significant performance and scalability bottleneck in the Recruiter Applicants flow.

Previously, the Recruiter Applicants page fetched **all applications for a given job simultaneously without database-level limits**. If a job accumulated thousands of applications, this behavior could:

- Heavily strain the MongoDB connection pool
- Spike Node.js memory usage, potentially causing Out Of Memory (OOM) crashes
- Freeze the client-side UI because of oversized JSON payloads
- Degrade overall application responsiveness

### Changes Implemented

#### Database Optimization
The `getJobApplications` service now implements **offset-based pagination** using `skip` and `limit` to reduce memory consumption and improve scalability.

#### API Response Improvements
The endpoint response now returns structured pagination metadata:

```json
{
  "applications": [],
  "totalCount": 0,
  "totalPages": 0,
  "currentPage": 1
}
```

#### UI / UX Updates
The Recruiter Applicants page now:

- Tracks pagination using a dedicated `page` state
- Uses a default `limit: 20`
- Adds **Previous** and **Next** navigation controls
- Automatically resets the page to `1` when filters or sorting options change

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Performance Optimization (improves API scalability)