### PR TITLE
Use Redis-backed auth code store for multi-instance OAuth compatibility

### DIFF
--- a/COMPLETION_CHECKLIST.md
+++ b/COMPLETION_CHECKLIST.md
@@ -179,7 +179,7 @@
 
 ## 📂 File Structure Verification
 
-```
+```text
 ✅ client/src/modules/notifications/
    ✅ hooks/
       ✅ useNotifications.js

--- a/FILES_SUMMARY.md
+++ b/FILES_SUMMARY.md
@@ -67,6 +67,7 @@
 
 - Added import: `import NotificationsPage from "../modules/notifications/pages/NotificationsPage";`
 - Added route:
+
   ```javascript
   <Route
     path="/notifications"
@@ -122,7 +123,7 @@ These already exist in project:
 
 ## 📂 Complete Project Structure
 
-```
+```text
 SkillsSphere-AI/
 ├── client/
 │   └── src/
@@ -329,7 +330,7 @@ notifications: {
 
 ## 🔗 Component Communication Diagram
 
-```
+```text
 ┌─────────────────────────────────────┐
 │         Socket Events               │
 │  new-notification from backend      │

--- a/NOTIFICATION_CENTER_GUIDE.md
+++ b/NOTIFICATION_CENTER_GUIDE.md
@@ -15,7 +15,7 @@ A complete Notification Center UI feature has been implemented for SkillsSphere-
 
 ## 📁 File Structure
 
-```
+```text
 client/src/
 ├── modules/notifications/
 │   ├── hooks/
@@ -526,7 +526,7 @@ All dependencies already in project:
 
 ### Data Flow
 
-```
+```text
 Socket Event → SocketNotificationListener
              → Redux (addLiveNotification)
              → useNotifications hook (useSelector)
@@ -536,7 +536,7 @@ Socket Event → SocketNotificationListener
 
 ### State Flow
 
-```
+```text
 User Action → useNotifications hook
             → Redux Thunk
             → API Call

--- a/server/src/modules/auth/controller.js
+++ b/server/src/modules/auth/controller.js
@@ -242,7 +242,7 @@ export const googleOAuthCallback = asyncHandler(async (req, res, next) => {
   }
 
   // Generate a short-lived one-time auth code (never expose JWT in URL)
-  const authCode = generateAuthCode(user._id.toString());
+  const authCode = await generateAuthCode(user._id.toString());
 
   res.redirect(`${callbackUrl}?code=${authCode}`);
 });

--- a/server/src/modules/auth/service.js
+++ b/server/src/modules/auth/service.js
@@ -264,7 +264,7 @@ export const findOrCreateGoogleUser = async ({ email, name, picture }) => {
 
 // Exchange a one-time auth code for a JWT
 export const exchangeAuthCodeForToken = async (code) => {
-  const userId = consumeAuthCode(code);
+  const userId = await consumeAuthCode(code);
   if (!userId) return null;
 
   const user = await User.findById(userId);

--- a/server/src/utils/__tests__/authCodeStore.test.js
+++ b/server/src/utils/__tests__/authCodeStore.test.js
@@ -3,43 +3,43 @@ import assert from "node:assert/strict";
 import { generateAuthCode, consumeAuthCode } from "../authCodeStore.js";
 
 describe("authCodeStore", () => {
-  it("generates a unique auth code", () => {
-    const code1 = generateAuthCode("user123");
-    const code2 = generateAuthCode("user123");
+  it("generates a unique auth code", async () => {
+    const code1 = await generateAuthCode("user123");
+    const code2 = await generateAuthCode("user123");
 
     assert.equal(typeof code1, "string");
     assert.equal(code1.length, 48);
     assert.notEqual(code1, code2);
   });
 
-  it("returns userId when consuming a valid code", () => {
-    const code = generateAuthCode("user456");
-    const userId = consumeAuthCode(code);
+  it("returns userId when consuming a valid code", async () => {
+    const code = await generateAuthCode("user456");
+    const userId = await consumeAuthCode(code);
 
     assert.equal(userId, "user456");
   });
 
-  it("returns null when consuming a bogus code", () => {
-    const result = consumeAuthCode("bogus-code-123");
+  it("returns null when consuming a bogus code", async () => {
+    const result = await consumeAuthCode("bogus-code-123");
 
     assert.equal(result, null);
   });
 
-  it("deletes code after first consumption", () => {
-    const code = generateAuthCode("user789");
-    consumeAuthCode(code);
+  it("deletes code after first consumption", async () => {
+    const code = await generateAuthCode("user789");
+    await consumeAuthCode(code);
 
-    const secondAttempt = consumeAuthCode(code);
+    const secondAttempt = await consumeAuthCode(code);
     assert.equal(secondAttempt, null);
   });
 
-  it("generates unique codes for different users", () => {
-    const code1 = generateAuthCode("user111");
-    const code2 = generateAuthCode("user222");
+  it("generates unique codes for different users", async () => {
+    const code1 = await generateAuthCode("user111");
+    const code2 = await generateAuthCode("user222");
 
     assert.notEqual(code1, code2);
 
-    assert.equal(consumeAuthCode(code1), "user111");
-    assert.equal(consumeAuthCode(code2), "user222");
+    assert.equal(await consumeAuthCode(code1), "user111");
+    assert.equal(await consumeAuthCode(code2), "user222");
   });
 });

--- a/server/src/utils/authCodeStore.js
+++ b/server/src/utils/authCodeStore.js
@@ -1,37 +1,56 @@
 import crypto from "crypto";
+import redisClient from "../config/redis.js";
 
-const CODE_TTL_MS = 60 * 1000;
-const CLEANUP_INTERVAL_MS = 30 * 1000;
+const CODE_TTL_S = 60;
+const CODE_TTL_MS = CODE_TTL_S * 1000;
 
-const store = new Map();
+const fallbackStore = new Map();
 
-const cleanup = () => {
+setInterval(() => {
   const now = Date.now();
-  for (const [code, entry] of store) {
+  for (const [code, entry] of fallbackStore) {
     if (entry.expiresAt <= now) {
-      store.delete(code);
+      fallbackStore.delete(code);
     }
   }
-};
+}, 30 * 1000);
 
-setInterval(cleanup, CLEANUP_INTERVAL_MS);
-
-export const generateAuthCode = (userId) => {
+export const generateAuthCode = async (userId) => {
   const code = crypto.randomBytes(24).toString("hex");
-  store.set(code, {
-    userId,
-    expiresAt: Date.now() + CODE_TTL_MS,
-  });
+
+  if (redisClient?.isReady) {
+    try {
+      await redisClient.setEx(`auth:code:${code}`, CODE_TTL_S, userId);
+      return code;
+    } catch {
+      // Redis unavailable — fall through to in-memory store
+    }
+  }
+
+  fallbackStore.set(code, { userId, expiresAt: Date.now() + CODE_TTL_MS });
   return code;
 };
 
-export const consumeAuthCode = (code) => {
-  const entry = store.get(code);
+export const consumeAuthCode = async (code) => {
+  if (redisClient?.isReady) {
+    try {
+      const userId = await redisClient.get(`auth:code:${code}`);
+      if (userId) {
+        await redisClient.del(`auth:code:${code}`);
+        return userId;
+      }
+      return null;
+    } catch {
+      // Redis unavailable — fall through to in-memory store
+    }
+  }
+
+  const entry = fallbackStore.get(code);
   if (!entry) return null;
   if (entry.expiresAt <= Date.now()) {
-    store.delete(code);
+    fallbackStore.delete(code);
     return null;
   }
-  store.delete(code);
+  fallbackStore.delete(code);
   return entry.userId;
 };


### PR DESCRIPTION
close #733 
## What this fixes

The one-time auth codes generated during Google OAuth (`server/src/utils/authCodeStore.js`) were stored in an in-memory `Map` that cannot be shared across server processes. When running multiple replicas behind a load balancer — a standard production topology — the code created by instance A during the redirect callback is invisible to instance B that handles the subsequent exchange-code POST request. This causes every OAuth login to fail with "Invalid or expired authorization code" under any multi-instance deployment.

## Root cause

`server/src/utils/authCodeStore.js` uses `const store = new Map()` as a per-process data structure. `generateAuthCode()` writes to local process memory and `consumeAuthCode()` reads from it. With a load balancer, the callback and exchange-code requests are distributed across different processes, so the latter always returns `null`.

## What changed

- **server/src/utils/authCodeStore.js** — Rewrote `generateAuthCode` and `consumeAuthCode` to use `redisClient.setEx` with a 60-second TTL when Redis is available (`redisClient.isReady`). Retained an in-memory `Map` fallback that activates when Redis is unreachable, preserving the existing development experience without a running Redis instance. Both functions are now async.
- **server/src/modules/auth/controller.js** — Added `await` to the `generateAuthCode()` call in `googleOAuthCallback`.
- **server/src/modules/auth/service.js** — Added `await` to the `consumeAuthCode()` call in `exchangeAuthCodeForToken`.
- **server/src/utils/__tests__/authCodeStore.test.js** — Updated test callbacks to `async` to match the new async signatures.

## How to verify

1. With Redis running, step through `GET /api/auth/google/callback` — confirm `setEx` stores `auth:code:<generated_hex>` in Redis.
2. Call `POST /api/auth/exchange-code` with the same code — confirm `get` returns the userId and `del` removes the key.
3. Without Redis running, repeat steps 1–2 — confirm the in-memory fallback works identically.
4. Run `node --test src/utils/__tests__/authCodeStore.test.js` from the `server/` directory — all 5 tests pass.

## Edge cases considered

- **Redis unavailable**: Both functions catch Redis errors and revert to the in-memory `Map`, exactly matching the old behavior. This covers local development where Redis may not be running.
- **Code consumed twice**: The Redis path deletes the key on first read (get + del), so a second consume returns `null`. Same semantics as before.
- **Expired code**: Redis TTL handles expiry automatically (60 seconds). The in-memory fallback uses the same periodic cleanup as the original implementation.
- **Redis connection drops mid-operation**: Caught by the try/catch — falls back to in-memory for that single operation. Subsequent calls re-check `isReady`.