### PR TITLE
fix: synchronize dark/light mode theme state across components

### DIFF
--- a/client/src/app/main.jsx
+++ b/client/src/app/main.jsx
@@ -7,6 +7,7 @@ import App from './App.jsx';
 import './index.css';
 import { ToastProvider } from '../shared/components';
 import ErrorBoundary from '../components/ErrorBoundary.jsx';
+import { ThemeProvider } from '../shared/contexts/ThemeContext.jsx';
 if (import.meta.env.DEV && typeof window !== 'undefined') {
   const originalError = console.error;
   console.error = (...args) => {
@@ -30,13 +31,15 @@ document.documentElement.classList.toggle("light", savedTheme === "light");
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <Provider store={store}>
-      <BrowserRouter>
-        <ToastProvider>
-          <ErrorBoundary>
-            <App />
-          </ErrorBoundary>
-        </ToastProvider>
-      </BrowserRouter>
+      <ThemeProvider>
+        <BrowserRouter>
+          <ToastProvider>
+            <ErrorBoundary>
+              <App />
+            </ErrorBoundary>
+          </ToastProvider>
+        </BrowserRouter>
+      </ThemeProvider>
     </Provider>
   </React.StrictMode>
 );

--- a/client/src/shared/components/ThemeToggle.jsx
+++ b/client/src/shared/components/ThemeToggle.jsx
@@ -1,30 +1,7 @@
-import { useEffect, useState } from "react";
+import { useTheme } from "../contexts/ThemeContext";
 
 const ThemeToggle = () => {
-  const [darkMode, setDarkMode] = useState(false);
-
-  useEffect(() => {
-    const savedTheme =
-      localStorage.getItem("skillssphere.theme") || "light";
-
-    const isDark = savedTheme === "dark";
-
-    setDarkMode(isDark);
-
-    document.documentElement.classList.toggle("dark", isDark);
-    document.documentElement.classList.toggle("light", !isDark);
-  }, []);
-
-  const toggleTheme = () => {
-    const newTheme = darkMode ? "light" : "dark";
-
-    setDarkMode(!darkMode);
-
-    localStorage.setItem("skillssphere.theme", newTheme);
-
-    document.documentElement.classList.toggle("dark", newTheme === "dark");
-    document.documentElement.classList.toggle("light", newTheme === "light");
-  };
+  const { theme, toggleTheme } = useTheme();
 
   return (
     <button
@@ -39,7 +16,7 @@ const ThemeToggle = () => {
         hover:bg-[var(--surface-hover)]
       "
     >
-      {darkMode ? "☀️ Light" : "🌙 Dark"}
+      {theme === "dark" ? "☀️ Light" : "🌙 Dark"}
     </button>
   );
 };

--- a/client/src/shared/contexts/ThemeContext.jsx
+++ b/client/src/shared/contexts/ThemeContext.jsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+const ThemeContext = createContext();
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+};
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(() => {
+    return localStorage.getItem("skillssphere.theme") || "light";
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle("dark", theme === "dark");
+    root.classList.toggle("light", theme === "light");
+    root.dataset.theme = theme;
+    localStorage.setItem("skillssphere.theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prevTheme) => (prevTheme === "dark" ? "light" : "dark"));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/client/src/shared/landing/Navbar.jsx
+++ b/client/src/shared/landing/Navbar.jsx
@@ -8,6 +8,7 @@ import { getProtectedAssetUrl } from '../../utils/protectedAssetUrl';
 import { getSignedFileUrl } from '../../services/fileService';
 import NotificationsDropdown from '../components/NotificationsDropdown';
 import { getUnreadCount } from '../../features/notifications/notificationsSlice';
+import { useTheme } from '../contexts/ThemeContext';
 
 const Navbar = () => {
   const dispatch = useDispatch();
@@ -40,10 +41,7 @@ const Navbar = () => {
   const [isNavMenuOpen, setIsNavMenuOpen] = useState(false);
   const [isProfileOpen, setIsProfileOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
-  const [theme, setTheme] = useState(() => {
-    if (typeof window === 'undefined') return 'dark';
-    return window.localStorage.getItem('skillssphere.theme') || 'light';
-  });
+  const { theme, toggleTheme } = useTheme();
   const location = useLocation();
   const navMenuRef = useRef(null);
 
@@ -83,17 +81,6 @@ const Navbar = () => {
 
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [isNavMenuOpen]);
-
-  useEffect(() => {
-    const root = document.documentElement;
-    // keep dataset and classes in sync
-    root.dataset.theme = theme;
-    root.classList.toggle('dark', theme === 'dark');
-    root.classList.toggle('light', theme === 'light');
-    window.localStorage.setItem('skillssphere.theme', theme);
-  }, [theme]);
-
-  const toggleTheme = () => setTheme((current) => (current === 'dark' ? 'light' : 'dark'));
 
   const navLinks = [
     { name: 'Home', path: '/', icon: <Home size={20} /> },

--- a/client/src/shared/landing_components/Navbar.jsx
+++ b/client/src/shared/landing_components/Navbar.jsx
@@ -12,28 +12,12 @@ import {
 } from "lucide-react";
 import Button from "../landing/Button";
 import NotificationBell from "../../modules/notifications/components/NotificationBell";
-
-const getStoredTheme = () => {
-  try {
-    return window?.localStorage?.getItem("skillssphere.theme") || "light";
-  } catch {
-    return "light";
-  }
-};
-
-const storeTheme = (theme) => {
-  try {
-    window?.localStorage?.setItem("skillssphere.theme", theme);
-  } catch {
-    // Storage can be unavailable in test or privacy-restricted environments.
-  }
-};
-
+import { useTheme } from "../contexts/ThemeContext";
 const Navbar = ({ isAuthenticated = false, user = null }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const location = useLocation();
-  const [theme, setTheme] = useState(getStoredTheme);
+  const { theme, toggleTheme } = useTheme();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -57,15 +41,6 @@ const Navbar = ({ isAuthenticated = false, user = null }) => {
   useEffect(() => {
     setIsMenuOpen(false);
   }, [location.pathname]);
-  useEffect(() => {
-    document.documentElement.classList.toggle("dark", theme === "dark");
-    document.documentElement.classList.toggle("light", theme === "light");
-
-    storeTheme(theme);
-  }, [theme]);
-  const toggleTheme = () => {
-    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
-  };
 
   const navLinks = [
     { name: "Home", path: "/", icon: <Home size={20} /> },


### PR DESCRIPTION
## Description
This PR addresses the issue where the theme toggle (Dark/Light mode) fell out of sync across different navigation bars and components. Previously, multiple components were maintaining their own independent `useState` and `localStorage` synchronizations for the theme.

This PR centralizes the theme logic by introducing a `ThemeProvider` context. All components now consume the `useTheme` hook, ensuring that toggling the theme in one place immediately updates all icons and styles across the entire application without any desynchronization.

Resolves #753 

## Changes Made
- **Added** `client/src/shared/contexts/ThemeContext.jsx` to serve as the single source of truth for the active theme.
- **Updated** `client/src/app/main.jsx` to wrap the application with the new `ThemeProvider`.
- **Refactored** `ThemeToggle.jsx`, `landing/Navbar.jsx`, and `landing_components/Navbar.jsx` to rip out their local state/storage logic and replace it with `useTheme`.

## Testing Video
> Please see the attached screen recording demonstrating that clicking the theme toggle on the navbar or anywhere else instantly updates the icons globally without falling out of sync.

<details>
<summary>View Demo</summary>
</details>


https://github.com/user-attachments/assets/9882c1cf-6915-4a71-b3d9-5c2af4d09cbe


