### PR TITLE
fix: preserve intended redirect route during Google OAuth login

### DIFF
--- a/client/src/modules/auth/Login.jsx
+++ b/client/src/modules/auth/Login.jsx
@@ -161,6 +161,9 @@ const Login = () => {
             <button
               type="button"  //prevents from validation,so that the toast notification doesnt show up when we click on the continue with google button
               onClick={() => {
+                if (location.state?.from?.pathname) {
+                  sessionStorage.setItem('oauth_redirect', location.state.from.pathname);
+                }
                 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
                 const redirect = encodeURIComponent(`${window.location.origin}/auth/callback`);
                 window.location.href = `${API_URL}/api/auth/google?redirect=${redirect}`;

--- a/client/src/modules/auth/OAuthCallback.jsx
+++ b/client/src/modules/auth/OAuthCallback.jsx
@@ -51,7 +51,10 @@ const OAuthCallback = () => {
 
         dispatch(setOAuthData({ token, user, rememberMe: true }));
         success(`Welcome ${user.name}!`);
-        navigate('/dashboard', { replace: true });
+        const fallbackPath = '/dashboard';
+        const redirectTo = sessionStorage.getItem('oauth_redirect') || fallbackPath;
+        sessionStorage.removeItem('oauth_redirect');
+        navigate(redirectTo, { replace: true });
       } catch (err) {
         console.error(err);
         showError('Could not complete login. Please try again.');


### PR DESCRIPTION
## Description
This PR addresses an issue where users authenticating via the "Continue with Google" OAuth flow would lose their React Router state context. Previously, if an unauthenticated user tried to access a protected route (e.g., `/profile`), they were routed to the `/login` page but their original destination was lost as soon as they left the app for Google's authorization page. The callback handler would then hardcode a redirect to `/dashboard`.

This PR ensures a seamless user experience by:
1. Temporarily persisting the user's intended destination (`location.state.from`) into `sessionStorage` immediately before redirecting to Google.
2. Retrieving that destination in the OAuth callback handler and executing a dynamic redirect instead of a hardcoded one.
3. Automatically cleaning up the session storage key to prevent any caching bugs on future logins.

Resolves #755 

## Changes Made
- **Modified** `client/src/modules/auth/Login.jsx`: Added logic to save `oauth_redirect` to `sessionStorage` when the Google login button is clicked.
- **Modified** `client/src/modules/auth/OAuthCallback.jsx`: Refactored the `exchangeCode` function to read the intended path from `sessionStorage` and dynamically route the user back to the correct page after successful authentication.

## Testing Video
> **Note to reviewer:** Please see the attached screen recording demonstrating an unauthenticated user navigating to a protected route, logging in with Google, and being correctly redirected back to the initially requested page instead of the dashboard.

<details>
<summary>View Demo</summary>
</details>


https://github.com/user-attachments/assets/22d3198d-aaed-4109-9209-9a990b3029d2


