### PR TITLE
fix: resolve media stream leaks on unmount and restore missing navigation

### DIFF
--- a/client/src/modules/classrooms/components/VideoTile.jsx
+++ b/client/src/modules/classrooms/components/VideoTile.jsx
@@ -8,6 +8,11 @@ export default function VideoTile({ stream, user, isMuted, isHandRaised, isScree
     if (videoRef.current && stream) {
       videoRef.current.srcObject = stream;
     }
+    return () => {
+      if (videoRef.current) {
+        videoRef.current.srcObject = null;
+      }
+    };
   }, [stream]);
 
   return (

--- a/client/src/modules/mock-interview/components/CameraCheck.jsx
+++ b/client/src/modules/mock-interview/components/CameraCheck.jsx
@@ -59,11 +59,26 @@ const CameraCheck = ({ onStreamReady }) => {
     startCamera();
 
     return () => {
-      if (currentStream) {
-        currentStream.getTracks().forEach((track) => track.stop());
+      if (javascriptNode) {
+        javascriptNode.onaudioprocess = null;
+        javascriptNode.disconnect();
       }
-      if (audioContext) {
+      if (microphone) {
+        microphone.disconnect();
+      }
+      if (analyser) {
+        analyser.disconnect();
+      }
+      if (audioContext && audioContext.state !== "closed") {
         audioContext.close();
+      }
+      if (videoRef.current) {
+        videoRef.current.srcObject = null;
+      }
+      if (currentStream) {
+        currentStream.getTracks().forEach((track) => {
+          track.stop();
+        });
       }
     };
   }, []);

--- a/client/src/modules/mock-interview/pages/InterviewLobby.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewLobby.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import Navbar from "../../../shared/landing/Navbar";
 import CameraCheck from "../components/CameraCheck";
 import PersonaSelector from "../components/PersonaSelector";
 import Button from "../../../shared/components/Button";
@@ -68,7 +69,9 @@ const InterviewLobby = () => {
   }));
 
   return (
-    <div className="max-w-[1200px] mx-auto p-8 min-h-[calc(100vh-80px)] flex flex-col gap-8">
+    <>
+      <Navbar />
+      <div className="pt-24 max-w-[1200px] mx-auto p-8 min-h-[calc(100vh-80px)] flex flex-col gap-8">
       <header className="text-center mb-4">
         <h1 className="text-4xl font-extrabold bg-gradient-to-br from-indigo-500 to-purple-500 bg-clip-text text-transparent mb-2">Adaptive Cognitive Interview</h1>
         <p className="text-slate-400 max-w-2xl mx-auto">
@@ -160,6 +163,7 @@ const InterviewLobby = () => {
         </div>
       </div>
     </div>
+    </>
   );
 };
 

--- a/client/src/modules/mock-interview/pages/InterviewSession.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewSession.jsx
@@ -228,10 +228,18 @@ const InterviewSession = () => {
 
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
-      newSocket.close();
-      if (mediaRecorderRef.current && mediaRecorderRef.current.state !== "inactive") {
-        mediaRecorderRef.current.stop();
+      if (mediaRecorderRef.current) {
+        if (mediaRecorderRef.current.state !== "inactive") {
+          mediaRecorderRef.current.stop();
+        }
+        if (mediaRecorderRef.current.stream) {
+          mediaRecorderRef.current.stream.getTracks().forEach((track) => track.stop());
+        }
       }
+      if (newSocket && newSocket.connected) {
+        newSocket.emit("end-audio-stream", { sessionId });
+      }
+      newSocket.close();
     };
   }, [session, user, sessionId]);
 


### PR DESCRIPTION
##  Bug Description
When navigating away from real-time intensive components (like the Mock Interview Lobby or the Interview Session itself), the application failed to cleanly tear down the underlying hardware media tracks and audio visualizer nodes. This caused a memory leak and left the browser's red microphone/camera active indicator hanging persistently even after the user navigated away. Additionally, the Mock Interview Lobby was missing the top navigation bar, trapping users on the page.

## Issue Resolved
Closes #757 

##  Proposed Changes
- **Media Hardware Teardown:** Upgraded the `useEffect` cleanup block in `CameraCheck.jsx` to rigorously disconnect `AudioContext` nodes, unset the video element's `srcObject`, and forcefully iterate over `stream.getTracks()` to stop all active hardware inputs.
- **Session Cleanup:** Added identical explicit `.stop()` loops to the `MediaRecorder` stream in `InterviewSession.jsx` along with a graceful WebSocket termination event.
- **Classroom Leak Prevention:** Applied robust unmount cleanup to `VideoTile.jsx` to proactively prevent similar leaks during Live Classrooms.
- **Restored Navigation:** Injected the missing `<Navbar />` component and adjusted the layout padding in `InterviewLobby.jsx`.

##  Testing Video
> **Note to reviewer:** Please see the attached screen recording demonstrating a user granting camera/mic access in the interview lobby and subsequently navigating away using the newly restored Navbar. Notice that the red browser tab recording indicator disappears instantly upon routing away.

<details>
<summary>View Demo</summary>
</details>



https://github.com/user-attachments/assets/6f723f75-ddad-4807-8ec4-a4ca2bbaefe9


