### PR TITLE
Fix/incomplete cascade deletion (#766)

### DIFF
--- a/server/src/utils/cascadeDelete.js
+++ b/server/src/utils/cascadeDelete.js
@@ -12,6 +12,7 @@ import InterviewSession from "../database/models/InterviewSession.js";
 import AnalysisHistory from "../database/models/AnalysisHistory.js";
 import ClassroomSession from "../database/models/ClassroomSession.js";
 import JobPosting from "../database/models/JobPosting.js";
+import Notification from "../database/models/Notification.js";
 
 /**
  * Sweeps and deletes all physical files and MongoDB documents associated with a user.
@@ -31,6 +32,9 @@ export const cascadeDeleteUser = async (userId) => {
 
   let resumes = [];
   let interviewSessions = [];
+  
+  const userIdStr = userId.toString();
+  const userIdObj = new mongoose.Types.ObjectId(userIdStr);
 
   try {
     // 2. Find and delete user resumes
@@ -40,8 +44,21 @@ export const cascadeDeleteUser = async (userId) => {
     // 3. Find and delete user interview sessions
     interviewSessions = await InterviewSession.find({ userId }).session(session);
     await InterviewSession.deleteMany({ userId }, { session });
+    
+    // Clear user from conductor and observer roles in other sessions
+    await InterviewSession.updateMany(
+      { conductorId: userId },
+      { $unset: { conductorId: "" } },
+      { session }
+    );
+    await InterviewSession.updateMany(
+      { observers: userId },
+      { $pull: { observers: userId } },
+      { session }
+    );
 
     // 4. Delete other student-related relational data
+    await Notification.deleteMany({ userId }, { session });
     await MatchResult.deleteMany({ user: userId }, { session });
     await LearningProgress.deleteMany({ user: userId }, { session });
     await JobApplication.deleteMany({ applicant: userId }, { session });
@@ -49,11 +66,40 @@ export const cascadeDeleteUser = async (userId) => {
     await AnalysisHistory.deleteMany({ user: userId }, { session });
     await ClassroomSession.deleteMany({ host: userId }, { session });
 
+    // Remove chat messages sent by this user in other classrooms
+    await ClassroomSession.updateMany(
+      { 
+        $or: [
+          { "chatHistory.sender.id": userIdStr },
+          { "chatHistory.sender.id": userIdObj }
+        ]
+      },
+      { 
+        $pull: { 
+          chatHistory: { 
+            $or: [
+              { "sender.id": userIdStr },
+              { "sender.id": userIdObj }
+            ]
+          } 
+        } 
+      },
+      { session }
+    );
+
     // 5. If recruiter: delete posted jobs and cascading applications to them
     const postedJobs = await JobPosting.find({ recruiter: userId }).session(session);
     if (postedJobs.length > 0) {
       const jobIds = postedJobs.map((j) => j._id);
       await JobApplication.deleteMany({ job: { $in: jobIds } }, { session });
+      
+      // Clean up orphaned match results recommendations referencing these jobs
+      await MatchResult.updateMany(
+        { "recommendations.job": { $in: jobIds } },
+        { $pull: { recommendations: { job: { $in: jobIds } } } },
+        { session }
+      );
+      
       await JobPosting.deleteMany({ recruiter: userId }, { session });
     }
 


### PR DESCRIPTION
## Description
Resolves #766 

Previously, the `cascadeDeleteUser` utility failed to clean up several nested references when a user deleted their account. This resulted in orphaned documents, dangling pointers (which risked `null` reference crashes on `.populate()`), and GDPR "Right to be Forgotten" violations since identifying chat data was left behind.

This PR introduces comprehensive cascading coverage to the deletion transaction.

## Changes Made
- **Notifications**: Added a sweep to delete all `Notification` documents where `userId` matches the deleted user.
- **Match Results**: When deleting a Recruiter, their `JobPosting`s are deleted. Added logic to sweep the `MatchResult` collection and `$pull` any `recommendations` referencing those deleted jobs.
- **Interview Sessions**: The deleted user is now stripped from any active `InterviewSession` (unsetting `conductorId` and pulling from the `observers` array).
- **Classroom Sessions**: Used the `$pull` operator to wipe any messages sent by the deleted user from the `ClassroomSession.chatHistory` embedded arrays.

## Testing Performed
- [x] Verified full account deletion for a Student account (clears applications, interviews, etc.).
- [x] Verified full account deletion for a Recruiter account.
- [x] Confirmed that Job Postings deleted by the recruiter successfully cascade to update Student Match Results.
- [x] Checked MongoDB directly to ensure no dangling `ObjectId` references exist in `ClassroomSession` or `InterviewSession`.

## Impact
Improves database hygiene, eliminates risk of 500 Internal Server Errors from population failures, and ensures strict compliance with user data privacy requests.