### PR TITLE
Fix: Centralize API and WebSocket configuration across frontend components

### DIFF
--- a/client/src/config/env.js
+++ b/client/src/config/env.js
@@ -1,0 +1,2 @@
+export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+export const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || import.meta.env.VITE_API_URL || "http://localhost:5000";

--- a/client/src/modules/ai-assistant/components/ChatBox.jsx
+++ b/client/src/modules/ai-assistant/components/ChatBox.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import MessageBubble from "./MessageBubble";
+import { API_URL } from "../../../config/env";
 
 const ChatBox = () => {
   const [messages, setMessages] = useState([
@@ -11,7 +12,7 @@ const ChatBox = () => {
   // 🔥 NEW: backend call function
   const sendMessageToBackend = async (message) => {
     try {
-      const res = await fetch("http://localhost:5000/api/chat", {
+      const res = await fetch(`${API_URL}/api/chat`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/client/src/modules/auth/ForgotPassword.jsx
+++ b/client/src/modules/auth/ForgotPassword.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from "react-router-dom";
 import Input from "../../shared/components/Input";
 import Button from "../../shared/components/Button";
 import { useToast } from "../../shared/components";
+import { API_URL } from "../../config/env";
 
 const ForgotPassword = () => {
   const navigate = useNavigate();
@@ -26,7 +27,6 @@ const ForgotPassword = () => {
     setError("");
 
     try {
-      const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
       const response = await fetch(`${API_URL}/api/auth/forgot-password`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/client/src/modules/auth/Login.jsx
+++ b/client/src/modules/auth/Login.jsx
@@ -6,6 +6,7 @@ import Input from "../../shared/components/Input";
 import Button from "../../shared/components/Button";
 import { useToast } from "../../shared/components";
 import Navbar from "../../shared/landing/Navbar";
+import { API_URL } from "../../config/env";
 
 const Login = () => {
   const dispatch = useDispatch();
@@ -164,7 +165,6 @@ const Login = () => {
                 if (location.state?.from?.pathname) {
                   sessionStorage.setItem('oauth_redirect', location.state.from.pathname);
                 }
-                const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
                 const redirect = encodeURIComponent(`${window.location.origin}/auth/callback`);
                 window.location.href = `${API_URL}/api/auth/google?redirect=${redirect}`;
               }}

--- a/client/src/modules/auth/OAuthCallback.jsx
+++ b/client/src/modules/auth/OAuthCallback.jsx
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { setOAuthData } from '../../features/auth/authSlice';
 import { useToast } from '../../shared/components';
+import { API_URL } from "../../config/env";
 
 const OAuthCallback = () => {
   const dispatch = useDispatch();
@@ -15,7 +16,6 @@ const OAuthCallback = () => {
     const params = new URLSearchParams(location.search);
     const code = params.get('code');
     const error = params.get('error');
-    const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
 
     // Purge sensitive params from URL immediately
     if (window.history.replaceState) {

--- a/client/src/modules/auth/Register.jsx
+++ b/client/src/modules/auth/Register.jsx
@@ -7,6 +7,7 @@ import Button from "../../shared/components/Button";
 import Input from "../../shared/components/Input";
 import Select from "../../shared/components/Select";
 import Navbar from "../../shared/landing/Navbar";
+import { API_URL } from "../../config/env";
 
 const Register = () => {
   const navigate = useNavigate();
@@ -218,8 +219,6 @@ const Register = () => {
             <button
               type="button"
               onClick={() => {
-                const API_URL =
-                  import.meta.env.VITE_API_URL || "http://localhost:5000";
                 const redirect = encodeURIComponent(
                   `${window.location.origin}/auth/callback`,
                 );

--- a/client/src/modules/auth/ResetPassword.jsx
+++ b/client/src/modules/auth/ResetPassword.jsx
@@ -4,6 +4,7 @@ import Input from "../../shared/components/Input";
 import Button from "../../shared/components/Button";
 import { KeyRound, ArrowLeft, CheckCircle } from "lucide-react";
 import { useToast } from "../../shared/components";
+import { API_URL } from "../../config/env";
 
 
 const ResetPassword = () => {
@@ -79,7 +80,6 @@ const ResetPassword = () => {
     if (Object.keys(newErrors).length === 0) {
       setLoading(true);
       try {
-        const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
         const response = await fetch(`${API_URL}/api/auth/reset-password`, {
           method: "POST",
           headers: {

--- a/client/src/modules/classrooms/pages/ClassroomRoom.jsx
+++ b/client/src/modules/classrooms/pages/ClassroomRoom.jsx
@@ -8,6 +8,8 @@ import VideoTile from "../components/VideoTile";
 import Whiteboard from "../components/Whiteboard";
 import SharedCodeEditor from "../components/SharedCodeEditor";
 
+import { SOCKET_URL } from "../../../config/env";
+
 export default function ClassroomRoom() {
   const { roomId } = useParams();
   const navigate = useNavigate();
@@ -40,7 +42,7 @@ export default function ClassroomRoom() {
     }
 
     // Initialize Socket
-    const s = io("http://localhost:5000");
+    const s = io(SOCKET_URL);
     setSocket(s);
     socketRef.current = s;
 

--- a/client/src/modules/mock-interview/pages/InterviewSession.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewSession.jsx
@@ -4,6 +4,7 @@ import { useSelector } from "react-redux";
 import { io } from "socket.io-client";
 import { submitAnswer, completeInterview } from "../services/interviewService";
 import { apiRequest } from "../../../services/apiClient";
+import { SOCKET_URL } from "../../../config/env";
 import InterviewSessionSkeleton from "../components/InterviewSessionSkeleton";
 import ObserverPanel from "../components/ObserverPanel";
 import RealtimeSentimentIndicator from "../components/RealtimeSentimentIndicator";
@@ -141,8 +142,7 @@ const InterviewSession = () => {
     if (!session || !user) return;
     const token = localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY);
     
-    const socketUrl = import.meta.env.VITE_API_URL || "http://localhost:5000";
-    const newSocket = io(socketUrl, { 
+    const newSocket = io(SOCKET_URL, { 
       auth: { token },
       reconnection: true,
       reconnectionAttempts: 10,

--- a/client/src/modules/mock-interview/pages/TutorInterviewConsole.jsx
+++ b/client/src/modules/mock-interview/pages/TutorInterviewConsole.jsx
@@ -4,6 +4,7 @@ import { useSelector } from "react-redux";
 import { PlayCircle, PauseCircle, Save, ArrowLeft, MessageSquare, CheckCircle, AlertCircle } from "lucide-react";
 import { apiRequest } from "../../../services/apiClient.js";
 import Navbar from "../../../shared/landing/Navbar";
+import { API_URL } from "../../../config/env";
 
 const TutorInterviewConsole = () => {
   const { id } = useParams(); // wait, react-router-dom provides this
@@ -97,7 +98,7 @@ const TutorInterviewConsole = () => {
       else activeAudio.pause();
     } else {
       if (activeAudio) activeAudio.pause();
-      const audio = new Audio(`http://localhost:5000/${url.replace(/\\/g, "/")}`);
+      const audio = new Audio(`${API_URL}/${url.replace(/\\/g, "/")}`);
       audio.play();
       setActiveAudio(audio);
     }

--- a/client/src/services/apiClient.js
+++ b/client/src/services/apiClient.js
@@ -1,14 +1,7 @@
+import { API_URL } from "../config/env";
+
 const getApiBaseUrl = () => {
-  try {
-    const env = import.meta?.env;
-    return (
-      env?.VITE_API_URL ||
-      env?.VITE_API_BASE_URL ||
-      "http://localhost:5001"
-    );
-  } catch {
-    return "http://localhost:5001";
-  }
+  return API_URL;
 };
 
 const toUrl = (path) => {

--- a/client/src/shared/components/GoogleOAuthButton.jsx
+++ b/client/src/shared/components/GoogleOAuthButton.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { API_URL } from "../../config/env";
 
 /**
  * GoogleOAuthButton — branded Google sign-in button used on Login & Register pages.
@@ -10,7 +11,6 @@ import React from "react";
  */
 const GoogleOAuthButton = ({ label = "Continue with Google" }) => {
   const handleClick = () => {
-    const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
     const redirect = encodeURIComponent(
       `${window.location.origin}/auth/callback`,
     );


### PR DESCRIPTION
## Description
This PR resolves an architectural issue where API backend URLs and WebSocket connections were either hardcoded to `http://localhost:5000` or contained redundant environment variable fallback logic duplicated across multiple components. This lack of centralization caused requests to fail or route incorrectly when testing against remote staging/production environments.

Closes #790

## Changes Made
- **Centralized Configuration**: Created `client/src/config/env.js` which exports `API_URL` and `SOCKET_URL`.
- **Refactored Features**:
  - **AI Assistant**: `ChatBox.jsx` now uses `API_URL` instead of a hardcoded fetch string.
  - **Classrooms**: `ClassroomRoom.jsx` initializes Socket.io using `SOCKET_URL`.
  - **Mock Interviews**: `InterviewSession.jsx` and `TutorInterviewConsole.jsx` now use the centralized config for sockets and audio retrieval.
  - **Auth Module**: Refactored `Register.jsx`, `Login.jsx`, `ForgotPassword.jsx`, `ResetPassword.jsx`, `OAuthCallback.jsx`, and `GoogleOAuthButton.jsx` to import their URLs directly from `config/env.js`.
- **API Client Standardization**: Refactored `getApiBaseUrl` in `apiClient.js` to rely exclusively on `env.js` and standardized the fallback port to `5000`.

## Evidence of Fix
As demonstrated in the attached screenshots, when the `.env` file is set to a remote URL (e.g., `VITE_API_URL=https://my-production-api.skillssphere.com`), the application's components (like the AI Assistant Chat) now successfully intercept the configuration and attempt to route their network requests to the configured remote environment instead of defaulting to `localhost:5000`.

<img width="689" height="547" alt="Screenshot 2026-05-27 at 2 06 25 PM" src="https://github.com/user-attachments/assets/e7348ac3-27ee-4ad3-82d8-b07a1a11405f" />

<img width="1467" height="802" alt="Screenshot 2026-05-27 at 2 11 55 PM" src="https://github.com/user-attachments/assets/290e2b7a-0436-497a-88c9-cc88cd9d5571" />


