### PR TITLE
fix(a11y): Add missing aria-labels to interactive icon elements (Resolves #792)

### DIFF
--- a/client/src/modules/dashboard/components/VersionComparisonModal.jsx
+++ b/client/src/modules/dashboard/components/VersionComparisonModal.jsx
@@ -53,6 +53,7 @@ const VersionComparisonModal = ({ isOpen, onClose, versions }) => {
           </div>
           <button 
             onClick={onClose}
+            aria-label="Close modal"
             className="p-2 hover:bg-white/10 rounded-full text-slate-400 hover:text-white transition-all"
           >
             <X size={24} />

--- a/client/src/shared/components/ConfirmDialog.jsx
+++ b/client/src/shared/components/ConfirmDialog.jsx
@@ -58,6 +58,7 @@ const ConfirmDialog = ({
         <button
           onClick={onCancel}
           disabled={loading}
+          aria-label="Close dialog"
           className="absolute top-4 right-4 p-1 text-slate-500 hover:text-slate-300 transition-colors disabled:opacity-50"
         >
           <X size={18} />

--- a/client/src/shared/components/StatusUpdateModal.jsx
+++ b/client/src/shared/components/StatusUpdateModal.jsx
@@ -50,6 +50,7 @@ const StatusUpdateModal = ({ isOpen, onClose, onUpdate, currentStatus, applicant
           </div>
           <button 
             onClick={onClose}
+            aria-label="Close modal"
             className="p-2 hover:bg-slate-800 rounded-xl text-slate-400 transition-colors"
           >
             <X size={20} />

--- a/client/src/shared/landing_components/Navbar.jsx
+++ b/client/src/shared/landing_components/Navbar.jsx
@@ -180,6 +180,7 @@ const Navbar = ({ isAuthenticated = false, user = null }) => {
             <button
               className="bg-[var(--surface-soft)] border border-[var(--border)] w-10 h-10 rounded-xl flex items-center justify-center text-slate-900 dark:text-white cursor-pointer min-h-[44px] min-w-[44px]"
               onClick={() => setIsMenuOpen(false)}
+              aria-label="Close mobile menu"
             >
               <X size={24} />
             </button>


### PR DESCRIPTION
## Description
This PR resolves a pervasive UI/UX accessibility bug where interactive elements (specifically buttons containing only icons) lacked semantic context. Screen readers were unable to interpret the actions of these buttons, causing them to fail WCAG compliance and degrading the experience for visually impaired users.

I performed a codebase-wide audit of all `<button>` elements utilizing `lucide-react` icons and injected concise `aria-label` attributes to ensure they are properly announced by screen readers (e.g., VoiceOver, NVDA).

## Related Issues
Closes #792 

## Changes Made
- **`Navbar.jsx`**: Added `aria-label="Close mobile menu"` to the mobile navigation drawer close button.
- **`ConfirmDialog.jsx`**: Added `aria-label="Close dialog"` to the `<X />` overlay button.
- **`StatusUpdateModal.jsx`**: Added `aria-label="Close modal"` to the header close button.
- **`VersionComparisonModal.jsx`**: Added `aria-label="Close modal"` to the header close button.

## How to Verify
1. Run the development server.
2. Open the browser Developer Tools (Elements tab) or the Accessibility Tree.
3. Inspect the icon-only buttons (like the Close button in the mobile navbar drawer, as seen in the screenshot below).
4. Verify that the `<button>` tags now explicitly contain the `aria-label` attribute describing their function. 
*(Alternatively, you can test this using Mac VoiceOver to hear the buttons being announced correctly).*

## Screenshots / Proof of Concept

<img width="1118" height="878" alt="Screenshot 2026-05-27 at 2 42 01 PM" src="https://github.com/user-attachments/assets/228e2e61-9959-486e-8f48-5dd6b0c71b40" />

