### PR TITLE
Fix: Prevent SSRF bypass via IPv6 addresses

### DIFF
--- a/server/src/utils/linkVerifier.js
+++ b/server/src/utils/linkVerifier.js
@@ -1,19 +1,19 @@
 import axios from "axios";
 import dns from "dns/promises";
+import ipaddr from "ipaddr.js";
 
 // Function to check if an IP is private/local
 const isPrivateIP = (ip) => {
-  const parts = ip.split(".").map(Number);
-  if (parts.length !== 4) return false;
-
-  return (
-    parts[0] === 10 ||
-    (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
-    (parts[0] === 192 && parts[1] === 168) ||
-    parts[0] === 127 ||
-    (parts[0] === 169 && parts[1] === 254) ||
-    parts[0] === 0 // 0.0.0.0
-  );
+  try {
+    const parsedIp = ipaddr.parse(ip);
+    const range = parsedIp.range();
+    return [
+      "unspecified", "broadcast", "multicast", "linkLocal", 
+      "loopback", "private", "reserved"
+    ].includes(range);
+  } catch (err) {
+    return false; // Invalid IP format
+  }
 };
 
 /**


### PR DESCRIPTION
Fixes #732. This PR utilizes the ipaddr.js library to accurately parse and validate IP ranges for both IPv4 and IPv6, closing a vulnerability where IPv6 loopback addresses bypassed the private IP check in linkVerifier.js.