### PR TITLE
fix(auth): Implement global token expiry interception and automatic logout on 401

### DIFF
--- a/client/src/app/App.jsx
+++ b/client/src/app/App.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { Routes, Route } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
-import { fetchCurrentUser } from "../features/auth/authSlice";
+import { fetchCurrentUser, logoutUser } from "../features/auth/authSlice";
 import ChatWidget from "../modules/ai-assistant/components/ChatWidget";
 import LandingPage from "../modules/landing/LandingPage";
 import DashboardPage from "../modules/dashboard/DashboardPage";
@@ -46,6 +46,18 @@ function App() {
       dispatch(fetchCurrentUser());
     }
   }, [dispatch, token]);
+
+  useEffect(() => {
+    const handleUnauthorized = () => {
+      dispatch(logoutUser());
+    };
+
+    window.addEventListener("auth:unauthorized", handleUnauthorized);
+
+    return () => {
+      window.removeEventListener("auth:unauthorized", handleUnauthorized);
+    };
+  }, [dispatch]);
 
   return (
     <div className="min-h-screen bg-[var(--background)] text-[var(--text-main)] transition-colors duration-300">

--- a/client/src/services/apiClient.js
+++ b/client/src/services/apiClient.js
@@ -74,6 +74,10 @@ export const apiRequest = async (path, options = {}) => {
   }
 
   if (!response.ok) {
+    if (response.status === 401 && typeof window !== "undefined") {
+      window.dispatchEvent(new Event("auth:unauthorized"));
+    }
+
     const message =
       (data &&
         typeof data === "object" &&


### PR DESCRIPTION
## Description
This Pull Request resolves a critical session management bug where an expired JWT token caused API requests to fail continuously (`401 Unauthorized`), but left the user stuck on protected pages facing generic "Failed to fetch" errors.

**Changes:**
1. **Global Interceptor (`apiClient.js`)**: Updated the primary fetch wrapper to inspect all outgoing API responses. If a `401` is returned, a custom `"auth:unauthorized"` DOM event is dispatched globally.
2. **App-Level Listener (`App.jsx`)**: Implemented a global `useEffect` listener hooked into Redux. When the `auth:unauthorized` event fires, it automatically dispatches the `logoutUser()` thunk.

## Why is this important?
- **Security:** Ensures stale or manipulated tokens immediately terminate the user's active session, preventing them from accessing secured routes.
- **User Experience (UX):** Rather than seeing broken components and generic network errors, the user is cleanly redirected to the login page to re-authenticate.

## Steps to Verify
1. Checkout this branch and run the application locally (`npm run dev`).
2. Log into the application and navigate to any protected route (e.g., `/dashboard`).
3. Open your browser DevTools (F12) -> **Application** tab -> **Local Storage**.
4. Delete the `skillssphere.auth.token` value manually.
5. Try to refresh the page or perform an action that triggers an API call.
6. **Expected result:** The global listener catches the 401 rejection and you are instantly logged out and sent back to the `/login` route!

## Related Issues
Closes #801