### PR TITLE
Fix: Broken Access Control in Roadmap Tutor/Recruiter Tracking

### DIFF
--- a/server/src/modules/roadmap/controller.js
+++ b/server/src/modules/roadmap/controller.js
@@ -1,6 +1,7 @@
 import LearningProgress from "../../database/models/LearningProgress.js";
 import asyncHandler from "../../utils/asyncHandler.js";
 import AppError from "../../utils/AppError.js";
+import User from "../../database/models/User.js";
 
 /**
  * Get the current user's learning progress and roadmap
@@ -315,6 +316,11 @@ export const optInRecruiterTracking = asyncHandler(async (req, res) => {
     throw new AppError("Recruiter ID is required", 400);
   }
 
+  const recruiter = await User.findById(recruiterId);
+  if (!recruiter || recruiter.role !== "recruiter") {
+    throw new AppError("Invalid user ID or user is not a recruiter", 403);
+  }
+
   const progress = await LearningProgress.findOne({ user: req.user._id });
   if (!progress) {
     throw new AppError("You do not have an active roadmap", 404);
@@ -339,6 +345,11 @@ export const optInTutorTracking = asyncHandler(async (req, res) => {
 
   if (!tutorId) {
     throw new AppError("Tutor ID is required", 400);
+  }
+
+  const tutor = await User.findById(tutorId);
+  if (!tutor || tutor.role !== "tutor") {
+    throw new AppError("Invalid user ID or user is not a tutor", 403);
   }
 
   const progress = await LearningProgress.findOne({ user: req.user._id });

--- a/server/src/utils/asyncHandler.js
+++ b/server/src/utils/asyncHandler.js
@@ -1,6 +1,6 @@
 const asyncHandler = (fn) => {
   return (req, res, next) => {
-    fn(req, res, next).catch(next);
+    return fn(req, res, next).catch(next);
   };
 };
 


### PR DESCRIPTION
## Description

This PR resolves a critical **Broken Access Control (BAC)** vulnerability in the roadmap progress tracking module (`server/src/modules/roadmap/controller.js`).

Previously, the `optInTutorTracking` and `optInRecruiterTracking` functions blindly pushed the provided user IDs into the `tutorsTracking` and `recruitersTracking` arrays without verifying the role of the user associated with that ID. This allowed a malicious student to supply the user ID of another student, improperly elevating their privileges and granting them unauthorized access to view and modify roadmap progress, assign resources, and view detailed interview histories.

## Resolved Issue
Resolves #815 

**Changes Include:**
- Added a `User.findById(id)` lookup in both tracking opt-in functions.
- Implemented strict role validation to ensure `tutor.role === "tutor"` and `recruiter.role === "recruiter"`.
- Requests attempting to exploit this vulnerability now correctly return a `403 Forbidden` error.

## Proof of Fix

Below is a screenshot of an automated security test designed specifically to mimic an attacker attempting to elevate the privileges of a non-tutor account. As demonstrated in the terminal output, the system now successfully intercepts the request and throws a `403 Forbidden` `AppError`, proving the vulnerability is fully patched.

<img width="580" height="343" alt="Screenshot 2026-05-28 at 4 50 48 PM" src="https://github.com/user-attachments/assets/1401594a-4836-4c6a-98b7-5ac53025fb67" />


## Checklist
- [x] Tested the BAC vulnerability fix locally
- [x] Verified that legitimate tutors/recruiters can still track roadmaps normally
- [x] Ensured role checks apply identically to both tutors and recruiters