### PR TITLE
Fix: Broken Access Control in Roadmap Recruiter Tracking

### DIFF
--- a/server/src/modules/roadmap/controller.js
+++ b/server/src/modules/roadmap/controller.js
@@ -1,4 +1,5 @@
 import LearningProgress from "../../database/models/LearningProgress.js";
+import User from "../../database/models/User.js";
 import asyncHandler from "../../utils/asyncHandler.js";
 import AppError from "../../utils/AppError.js";
 
@@ -315,6 +316,11 @@ export const optInRecruiterTracking = asyncHandler(async (req, res) => {
     throw new AppError("Recruiter ID is required", 400);
   }
 
+  const recruiter = await User.findById(recruiterId);
+  if (!recruiter || recruiter.role !== "recruiter") {
+    throw new AppError("Invalid user ID or user is not a recruiter", 403);
+  }
+
   const progress = await LearningProgress.findOne({ user: req.user._id });
   if (!progress) {
     throw new AppError("You do not have an active roadmap", 404);
@@ -339,6 +345,11 @@ export const optInTutorTracking = asyncHandler(async (req, res) => {
 
   if (!tutorId) {
     throw new AppError("Tutor ID is required", 400);
+  }
+
+  const tutor = await User.findById(tutorId);
+  if (!tutor || tutor.role !== "tutor") {
+    throw new AppError("Invalid user ID or user is not a tutor", 403);
   }
 
   const progress = await LearningProgress.findOne({ user: req.user._id });

--- a/server/src/utils/asyncHandler.js
+++ b/server/src/utils/asyncHandler.js
@@ -1,6 +1,6 @@
 const asyncHandler = (fn) => {
   return (req, res, next) => {
-    fn(req, res, next).catch(next);
+    return fn(req, res, next).catch(next);
   };
 };
 


### PR DESCRIPTION
## Description

This PR addresses a critical **Broken Access Control (BAC)** vulnerability discovered in the roadmap recruiter tracking feature (`server/src/modules/roadmap/controller.js`).

Previously, the `optInRecruiterTracking` endpoint accepted a `recruiterId` in the request body and blindly appended it to the `progress.recruitersTracking` array. It failed to verify if the ID actually corresponded to a user who possessed the `recruiter` role. This severe oversight allowed an unauthorized user (such as a malicious student) to grant recruiter-level visibility of their learning roadmap to other unauthorized accounts, bypassing standard data visibility rules.

## Resolved Issue
Resolves #818 

**Changes Include:**
- Added a mandatory database lookup (`User.findById(recruiterId)`) in `optInRecruiterTracking`.
- Enforced strict role validation to ensure `recruiter.role === "recruiter"`.
- Requests that attempt to supply non-recruiter IDs now correctly trigger a `403 Forbidden` `AppError`.
- Proactively patched identical vulnerable logic inside `optInTutorTracking` to prevent similar exploits.

## Proof of Fix

Below is a screenshot demonstrating an automated security test designed to mimic an attacker executing the exploit against the `optInRecruiterTracking` endpoint. As seen in the output, the system successfully detects that the provided ID does not belong to a recruiter and blocks the action, returning a `403 Forbidden` error!


<img width="575" height="341" alt="Screenshot 2026-05-28 at 5 07 02 PM" src="https://github.com/user-attachments/assets/4a7ca710-0b55-43ed-85c0-36e5ee576bdc" />


## Checklist
- [x] Tested the Recruiter Tracking BAC fix locally
- [x] Verified that legitimate recruiters can still track roadmaps normally
- [x] Ensured role verification correctly applies to tutors as well