### PR TITLE
fix(client): match vite proxy target port with backend config

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -18,11 +18,11 @@ export default defineConfig({
     strictPort: true,
     proxy: {
       "/api": {
-        target: "http://localhost:5001",
+        target: "http://localhost:5000",
         changeOrigin: true,
       },
       "/socket.io": {
-        target: "http://localhost:5001",
+        target: "http://localhost:5000",
         ws: true,
       },
     },


### PR DESCRIPTION
Fixes #824

Updates the target port in vite.config.js to 5000 to match the standard backend server configuration, restoring out-of-the-box local development proxying.