### PR TITLE
fix(server): use robust ES module path resolution for uploads

### DIFF
--- a/server/src/middleware/uploadAvatar.js
+++ b/server/src/middleware/uploadAvatar.js
@@ -1,8 +1,12 @@
 import multer from "multer";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
 
-const uploadDirectory = path.join(process.cwd(), "src", "uploads", "avatars");
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const uploadDirectory = path.join(__dirname, "..", "uploads", "avatars");
 
 if (!fs.existsSync(uploadDirectory)) {
   fs.mkdirSync(uploadDirectory, { recursive: true });

--- a/server/src/middleware/uploadResume.js
+++ b/server/src/middleware/uploadResume.js
@@ -2,10 +2,14 @@ import multer from "multer";
 import fs from "fs";
 import fsPromises from "fs/promises";
 import path from "path";
+import { fileURLToPath } from "url";
 import { validateResumeBufferSignatureSync } from "../utils/validateFileSignature.js";
 import asyncHandler from "../utils/asyncHandler.js";
 
-const uploadDirectory = path.join(process.cwd(), "src", "uploads");
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const uploadDirectory = path.join(__dirname, "..", "uploads");
 
 if (!fs.existsSync(uploadDirectory)) {
   fs.mkdirSync(uploadDirectory, { recursive: true });

--- a/server/src/utils/fileUtils.js
+++ b/server/src/utils/fileUtils.js
@@ -1,5 +1,9 @@
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 /**
  * Safely deletes a file from the local disk given its relative or absolute path.
@@ -14,7 +18,7 @@ export const safeDeletePhysicalFile = (filePath) => {
   try {
     const absolutePath = path.isAbsolute(filePath)
       ? filePath
-      : path.join(process.cwd(), filePath);
+      : path.join(__dirname, "..", "..", filePath);
     
     if (fs.existsSync(absolutePath)) {
       fs.unlinkSync(absolutePath);
@@ -47,7 +51,7 @@ export const safeDeleteAvatarByUrl = (avatarUrl) => {
     const filename = path.basename(cleanUrl);
     
     // Resolve absolute path assuming default upload directory
-    const filePath = path.join(process.cwd(), "src", "uploads", "avatars", filename);
+    const filePath = path.join(__dirname, "..", "uploads", "avatars", filename);
     return safeDeletePhysicalFile(filePath);
   } catch (err) {
     console.error(`[safeDeleteAvatarByUrl] Failed to delete avatar ${avatarUrl}:`, err.message);

--- a/server/src/utils/uploadPaths.js
+++ b/server/src/utils/uploadPaths.js
@@ -1,6 +1,10 @@
 import path from "path";
+import { fileURLToPath } from "url";
 
-const UPLOADS_ROOT = path.join(process.cwd(), "src", "uploads");
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const UPLOADS_ROOT = path.join(__dirname, "..", "uploads");
 const AVATARS_DIR = path.join(UPLOADS_ROOT, "avatars");
 const RESUMES_DIR = UPLOADS_ROOT;
 


### PR DESCRIPTION
Fixes #826

Replaces brittle process.cwd() calls with ES Module path resolution (import.meta.url / fileURLToPath) to construct absolute paths for file uploads, ensuring the backend resolves the correct directory regardless of where it is executed from.