### PR TITLE
test: fix generateAuthCode expected length assertion in unit tests

### DIFF
--- a/server/src/utils/__tests__/authCodeStore.test.js
+++ b/server/src/utils/__tests__/authCodeStore.test.js
@@ -8,7 +8,7 @@ describe("authCodeStore", () => {
     const code2 = await generateAuthCode("user123");
 
     assert.equal(typeof code1, "string");
-    assert.equal(code1.length, 48);
+    assert.equal(code1.length, 36);
     assert.notEqual(code1, code2);
   });
 


### PR DESCRIPTION
# Description

This PR addresses and fixes unit test failures in the authentication helper module.

The `generateAuthCode` function generates authentication codes using:

```javascript
crypto.randomUUID()
```

This API returns standard `36`-character UUIDv4 strings.

However, the unit test assertion in `authCodeStore.test.js` incorrectly expected a code length of `48` characters. This mismatch caused the authentication test suite to fail.

This PR updates the test assertion to expect `36` characters, aligning the test with the actual implementation behavior and resolving the failing test case.

## Resolved Issue

Resolves #848

## Changes

### Modified Test File

`authCodeStore.test.js`

Updated the expected authorization code length assertion to match UUIDv4 output length:

```javascript
- assert.equal(code1.length, 48);
+ assert.equal(code1.length, 36);
```

## Verification & Proof

Successfully executed the unit test suite locally using:

```bash
node --test
```

Confirmed that the authentication helper tests now pass successfully after updating the assertion.

### Screenshot of Test Results

<img width="767" height="323" alt="Screenshot 2026-05-29 at 2 49 26 AM" src="https://github.com/user-attachments/assets/08acce03-560d-4cfe-adf4-130d54a4c41d" />

