### PR TITLE
fix: SSRF vulnerability and test mismatch in link verifier

### DIFF
--- a/server/src/utils/__tests__/linkVerifier.test.js
+++ b/server/src/utils/__tests__/linkVerifier.test.js
@@ -5,7 +5,7 @@ import dns from "dns";
 import { verifyLink, verifyLinks } from "../linkVerifier.js";
 
 // Setup DNS mock to resolve to a safe IP by default
-mock.method(dns.promises, "resolve", async () => ["8.8.8.8"]);
+mock.method(dns.promises, "lookup", async () => ({ address: "8.8.8.8" }));
 
 test("verifyLink - returns false if url is missing", async () => {
   const result = await verifyLink(null);
@@ -14,17 +14,17 @@ test("verifyLink - returns false if url is missing", async () => {
 });
 
 test("verifyLink - blocks SSRF via localhost IP", async () => {
-  mock.method(dns.promises, "resolve", async () => ["127.0.0.1"]);
+  mock.method(dns.promises, "lookup", async () => ({ address: "127.0.0.1" }));
   const result = await verifyLink("http://localhost:5000");
   assert.equal(result.isValid, false);
-  assert.equal(result.error, "Blocked SSRF attempt (Internal IP)");
+  assert.equal(result.error, "Access to private IP is forbidden");
 });
 
 test("verifyLink - blocks SSRF via cloud metadata IP", async () => {
-  mock.method(dns.promises, "resolve", async () => ["169.254.169.254"]);
+  mock.method(dns.promises, "lookup", async () => ({ address: "169.254.169.254" }));
   const result = await verifyLink("http://169.254.169.254/latest/meta-data/");
   assert.equal(result.isValid, false);
-  assert.equal(result.error, "Blocked SSRF attempt (Internal IP)");
+  assert.equal(result.error, "Access to private IP is forbidden");
 });
 
 test("verifyLink - blocks SSRF via file protocol", async () => {
@@ -34,7 +34,8 @@ test("verifyLink - blocks SSRF via file protocol", async () => {
 });
 
 test("verifyLink - handles successful link verification", async () => {
-  // Mock axios.get to return a successful response
+  // Re-establish safe DNS mock and mock axios.get to return a successful response
+  mock.method(dns.promises, "lookup", async () => ({ address: "8.8.8.8" }));
   mock.method(axios, "get", async () => {
     return { status: 200 };
   });
@@ -49,7 +50,8 @@ test("verifyLink - handles successful link verification", async () => {
 });
 
 test("verifyLink - handles error status like 404 as invalid", async () => {
-  // Mock axios.get to throw an error for 404
+  // Re-establish safe DNS mock and mock axios.get to throw an error for 404
+  mock.method(dns.promises, "lookup", async () => ({ address: "8.8.8.8" }));
   mock.method(axios, "get", async () => {
     const err = new Error("Request failed with status code 404");
     err.response = { status: 404 };
@@ -64,6 +66,7 @@ test("verifyLink - handles error status like 404 as invalid", async () => {
 });
 
 test("verifyLink - handles bot protection (403, 429) as potentially valid", async () => {
+  mock.method(dns.promises, "lookup", async () => ({ address: "8.8.8.8" }));
   mock.method(axios, "get", async () => {
     const err = new Error("Request failed with status code 403");
     err.response = { status: 403 };
@@ -78,6 +81,7 @@ test("verifyLink - handles bot protection (403, 429) as potentially valid", asyn
 });
 
 test("verifyLinks - verifies multiple links in parallel", async () => {
+  mock.method(dns.promises, "lookup", async () => ({ address: "8.8.8.8" }));
   let calls = 0;
   mock.method(axios, "get", async () => {
     calls++;

--- a/server/src/utils/linkVerifier.js
+++ b/server/src/utils/linkVerifier.js
@@ -26,6 +26,9 @@ export const verifyLink = async (url) => {
 
   try {
     const parsedUrl = new URL(url);
+    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+      return { url, isValid: false, status: 400, error: "Unsupported protocol" };
+    }
     const hostname = parsedUrl.hostname;
 
     // Check if hostname is directly an IP and private
@@ -65,7 +68,7 @@ export const verifyLink = async (url) => {
   } catch (error) {
     // Handle cases where the site exists but blocks automated GETs (like LinkedIn)
     // If it's a 403 or 429, we still consider it "potentially valid" if it's a known domain
-    const isBotProtected = error.response && [403, 429, 999].includes(error.response.status);
+    const isBotProtected = !!(error.response && [403, 429, 999].includes(error.response.status));
     
     return {
       url,


### PR DESCRIPTION
# Description

This PR fixes a security vulnerability and resolves test suite failures in the link verification utility.

## Problems Identified

### Missing Protocol Validation

The `verifyLink` function accepted arbitrary URL protocols, including non-web schemes such as:

```text
file:///etc/passwd
```

There was no explicit restriction limiting accepted URLs to `http:` and `https:` protocols, creating potential security concerns around unsupported or local resource access.

### DNS Mock Mismatch

The test suite mocked:

```javascript
dns.promises.resolve
```

However, the implementation actually calls:

```javascript
dns.promises.lookup
```

Because the mocked API did not match the implementation, SSRF detection tests failed silently and DNS behavior was not properly intercepted.

### Error String Mismatch

The tests asserted the following SSRF error message:

```text
Blocked SSRF attempt (Internal IP)
```

But the implementation returned:

```text
Access to private IP is forbidden
```

This mismatch caused assertion failures despite equivalent security behavior.

### Boolean Coercion Bug

The `isBotProtected` variable relied on a short-circuit expression:

```javascript
error.response && [...]
```

Under non-HTTP error conditions, this expression could evaluate to:

```javascript
undefined
```

As a result, `isValid` could become `undefined` instead of a deterministic boolean value.

### Mock Leakage Between Tests

Tests invoking:

```javascript
mock.restoreAll()
```

also unintentionally removed the shared DNS mock.

Subsequent test cases then fell back to real DNS resolution, producing inconsistent behavior and test failures.

## Resolved Issue

Resolves #850 

## Changes

### `server/src/utils/linkVerifier.js`

- Added explicit protocol validation enforcing `http:` and `https:` only
- Unsupported protocols now return:

```javascript
{
  isValid: false,
  error: "Unsupported protocol"
}
```

- Added boolean coercion (`!!`) to ensure `isBotProtected` always resolves to a proper boolean value

### `server/src/utils/__tests__/linkVerifier.test.js`

- Replaced all DNS mocks:

```javascript
dns.promises.resolve
```

with:

```javascript
dns.promises.lookup
```

to match the implementation behavior

- Updated SSRF assertion strings:

```text
"Blocked SSRF attempt (Internal IP)"
```

→

```text
"Access to private IP is forbidden"
```

- Added `dns.promises.lookup` mock reinitialization after tests invoking `mock.restoreAll()` to prevent DNS mock leakage between test cases

## Verification & Proof

Executed the full link verifier test suite locally.

**Result:** `11/11` tests passing successfully.

<img width="636" height="366" alt="Screenshot 2026-05-29 at 3 03 24 AM" src="https://github.com/user-attachments/assets/0190122b-6405-4efd-9f16-c6063838f755" />


