### PR TITLE
fix: resolve persistent tab title pollution by utility subcomponents

### DIFF
--- a/client/src/modules/ai-assistant/components/ChatBox.jsx
+++ b/client/src/modules/ai-assistant/components/ChatBox.jsx
@@ -1,11 +1,7 @@
 import { useState } from "react";
 import MessageBubble from "./MessageBubble";
 import { API_URL } from "../../../config/env";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const ChatBox = () => {
-  useDocumentTitle("Chat Box");
   const [messages, setMessages] = useState([
     { sender: "bot", text: "Hi! How can I help you?" },
   ]);

--- a/client/src/modules/ai-assistant/components/ChatWidget.jsx
+++ b/client/src/modules/ai-assistant/components/ChatWidget.jsx
@@ -1,10 +1,6 @@
 import { useState } from "react";
 import ChatBox from "./ChatBox";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const ChatWidget = () => {
-  useDocumentTitle("Chat Widget");
   const [isOpen, setIsOpen] = useState(false);
 
   const toggleChat = () => {

--- a/client/src/modules/ai-assistant/components/MessageBubble.jsx
+++ b/client/src/modules/ai-assistant/components/MessageBubble.jsx
@@ -1,6 +1,4 @@
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 const MessageBubble = ({ sender, text }) => {
-  useDocumentTitle("Message Bubble");
   const isUser = sender === "user";
 
   return (

--- a/client/src/modules/auth/components/ComponentDemo.jsx
+++ b/client/src/modules/auth/components/ComponentDemo.jsx
@@ -1,9 +1,6 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { Input, Button, Select } from "../../../shared/components";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const ROLE_OPTIONS = [
   { value: "student",   label: "Student" },
   { value: "tutor",     label: "Tutor" },
@@ -11,7 +8,6 @@ const ROLE_OPTIONS = [
 ];
 
 const ComponentDemo = () => {
-  useDocumentTitle("Component Demo");
   const [form, setForm] = useState({ fullName: "", email: "", password: "", role: "" });
   const [errors, setErrors] = useState({});
   const [loading, setLoading] = useState(false);

--- a/client/src/modules/classrooms/components/SharedCodeEditor.jsx
+++ b/client/src/modules/classrooms/components/SharedCodeEditor.jsx
@@ -1,11 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import Editor from "@monaco-editor/react";
 import { Code2, Info, Play, Terminal, XCircle, Loader2 } from "lucide-react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 export default function SharedCodeEditor({ socket, roomId, userRole }) {
-  useDocumentTitle("Shared Code Editor");
   const [code, setCode] = useState(`// Welcome to SkillSphere AI Live Coding Classroom!\n// Type your collaborative code here...\n\nfunction helloWorld() {\n  console.log("Welcome to class!");\n}`);
   const [language, setLanguage] = useState("javascript");
   const [lastEditorInfo, setLastEditorInfo] = useState("");

--- a/client/src/modules/classrooms/components/VideoTile.jsx
+++ b/client/src/modules/classrooms/components/VideoTile.jsx
@@ -1,10 +1,6 @@
 import React, { useRef, useEffect } from "react";
 import { Hand, MicOff, VideoOff } from "lucide-react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 export default function VideoTile({ stream, user, isMuted, isHandRaised, isScreenShare, isLocal }) {
-  useDocumentTitle("Video Tile");
   const videoRef = useRef();
 
   useEffect(() => {

--- a/client/src/modules/classrooms/components/Whiteboard.jsx
+++ b/client/src/modules/classrooms/components/Whiteboard.jsx
@@ -1,10 +1,6 @@
 import React, { useRef, useState, useEffect } from "react";
 import { Trash2, Eraser, Edit2 } from "lucide-react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 export default function Whiteboard({ socket, roomId, userRole }) {
-  useDocumentTitle("Whiteboard");
   const canvasRef = useRef(null);
   const [isDrawing, setIsDrawing] = useState(false);
   const [color, setColor] = useState("#38bdf8"); // Neon Blue default

--- a/client/src/modules/dashboard/components/DashboardSkeleton.jsx
+++ b/client/src/modules/dashboard/components/DashboardSkeleton.jsx
@@ -1,8 +1,6 @@
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 // Skeleton placeholder for dashboard widgets and analytics
 
 const DashboardSkeleton = () => {
-  useDocumentTitle("Skeleton");
   return (
     <div className="w-full space-y-6 animate-pulse">
       {/* Header Section Skeleton */}

--- a/client/src/modules/dashboard/components/PerformanceTrend.jsx
+++ b/client/src/modules/dashboard/components/PerformanceTrend.jsx
@@ -9,11 +9,7 @@ import {
   Tooltip as RechartsTooltip 
 } from "recharts";
 import { BarChart3, Calendar, Activity } from "lucide-react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const PerformanceTrend = ({ data, historyLength, customTooltip: CustomTooltip }) => {
-  useDocumentTitle("Performance Trend");
   return (
     <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 overflow-hidden backdrop-blur-md">
       <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center justify-between">

--- a/client/src/modules/dashboard/components/StatCard.jsx
+++ b/client/src/modules/dashboard/components/StatCard.jsx
@@ -1,9 +1,5 @@
 import React from "react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const StatCard = ({ icon: Icon, label, value, color, className = "" }) => {
-  useDocumentTitle("Stat Card");
   const colorVariants = {
     blue: "border-blue-500/30 from-blue-500/5 text-blue-400 bg-blue-500/20",
     emerald: "border-emerald-500/30 from-emerald-500/5 text-emerald-400 bg-emerald-500/20",

--- a/client/src/modules/dashboard/components/SuggestionItem.jsx
+++ b/client/src/modules/dashboard/components/SuggestionItem.jsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from "react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 import { 
 
   AlertCircle, 
@@ -10,7 +9,6 @@ import {
 } from "lucide-react";
 
 const SuggestionItem = ({ suggestion }) => {
-  useDocumentTitle("Suggestion Item");
   // Handle both string and object formats for robustness
   const text = typeof suggestion === "string" ? suggestion : (suggestion?.text || "");
   const priority = suggestion?.priority || "";

--- a/client/src/modules/dashboard/components/VersionComparisonModal.jsx
+++ b/client/src/modules/dashboard/components/VersionComparisonModal.jsx
@@ -10,11 +10,7 @@ import {
   Layout
 } from "lucide-react";
 import Button from "../../../shared/components/Button";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const VersionComparisonModal = ({ isOpen, onClose, versions }) => {
-  useDocumentTitle("Version Comparison Modal");
   if (!isOpen || !versions || versions.length !== 2) return null;
 
   // versions[0] is the older one based on history array order (newest first)

--- a/client/src/modules/job-matcher/components/MatchScoreCard.jsx
+++ b/client/src/modules/job-matcher/components/MatchScoreCard.jsx
@@ -1,6 +1,4 @@
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 export default function MatchScoreCard({ score }) {
-  useDocumentTitle("Match Score Card");
   return (
     <div className="bg-white/10 backdrop-blur-lg border border-white/20 p-6 rounded-2xl shadow-xl text-white text-center">
 

--- a/client/src/modules/job-matcher/components/MatcherForm.jsx
+++ b/client/src/modules/job-matcher/components/MatcherForm.jsx
@@ -1,9 +1,5 @@
 import { useState } from "react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 export default function MatcherForm({ onSubmit }) {
-  useDocumentTitle("Matcher Form");
   const [type, setType] = useState("existing");
   const [resumeId, setResumeId] = useState("");
   const [file, setFile] = useState(null);

--- a/client/src/modules/job-matcher/components/MatcherResult.jsx
+++ b/client/src/modules/job-matcher/components/MatcherResult.jsx
@@ -1,11 +1,7 @@
 import MatchScoreCard from "./MatchScoreCard";
 import MissingSkillsList from "./MissingSkillsList";
 import RecommendedJobsList from "./RecommendedJobsList";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 export default function MatcherResult({ data }) {
-  useDocumentTitle("Matcher Result");
   return (
     <div className="grid md:grid-cols-3 gap-6">
       

--- a/client/src/modules/job-matcher/components/MissingSkillsList.jsx
+++ b/client/src/modules/job-matcher/components/MissingSkillsList.jsx
@@ -1,6 +1,4 @@
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 const MissingSkillsList = ({ skills }) => {
-  useDocumentTitle("Missing Skills List");
   if (!skills || skills.length === 0) return null;
 
   return (

--- a/client/src/modules/job-matcher/components/RecommendedJobsList.jsx
+++ b/client/src/modules/job-matcher/components/RecommendedJobsList.jsx
@@ -1,6 +1,4 @@
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 export default function RecommendedJobsList({ jobs }) {
-  useDocumentTitle("Recommended Jobs List");
   return (
     <div className="bg-white/10 backdrop-blur-lg border border-white/20 p-5 rounded-2xl shadow-xl text-white">
       

--- a/client/src/modules/landing/components/CTA.jsx
+++ b/client/src/modules/landing/components/CTA.jsx
@@ -1,11 +1,7 @@
 import { useSelector } from "react-redux";
 import { ArrowRight, Sparkles } from "lucide-react";
 import { Link } from "react-router-dom";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const CTA = () => {
-  useDocumentTitle("CTA");
   const { isAuthenticated, user } = useSelector((state) => state.auth);
   const isRecruiter = user?.role === "recruiter";
   const cta = isAuthenticated

--- a/client/src/modules/landing/components/Features.jsx
+++ b/client/src/modules/landing/components/Features.jsx
@@ -11,9 +11,6 @@ import {
   Video,
 } from "lucide-react";
 import Card from "../../../shared/landing/Card";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const ClassroomPreview = () => (
   <div className="grid h-36 grid-cols-[1fr_0.72fr] gap-3 rounded-lg border border-[var(--border)] bg-[var(--background)] p-3">
     <div className="relative rounded-lg bg-[var(--surface)] p-3">
@@ -183,7 +180,6 @@ const previews = {
 };
 
 const Features = () => {
-  useDocumentTitle("Features");
   const featuresList = [
     {
       key: "classroom",

--- a/client/src/modules/landing/components/Footer.jsx
+++ b/client/src/modules/landing/components/Footer.jsx
@@ -1,10 +1,6 @@
 import { Link } from "react-router-dom";
 import { Mail, ArrowRight, Sparkles } from "lucide-react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const Footer = () => {
-  useDocumentTitle("Footer");
   return (
     <footer className="relative border-t border-[var(--border)] bg-slate-950 overflow-hidden">
       {/* Decorative gradient background elements */}

--- a/client/src/modules/landing/components/Hero.jsx
+++ b/client/src/modules/landing/components/Hero.jsx
@@ -1,8 +1,5 @@
 import { CheckCircle2, FileSearch, LineChart, MessageSquareText, Sparkles, Video } from "lucide-react";
 import Button from "../../../shared/landing/Button";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const headingGradientStyle = {
   backgroundImage: "linear-gradient(135deg, #7C3AED 0%, #4F46E5 50%, #059669 100%)",
   WebkitBackgroundClip: "text",
@@ -26,7 +23,6 @@ const renderAnimatedChars = (text, startDelay = 0, stepDelay = 80) =>
   ));
 
 const Hero = () => {
-  useDocumentTitle("Hero");
   return (
     <section className="relative min-h-[92vh] max-sm:min-h-[72vh] flex items-center px-4 pt-28 pb-16 overflow-visible animate-slide-up sm:pt-28 sm:pb-14">
       {/* Light mode gradient orbs */}

--- a/client/src/modules/landing/components/TargetUsers.jsx
+++ b/client/src/modules/landing/components/TargetUsers.jsx
@@ -1,10 +1,6 @@
 import { BookOpen, Briefcase, CheckCircle2, Users } from "lucide-react";
 import Card from "../../../shared/landing/Card";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const TargetUsers = () => {
-  useDocumentTitle("Target Users");
   const users = [
     {
       icon: <BookOpen className="text-[var(--primary)]" size={34} />,

--- a/client/src/modules/mock-interview/components/CameraCheck.jsx
+++ b/client/src/modules/mock-interview/components/CameraCheck.jsx
@@ -1,10 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Video, VideoOff, Mic } from "lucide-react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const CameraCheck = ({ onStreamReady }) => {
-  useDocumentTitle("Camera Check");
   const videoRef = useRef(null);
   const [stream, setStream] = useState(null);
   const [error, setError] = useState(null);

--- a/client/src/modules/mock-interview/components/InterviewResultsSkeleton.jsx
+++ b/client/src/modules/mock-interview/components/InterviewResultsSkeleton.jsx
@@ -1,8 +1,6 @@
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 // Skeleton placeholder for interview results
 
 const InterviewResultsSkeleton = () => {
-  useDocumentTitle("Interview Results Skeleton");
   return (
     <div className="results-container animate-pulse">
       {/* Header Section Skeleton */}

--- a/client/src/modules/mock-interview/components/InterviewSessionSkeleton.jsx
+++ b/client/src/modules/mock-interview/components/InterviewSessionSkeleton.jsx
@@ -1,8 +1,6 @@
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 // Skeleton placeholder for interview session loading
 
 const InterviewSessionSkeleton = () => {
-  useDocumentTitle("Interview Session Skeleton");
   return (
     <div className="session-container animate-pulse">
       {/* Header Bar Skeleton */}

--- a/client/src/modules/mock-interview/components/ObserverPanel.jsx
+++ b/client/src/modules/mock-interview/components/ObserverPanel.jsx
@@ -1,10 +1,6 @@
 import React, { useState } from "react";
 import { Users, FileText, Send, Eye } from "lucide-react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 export default function ObserverPanel({ participants, onSendFeedback, isConductor }) {
-  useDocumentTitle("Observer Panel");
   const [note, setNote] = useState("");
   const [savedNotes, setSavedNotes] = useState([]);
 

--- a/client/src/modules/mock-interview/components/PersonaSelector.jsx
+++ b/client/src/modules/mock-interview/components/PersonaSelector.jsx
@@ -1,8 +1,5 @@
 import React from "react";
 import { UserCheck, Rocket, GraduationCap, Handshake, Briefcase } from "lucide-react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const PERSONAS = [
   {
     id: "friendly",
@@ -47,7 +44,6 @@ const PERSONAS = [
 ];
 
 const PersonaSelector = ({ selectedPersona, onSelect }) => {
-  useDocumentTitle("Persona Selector");
   return (
     <div className="group relative rounded-3xl bg-white/70 dark:bg-slate-900/60 p-6 sm:p-8 border border-white/20 dark:border-slate-800 shadow-[0_20px_40px_rgba(0,0,0,0.08)] dark:shadow-[0_20px_40px_rgba(0,0,0,0.4)] backdrop-blur-xl transition-all duration-300 hover:shadow-[0_20px_50px_rgba(168,85,247,0.1)] hover:border-purple-500/30">
       <div className="absolute inset-0 bg-gradient-to-br from-purple-500/5 to-fuchsia-500/5 rounded-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-500" />

--- a/client/src/modules/mock-interview/components/RealtimeSentimentIndicator.jsx
+++ b/client/src/modules/mock-interview/components/RealtimeSentimentIndicator.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { Activity, Brain, AlertCircle } from 'lucide-react';
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const RealtimeSentimentIndicator = ({ analysis }) => {
-  useDocumentTitle("Realtime Sentiment Indicator");
   if (!analysis) return null;
 
   const { confidence, tone, hesitationCount } = analysis;

--- a/client/src/modules/notifications/components/NotificationBell.jsx
+++ b/client/src/modules/notifications/components/NotificationBell.jsx
@@ -2,15 +2,11 @@ import React, { useState, useCallback } from "react";
 import { Bell } from "lucide-react";
 import NotificationDropdown from "./NotificationDropdown";
 import useNotifications from "../hooks/useNotifications";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 /**
  * Notification Bell Icon with dropdown
  * Shows unread badge and manages dropdown visibility
  */
 const NotificationBell = () => {
-  useDocumentTitle("Notification Bell");
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const {
     notifications,

--- a/client/src/modules/notifications/components/NotificationCard.jsx
+++ b/client/src/modules/notifications/components/NotificationCard.jsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from "react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 import {
 
   Trash2,
@@ -86,7 +85,6 @@ const NotificationCard = ({
   onDelete,
   isCompact = false,
 }) => {
-  useDocumentTitle("Notification Card");
   const { _id, title, message, type, isRead, createdAt } = notification;
 
   const config = useMemo(() => getNotificationTypeConfig(type), [type]);

--- a/client/src/modules/notifications/components/NotificationDropdown.jsx
+++ b/client/src/modules/notifications/components/NotificationDropdown.jsx
@@ -2,9 +2,6 @@ import React, { useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { Trash2, ArrowRight, CheckCheck } from "lucide-react";
 import NotificationCard from "./NotificationCard";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 /**
  * Dropdown panel showing recent notifications
  * Positioned relative to the bell icon
@@ -20,7 +17,6 @@ const NotificationDropdown = ({
   onMarkAllAsRead,
   onDeleteAll,
 }) => {
-  useDocumentTitle("Notification Dropdown");
   const dropdownRef = useRef(null);
   const isEmpty = notifications.length === 0 && !loading;
 

--- a/client/src/modules/profile/components/ProfileField.jsx
+++ b/client/src/modules/profile/components/ProfileField.jsx
@@ -1,8 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 /**
  * ProfileField — A single read-only info row used inside the profile cards.
  *
@@ -13,7 +10,6 @@ import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
  * @param {React.ReactNode} icon    - Optional lucide-react icon element
  */
 const ProfileField = ({ label, value, icon }) => {
-  useDocumentTitle("Profile Field");
   return (
     <div className="flex items-start gap-3 py-3 border-b border-white/5 last:border-b-0">
       {icon && (

--- a/client/src/modules/profile/components/ProfileSkeleton.jsx
+++ b/client/src/modules/profile/components/ProfileSkeleton.jsx
@@ -1,8 +1,6 @@
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 // Skeleton placeholder for profile sections
 
 const ProfileSkeleton = () => {
-  useDocumentTitle("Profile Skeleton");
   return (
     <div className="min-h-screen animate-pulse">
       {/* Top Navigation Skeleton */}

--- a/client/src/modules/recruiter-jobs/components/JobPostingForm.jsx
+++ b/client/src/modules/recruiter-jobs/components/JobPostingForm.jsx
@@ -4,9 +4,6 @@ import Input from "../../../shared/components/Input";
 import Select from "../../../shared/components/Select";
 import Button from "../../../shared/components/Button";
 import { useToast } from "../../../shared/components";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const STATUS_OPTIONS = [
   { value: "draft", label: "Draft" },
   { value: "open", label: "Open" },
@@ -55,7 +52,6 @@ const getSubmitErrorMessage = (error) => {
 };
 
 const JobPostingForm = ({ onSubmit, initialData = {}, isLoading = false, fieldErrors = {} }) => {
-  useDocumentTitle("Job Posting Form");
   const { success, error: showError } = useToast();
   const isEditMode = Boolean(initialData?._id || initialData?.id);
   const submitButtonText = isEditMode ? "Update Job" : "Post Job";

--- a/client/src/modules/resume-analyzer/components/AnalysisReportPDF.jsx
+++ b/client/src/modules/resume-analyzer/components/AnalysisReportPDF.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 import {
   AlertCircle,
   CheckCircle2,
@@ -11,7 +10,6 @@ import {
 } from "lucide-react";
 
 const AnalysisReportPDF = ({ result, fileName }) => {
-  useDocumentTitle("Analysis Report PDF");
   if (!result) return null;
 
   const score = result.score || 0;

--- a/client/src/modules/resume-analyzer/components/AnalysisResult.jsx
+++ b/client/src/modules/resume-analyzer/components/AnalysisResult.jsx
@@ -23,11 +23,7 @@ import { generateCoverLetter } from "../services/resumeService";
 import html2pdf from "html2pdf.js";
 import AnalysisReportPDF from "./AnalysisReportPDF";
 import { useToast } from "../../../shared/components";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const AnalysisResult = ({ result, file, jobDescription, onReset }) => {
-  useDocumentTitle("Analysis Result");
   const score = result?.score || 0;
   const isJDProvided = result.isJDProvided;
   const suggestions = (result.gapAnalysis?.suggestions || []).slice(0, 8);

--- a/client/src/modules/resume-analyzer/components/DragDropUpload.jsx
+++ b/client/src/modules/resume-analyzer/components/DragDropUpload.jsx
@@ -2,9 +2,6 @@ import { AlertCircle, CheckCircle2, Loader2, UploadCloud } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useToast } from "../../../shared/components";
 import Button from "../../../shared/landing/Button";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const MAX_RESUME_FILE_SIZE_BYTES = 5 * 1024 * 1024;
 const SUPPORTED_RESUME_EXTENSIONS = [".pdf", ".doc", ".docx"];
 const SUPPORTED_RESUME_MIME_TYPES = [
@@ -70,7 +67,6 @@ const getUploadErrorMessage = (error) => {
 };
 
 const DragDropUpload = ({ onFileUpload }) => {
-  useDocumentTitle("Drag Drop Upload");
   const { success, warning, error: showError } = useToast();
   const [isDragActive, setIsDragActive] = useState(false);
   const [selectedFile, setSelectedFile] = useState(null);

--- a/client/src/modules/resume-analyzer/components/JobDescriptionInput.jsx
+++ b/client/src/modules/resume-analyzer/components/JobDescriptionInput.jsx
@@ -9,9 +9,6 @@ import {
   FileText,
 } from "lucide-react";
 import { TextArea, Button, useToast } from "../../../shared/components";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 /**
  * Cleans raw JD text:
  * - Collapses 3+ blank lines to 2
@@ -29,7 +26,6 @@ const cleanJDText = (raw) => {
 const CHAR_LIMIT = 5000;
 
 const JobDescriptionInput = ({ value, onChange }) => {
-  useDocumentTitle("Job Description Input");
   const { success, error: showError, warning, info } = useToast();
   const fileInputRef = useRef(null);
   const [isDragOver, setIsDragOver] = useState(false);

--- a/client/src/modules/resume-analyzer/components/ResumeSkeleton.jsx
+++ b/client/src/modules/resume-analyzer/components/ResumeSkeleton.jsx
@@ -1,8 +1,6 @@
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 // Skeleton placeholder for resume analysis results
 
 const ResumeSkeleton = () => {
-  useDocumentTitle("Resume Skeleton");
   return (
     <div className="w-full space-y-8 animate-pulse">
       {/* AI Intelligence Banner Skeleton */}

--- a/client/src/modules/resume-analyzer/components/SkillGapVenn.jsx
+++ b/client/src/modules/resume-analyzer/components/SkillGapVenn.jsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { User, Briefcase, Zap, AlertCircle, CheckCircle2 } from "lucide-react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const SkillGapVenn = ({ skillMatch = {}, isJDProvided = false, mode = "match" }) => {
-  useDocumentTitle("Skill Gap Venn");
   if (!isJDProvided && mode !== "benchmark") return null;
 
   const { matchedSkills = [], missingSkills = [], extraSkills = [] } = skillMatch.details || {};

--- a/client/src/modules/roadmap/components/ContributionSummaryCard.jsx
+++ b/client/src/modules/roadmap/components/ContributionSummaryCard.jsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { Star, TrendingUp, Award } from "lucide-react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 const ContributionSummaryCard = ({ roadmap }) => {
-  useDocumentTitle("Contribution Summary Card");
   if (!roadmap || !roadmap.roadmap) return null;
 
   const contributionTopics = roadmap.roadmap.filter(

--- a/client/src/modules/student-jobs/components/JobApplyForm.jsx
+++ b/client/src/modules/student-jobs/components/JobApplyForm.jsx
@@ -1,9 +1,6 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { X, Send, Link2, FileText, User, Mail } from "lucide-react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
 /**
  * JobApplyForm — Modal form for students to apply to a job.
  *
@@ -12,7 +9,6 @@ import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
  * Optional Cover Note.
  */
 const JobApplyForm = ({ job, user, onSubmit, onClose, isSubmitting }) => {
-  useDocumentTitle("Job Apply Form");
   const [resumeLink, setResumeLink] = useState("");
   const [coverNote, setCoverNote] = useState("");
   const [error, setError] = useState("");

--- a/client/src/modules/student-jobs/components/JobCardSkeleton.jsx
+++ b/client/src/modules/student-jobs/components/JobCardSkeleton.jsx
@@ -1,8 +1,6 @@
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 // Skeleton placeholder card displayed during jobs loading state
 
 const JobCardSkeleton = () => {
-  useDocumentTitle("Job Card Skeleton");
   return (
     <div className="animate-pulse rounded-2xl border border-white/5 bg-slate-900/40 p-6">
       <div className="flex justify-between items-start mb-5">

--- a/client/src/modules/student-jobs/components/JobFilters.jsx
+++ b/client/src/modules/student-jobs/components/JobFilters.jsx
@@ -3,12 +3,7 @@ import PropTypes from "prop-types";
 import { Search, Filter, Calendar, IndianRupee, X } from "lucide-react";
 import Input from "../../../shared/components/Input";
 import Select from "../../../shared/components/Select";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-
-
 const JobFilters = ({ onFilterChange }) => {
-  useDocumentTitle("Job Filters");
   const [filters, setFilters] = useState({
     designation: "",
     minSalary: "",


### PR DESCRIPTION
# Description

This PR resolves an issue where the browser tab title was being hijacked and incorrectly overridden by nested subcomponents mounting within rendered pages.

## Problems Identified

An automated injection script (`inject_title.py`) had previously been executed against the codebase and indiscriminately inserted the `useDocumentTitle` hook into virtually every `.jsx` file.

As a result, utility and presentation subcomponents such as:

- `NotificationBell`
- `NotificationCard`
- `VideoTile`
- Additional nested `/components/` modules

began independently managing `document.title`.

Because these child components mount after their parent pages, they unintentionally overrode the intended page-level browser tab title.

### Example Behavior

Expected:

```text
Notifications | SkillSphere AI
```

Observed:

```text
Notifications | SkillSphere AI
↓
Notification Bell | SkillSphere AI
```

The title would initially render correctly, then be overwritten when a nested child component mounted.

## Resolved Issue

Resolves #852

## Changes

- Systematically removed the `useDocumentTitle` import and hook invocation from **44 nested subcomponents** across the codebase
- Removed all hook usage from files located under `/components/` directories
- Retained `useDocumentTitle` usage for valid top-level page containers only
- Preserved hook usage in:
  - `*Page.jsx`
  - `*Dashboard.jsx`
  - Other legitimate route-level containers
- Confirmed the React frontend builds successfully with:
  - No unresolved imports
  - No syntax issues
  - No hook reference errors

## Verification & Proof

Verified that `useDocumentTitle` now exists only on appropriate page-level components.

Codebase validation confirms:

```text
Search: useDocumentTitle within /components/ directories
Result: 0 matches
```

Confirmed successful frontend build after cleanup.

### Screenshot of Test Results

<img width="659" height="585" alt="Screenshot 2026-05-29 at 3 18 55 AM" src="https://github.com/user-attachments/assets/a87cde9c-4b3d-4fd1-9e53-9efe0062367c" />
