### PR TITLE
Add authorization check to join-interview WebSocket handler

### DIFF
--- a/server/src/modules/interviews/socket.js
+++ b/server/src/modules/interviews/socket.js
@@ -1,4 +1,5 @@
 import InterviewSession from "../../database/models/InterviewSession.js";
+import LearningProgress from "../../database/models/LearningProgress.js";
 import { processAnswerSubmission } from "./service.js";
 import { transcribeAudioStream } from "../../integrations/aiInterviewService.js";
 
@@ -16,6 +17,18 @@ export function initInterviewSockets(io) {
         const user = socket.user; // populated by auth middleware
         if (!user) {
           socket.emit("unauthorized", { message: "User authentication required" });
+          return;
+        }
+
+        const userId = user._id;
+        const isOwner = session.userId.equals(userId);
+        const isConductor = session.conductorId && session.conductorId.equals(userId);
+        const isObserver = session.observers && session.observers.some((id) => id.equals(userId));
+        const isTutor = user.role === "tutor" &&
+          await LearningProgress.findOne({ user: session.userId, tutorsTracking: userId });
+
+        if (!isOwner && !isConductor && !isObserver && !isTutor) {
+          socket.emit("unauthorized", { message: "You are not authorized to join this interview session" });
           return;
         }
 


### PR DESCRIPTION
Closes #854

## What this fixes

The join-interview WebSocket handler let any authenticated user join any interview room. An attacker who knew a victim's sessionId (a UUID that could leak via analytics APIs or social engineering) could join the room, observe live participant activity, receive scoring broadcasts, and in the original code submit answers attributed to the victim.

The REST API routes correctly scoped all operations by userId and were never vulnerable. The WebSocket layer was the gap.

## Root cause

The join-interview handler at server/src/modules/interviews/socket.js:8 called socket.join(sessionId) after checking only that the session existed and the user was authenticated. It never verified that the user owned the session, was the designated conductor, was listed as an observer, or was a tutor authorized to track the student via LearningProgress.

## What changed

server/src/modules/interviews/socket.js:
- Added one import: LearningProgress model
- Added 12 lines of authorization logic after the user-authentication check and before socket.join()
- The handler now grants access only if one of these is true: the user owns the session (userId match), the user is the conductor (conductorId match), the user is in the observers array, or the user is a tutor with a LearningProgress record linking them to the student owner

## How to verify

1. Authenticate as User A and extract the JWT
2. Connect to the WebSocket with User A's JWT
3. Send: { event: "join-interview", data: { sessionId: "<User B's session ID>" } }
4. The server responds with "unauthorized" and does not add the socket to the room
5. All downstream events (submit-answer, start-audio-stream, save-private-note, submit-live-feedback) silently return because socket.data.sessionId was never set
6. User A can still join their own sessions normally

## Edge cases considered

- Unauthenticated connections: Already prevented by the io.use() middleware in server/index.js:67, which calls verifySocketToken and rejects if no token is present
- Tutor access: Tutors who have a LearningProgress record tracking the student owner are authorized — this matches the existing authorization pattern used by getTutorSessionDetails and addTutorFeedback in the service layer
- Conductor and observer roles: Honored per the InterviewSession schema fields (conductorId, observers) so legitimate multi-participant interviews continue to work
- Session not found: Returns the same "unauthorized" event as the ownership check, avoiding information leakage about whether a sessionId is valid
