### PR TITLE
Fixes #864: Security, Migrate JWT token blacklist from in-memory Map to Redis

### DIFF
--- a/server/src/middleware/authMiddleware.js
+++ b/server/src/middleware/authMiddleware.js
@@ -29,7 +29,7 @@ export const protect = asyncHandler(async (req, res, next) => {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
 
     // 3) Check if token has been revoked (logged out)
-    if (decoded.jti && isTokenBlacklisted(decoded.jti)) {
+    if (decoded.jti && await isTokenBlacklisted(decoded.jti)) {
       return next(
         new AppError("Token has been revoked. Please log in again.", 401)
       );
@@ -77,7 +77,7 @@ export const authorizeRoles = (...roles) => {
 export const verifySocketToken = async (token) => {
   if (!token) throw new Error("Authentication required");
   const decoded = jwt.verify(token, process.env.JWT_SECRET);
-  if (decoded.jti && isTokenBlacklisted(decoded.jti)) {
+  if (decoded.jti && await isTokenBlacklisted(decoded.jti)) {
     throw new Error("Token has been revoked");
   }
   const user = await User.findById(decoded.userId).select("-password");

--- a/server/src/utils/tokenBlacklist.js
+++ b/server/src/utils/tokenBlacklist.js
@@ -1,43 +1,47 @@
+import redisClient from "../config/redis.js";
+
 /**
- * In-memory JWT token blacklist.
- *
- * Stores revoked token JTIs (JWT IDs) along with their expiration timestamps.
- * Expired entries are automatically purged every 15 minutes to prevent memory leaks.
- *
- * Trade-off: blacklisted tokens are lost on server restart, so a revoked token
- * could be reused until it expires naturally. For multi-instance deployments,
- * swap this store for Redis or a shared cache.
+ * JWT token blacklist (Redis-backed with in-memory fallback).
  */
 
-// Map<jti: string, expiresAt: number (epoch seconds)>
 const blacklist = new Map();
+const CLEANUP_INTERVAL_MS = 15 * 60 * 1000;
 
-const CLEANUP_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
-
-/**
- * Add a token's JTI to the blacklist.
- * @param {string} jti    - The JWT ID claim from the token
- * @param {number} exp    - The token's expiration time (epoch seconds, from JWT `exp` claim)
- */
-export const blacklistToken = (jti, exp) => {
+export const blacklistToken = async (jti, exp) => {
   if (!jti || !exp) return;
+  const now = Math.floor(Date.now() / 1000);
+  const ttl = exp - now;
+  
+  if (ttl <= 0) return;
+
+  if (redisClient?.isReady) {
+    try {
+      await redisClient.setEx(`bl_${jti}`, ttl, "1");
+      return;
+    } catch (err) {
+      console.error("Redis blacklist error:", err);
+    }
+  }
+  
+  // Fallback
   blacklist.set(jti, exp);
 };
 
-/**
- * Check whether a token's JTI has been blacklisted.
- * @param {string} jti - The JWT ID claim to look up
- * @returns {boolean}  - true if the token was revoked
- */
-export const isTokenBlacklisted = (jti) => {
+export const isTokenBlacklisted = async (jti) => {
   if (!jti) return false;
+  
+  if (redisClient?.isReady) {
+    try {
+      const exists = await redisClient.exists(`bl_${jti}`);
+      if (exists) return true;
+    } catch (err) {
+      console.error("Redis check error:", err);
+    }
+  }
+  
   return blacklist.has(jti);
 };
 
-/**
- * Remove expired entries from the blacklist.
- * Called automatically on a timer — no need to invoke manually.
- */
 const purgeExpired = () => {
   const now = Math.floor(Date.now() / 1000);
   for (const [jti, exp] of blacklist) {
@@ -47,10 +51,7 @@ const purgeExpired = () => {
   }
 };
 
-// Schedule automatic cleanup
 const cleanupTimer = setInterval(purgeExpired, CLEANUP_INTERVAL_MS);
-
-// Allow the Node.js process to exit gracefully without waiting for this timer
 if (cleanupTimer.unref) {
   cleanupTimer.unref();
 }


### PR DESCRIPTION
## Summary
This PR fixes a security vulnerability where revoked JWT tokens would become valid again after a server restart or in multi-instance deployments. It migrates the `tokenBlacklist` implementation from an in-memory `Map` to Redis, utilizing the existing Redis connection in the project.

## Type of Change
- [x] Bug fix
- [x] Security fix

## Related Issue
Fixes #864

## Changes Made
- Changed `blacklistToken` to use `redisClient.setEx` with the appropriate token TTL.
- Changed `isTokenBlacklisted` to check Redis (`redisClient.exists`).
- Updated `authMiddleware.js` to `await` the new async `isTokenBlacklisted` check.
- Retained an in-memory fallback just in case Redis is momentarily unavailable.

## Validation
- [x] Build passes locally

*Contributing under GSSoC '26* 🚀
