### PR TITLE
Fixes #865:  Fix memory leak in authCodeStore by cleaning up expired codes

### DIFF
--- a/server/src/utils/authCodeStore.js
+++ b/server/src/utils/authCodeStore.js
@@ -1,6 +1,7 @@
 import crypto from "crypto";
 
 const authCodeStore = new Map();
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
 
 export const generateAuthCode = (userId) => {
   const code = crypto.randomUUID();
@@ -21,3 +22,17 @@ export const consumeAuthCode = (code) => {
   authCodeStore.delete(code);
   return entry.userId;
 };
+
+const purgeExpiredCodes = () => {
+  const now = Date.now();
+  for (const [code, entry] of authCodeStore) {
+    if (entry.expiresAt <= now) {
+      authCodeStore.delete(code);
+    }
+  }
+};
+
+const cleanupTimer = setInterval(purgeExpiredCodes, CLEANUP_INTERVAL_MS);
+if (cleanupTimer.unref) {
+  cleanupTimer.unref();
+}


### PR DESCRIPTION
## Summary
This PR fixes a memory leak in the Google OAuth flow. Previously, generated auth codes were stored in an in-memory map but were never cleaned up if they naturally expired (e.g., if a user abandoned the login flow). This adds a periodic cleanup timer to remove stale entries and free up memory.

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor

## Related Issue
Fixes #865

## Changes Made
- Added a `purgeExpiredCodes` function to `utils/authCodeStore.js` that removes any entries where `expiresAt` is in the past.
- Added a `setInterval` timer to run the cleanup automatically every 5 minutes (consistent with the pattern in `tokenBlacklist.js`).

## Validation
- [x] Build passes locally

*Contributing under GSSoC '26* 🚀

