### PR TITLE
feat(resume-analyzer): add pdf export for analysis results

### DIFF
--- a/client/src/modules/resume-analyzer/components/AnalysisResult.jsx
+++ b/client/src/modules/resume-analyzer/components/AnalysisResult.jsx
@@ -20,9 +20,9 @@ import Button from "../../../shared/landing/Button";
 import SkillGapVenn from "./SkillGapVenn";
 import CoverLetterModal from "../../../shared/components/CoverLetterModal";
 import { generateCoverLetter } from "../services/resumeService";
-import html2pdf from "html2pdf.js";
 import AnalysisReportPDF from "./AnalysisReportPDF";
 import { useToast } from "../../../shared/components";
+import { exportToPDF } from "../../../utils/exportUtils";
 const AnalysisResult = ({ result, file, jobDescription, onReset }) => {
   const score = result?.score || 0;
   const isJDProvided = result.isJDProvided;
@@ -38,6 +38,7 @@ const AnalysisResult = ({ result, file, jobDescription, onReset }) => {
 
   const { success, error: showError } = useToast();
   const [isExportingPDF, setIsExportingPDF] = useState(false);
+  const [exportError, setExportError] = useState("");
 
   useEffect(() => {
     if (
@@ -84,30 +85,27 @@ const AnalysisResult = ({ result, file, jobDescription, onReset }) => {
   const actionWords = result.readabilityMatch?.relevantVerbs || ["Spearheaded", "Orchestrated", "Transformed", "Optimized", "Architected", "Launched", "Pioneered", "Revitalized"];
 
   const handleExportPDF = async () => {
-    setIsExportingPDF(true);
-    try {
-      const element = document.getElementById("analysis-report-pdf");
-      if (!element) {
-        throw new Error("Report element not found in DOM.");
-      }
+    if (isExportingPDF) return;
 
+    setIsExportingPDF(true);
+    setExportError("");
+    try {
       const fileNameClean = file?.name 
         ? file.name.replace(/\.[^/.]+$/, "") 
-        : "resume";
+        : "resume-analysis";
 
-      const opt = {
+      await exportToPDF("analysis-report-pdf", `${fileNameClean}-analysis-report.pdf`, {
         margin: [0.4, 0.4, 0.4, 0.4],
-        filename: `${fileNameClean}_analysis_report.pdf`,
         image: { type: "jpeg", quality: 0.98 },
         html2canvas: { scale: 2, useCORS: true, letterRendering: true, scrollX: 0, scrollY: 0 },
         jsPDF: { unit: "in", format: "letter", orientation: "portrait" }
-      };
-
-      await html2pdf().set(opt).from(element).save();
+      });
       success("Report exported to PDF successfully.");
     } catch (err) {
       console.error("PDF Export Error:", err);
-      showError(err.message || "Failed to export PDF report.");
+      const message = "We couldn't export the PDF report. Please try again.";
+      setExportError(message);
+      showError(err.message || message);
     } finally {
       setIsExportingPDF(false);
     }
@@ -499,6 +497,7 @@ const AnalysisResult = ({ result, file, jobDescription, onReset }) => {
           <button 
             onClick={handleExportPDF} 
             disabled={isExportingPDF}
+            aria-busy={isExportingPDF}
             className={`group flex items-center justify-center gap-3 px-6 py-4 rounded-2xl border transition-all shadow-xl
               ${isExportingPDF 
                 ? 'bg-gray-100 dark:bg-surface/50 border-gray-200 dark:border-border cursor-not-allowed' 
@@ -512,13 +511,18 @@ const AnalysisResult = ({ result, file, jobDescription, onReset }) => {
             )}
             <div className="text-left">
               <span className="block text-sm font-bold text-gray-900 dark:text-text-main group-hover:text-secondary transition-colors">
-                {isExportingPDF ? "Exporting PDF..." : "Export PDF Report"}
+                {isExportingPDF ? "Exporting..." : "Export PDF"}
               </span>
               <span className="block text-[10px] uppercase tracking-widest text-gray-500 dark:text-text-muted mt-0.5">
                 Download Feedback
               </span>
             </div>
           </button>
+          {exportError && (
+            <span className="text-xs font-medium text-red-400 text-center" role="alert">
+              {exportError}
+            </span>
+          )}
         </div>
 
         {/* New Scan Button */}

--- a/client/src/modules/resume-analyzer/components/__tests__/AnalysisResult.pdf.test.jsx
+++ b/client/src/modules/resume-analyzer/components/__tests__/AnalysisResult.pdf.test.jsx
@@ -1,0 +1,185 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AnalysisResult from "../AnalysisResult";
+import { exportToPDF } from "../../../../utils/exportUtils";
+
+const toast = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../../../../utils/exportUtils", () => ({
+  exportToPDF: vi.fn(),
+}));
+
+vi.mock("../../../../shared/components", () => ({
+  useToast: () => toast,
+}));
+
+vi.mock("../SkillGapVenn", () => ({
+  default: () => <div data-testid="skill-gap-venn" />,
+}));
+
+vi.mock("../../../../shared/components/CoverLetterModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../services/resumeService", () => ({
+  generateCoverLetter: vi.fn(),
+}));
+
+const analysisResult = {
+  score: 82,
+  isJDProvided: true,
+  mode: "targeted",
+  resumeId: "resume-1",
+  classification: { level: "Intermediate", label: "Strong practical profile" },
+  impactMatch: {
+    score: 78,
+    totalFindings: 3,
+    feedback: ["Good quantified impact across recent roles."],
+  },
+  atsOptimization: {
+    details: {
+      sectionResults: {
+        experience: true,
+        education: true,
+        skills: true,
+        summary: false,
+      },
+      contactResults: {
+        email: true,
+        phone: true,
+        linkedin: false,
+        github: true,
+        portfolio: false,
+      },
+    },
+  },
+  skillMatch: {
+    score: 75,
+    details: {
+      matchedSkills: ["React", "Node.js", "MongoDB"],
+      missingSkills: ["Docker", "Redis"],
+    },
+  },
+  keywordMatch: {
+    missingKeywords: ["CI/CD", "Kubernetes"],
+  },
+  techStandard: {
+    details: {
+      domainMissing: {
+        backend: ["Caching"],
+      },
+    },
+  },
+  readabilityMatch: {
+    relevantVerbs: ["Optimized", "Led", "Delivered"],
+  },
+  gapAnalysis: {
+    suggestions: [
+      { priority: "Strategic", text: "Add deployment and monitoring experience." },
+      { priority: "Critical", text: "Include missing cloud keywords from the target role." },
+    ],
+  },
+  verifiedLinks: [],
+};
+
+const renderAnalysis = () =>
+  render(
+    <MemoryRouter>
+      <AnalysisResult
+        result={analysisResult}
+        file={new File(["resume"], "Aarav Resume.pdf", { type: "application/pdf" })}
+        jobDescription="React Node.js role"
+        onReset={vi.fn()}
+      />
+    </MemoryRouter>,
+  );
+
+describe("AnalysisResult PDF export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    URL.createObjectURL = vi.fn(() => "blob:resume-preview");
+    URL.revokeObjectURL = vi.fn();
+    exportToPDF.mockResolvedValue(undefined);
+  });
+
+  it("shows the export PDF button after analysis results exist", () => {
+    renderAnalysis();
+
+    expect(screen.getByRole("button", { name: /export pdf/i })).toBeInTheDocument();
+    expect(document.getElementById("analysis-report-pdf")).toBeInTheDocument();
+  });
+
+  it("clicking export triggers PDF generation with a clean filename", async () => {
+    const user = userEvent.setup();
+    renderAnalysis();
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /export pdf/i }));
+    });
+
+    expect(exportToPDF).toHaveBeenCalledWith(
+      "analysis-report-pdf",
+      "Aarav Resume-analysis-report.pdf",
+      expect.objectContaining({
+        jsPDF: expect.objectContaining({ orientation: "portrait" }),
+      }),
+    );
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Report exported to PDF successfully.");
+    });
+  });
+
+  it("shows loading state and prevents duplicate export clicks", async () => {
+    const user = userEvent.setup();
+    let resolveExport;
+    exportToPDF.mockReturnValue(
+      new Promise((resolve) => {
+        resolveExport = resolve;
+      }),
+    );
+    renderAnalysis();
+
+    const button = screen.getByRole("button", { name: /export pdf/i });
+    await act(async () => {
+      await user.click(button);
+    });
+
+    expect(screen.getByRole("button", { name: /exporting/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /exporting/i })).toHaveAttribute("aria-busy", "true");
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /exporting/i }));
+    });
+    expect(exportToPDF).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveExport();
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /export pdf/i })).not.toBeDisabled();
+    });
+  });
+
+  it("shows a friendly error message when PDF generation fails", async () => {
+    const user = userEvent.setup();
+    exportToPDF.mockRejectedValueOnce(new Error("Canvas failed"));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    renderAnalysis();
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /export pdf/i }));
+    });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "We couldn't export the PDF report. Please try again.",
+    );
+    expect(toast.error).toHaveBeenCalledWith("Canvas failed");
+    expect(screen.getByRole("button", { name: /export pdf/i })).not.toBeDisabled();
+    consoleError.mockRestore();
+  });
+});

--- a/client/src/utils/exportUtils.js
+++ b/client/src/utils/exportUtils.js
@@ -44,19 +44,19 @@ export const exportToCSV = (filename, rows) => {
  * @param {string} elementId The ID of the HTML element to capture.
  * @param {string} filename The name of the PDF file to download (e.g., "report.pdf").
  */
-export const exportToPDF = (elementId, filename) => {
+export const exportToPDF = async (elementId, filename, options = {}) => {
   const element = document.getElementById(elementId);
   if (!element) {
-    console.warn(`Element with ID ${elementId} not found.`);
-    return;
+    throw new Error(`Element with ID ${elementId} not found.`);
   }
   const opt = {
     margin:       0.2,
     filename:     filename,
     image:        { type: 'jpeg', quality: 1.0 },
     html2canvas:  { scale: 2, useCORS: true, backgroundColor: '#0f172a' },
-    jsPDF:        { unit: 'in', format: 'a4', orientation: 'landscape' }
+    jsPDF:        { unit: 'in', format: 'a4', orientation: 'landscape' },
+    ...options,
   };
   
-  html2pdf().set(opt).from(element).save();
+  return html2pdf().set(opt).from(element).save();
 };


### PR DESCRIPTION


# PR Description

## Summary

Added PDF export functionality for resume analysis results, allowing users to download a professionally formatted report of their resume evaluation.

The implementation reuses the existing PDF export infrastructure already used elsewhere in the application, avoiding duplicate logic and maintaining consistency across export features.

## Changes Made

### PDF Export Utility Improvements

Updated:

* `client/src/utils/exportUtils.js`

Enhancements:

* Reused the existing `html2pdf.js` export flow.
* Modified `exportToPDF` to:

  * Return a Promise for better async handling.
  * Accept configurable PDF options.
  * Throw meaningful errors when the target export element is missing.
* Improved error propagation for consuming components.

### Resume Analysis Export

Updated:

* `client/src/modules/resume-analyzer/components/AnalysisResult.jsx`

Added:

* `Export PDF` action directly within the analysis results section.
* Export generation using the hidden `AnalysisReportPDF` report template.
* Loading state during export:

  * Button text changes to `Exporting...`
  * Button is disabled while processing
  * `aria-busy` added for accessibility
* Duplicate export prevention.
* Friendly error handling using a visible `role="alert"` message when export generation fails.

### Architecture Decision

`ResumeAnalyzerPage.jsx` already delegates result rendering to `AnalysisResult`.

To avoid duplicated responsibilities and maintain component separation, the export functionality was implemented directly inside the results component where the analyzed data is rendered.

## User Experience Improvements

* One-click PDF download for resume analysis reports.
* Clear export progress feedback.
* Better accessibility support.
* Improved reliability through async error handling.
* Consistent export behavior with existing PDF features.

## Tests Added

Added:

* `AnalysisResult.pdf.test.jsx`

Coverage includes:

* Export button rendering
* Successful PDF export flow
* Loading state behavior
* Duplicate-click prevention
* Export failure handling and alert messaging

## Verification

### Test Command

```bash
npm.cmd --workspace client run test:run -- AnalysisResult.pdf.test.jsx
```

### Result

✅ 4 tests passed successfully.

### Build Verification

```bash
npm.cmd --workspace client run build
```

✅ Build completed successfully.

## Notes

* No new dependencies were introduced.
* Existing PDF export infrastructure was reused.
* Existing build warnings related to duplicate `vite-plugin-node-polyfills` and `zod` entries in `client/package.json` remain unchanged and are outside the scope of this PR.

---
## Screenshot 

### Before export
<img width="545" height="870" alt="Screenshot 2026-05-29 173211" src="https://github.com/user-attachments/assets/4a290678-15ee-40ec-aaad-447db74e5f87" />
<img width="798" height="821" alt="Screenshot 2026-05-29 173237" src="https://github.com/user-attachments/assets/5a03705d-2211-4fc9-a62c-b648042d8da6" />
<img width="338" height="866" alt="Screenshot 2026-05-29 174038" src="https://github.com/user-attachments/assets/eb739cb0-9c25-4224-b59f-57c2af51e2f1" />

### After Exporting
<img width="653" height="806" alt="Screenshot 2026-05-29 174251" src="https://github.com/user-attachments/assets/d738ee62-8237-499d-b26a-10a4c8c0573e" />
<img width="1516" height="939" alt="Screenshot 2026-05-29 174339" src="https://github.com/user-attachments/assets/b34e0912-7b49-4794-9759-88d0f4f6f61a" />

### Generated pdf
[kanwar_resume_analysis_report.pdf](https://github.com/user-attachments/files/28391633/kanwar_resume_analysis_report.pdf)


<img width="337" height="806" alt="Screenshot 2026-05-29 174800" src="https://github.com/user-attachments/assets/7d47e7d8-a86e-4638-9bb8-97c1f41db4b4" />
