### PR TITLE
feat(frontend): set up talent finder routes, navbar link, service cli…

### DIFF
--- a/client/src/app/App.jsx
+++ b/client/src/app/App.jsx
@@ -21,6 +21,7 @@ const RecruiterAnalyticsPage = lazy(() => import("../modules/recruiter-jobs/page
 const CreateJobPostingPage = lazy(() => import("../modules/recruiter-jobs/pages/CreateJobPostingPage"));
 const EditJobPostingPage = lazy(() => import("../modules/recruiter-jobs/pages/EditJobPostingPage"));
 const RecruiterApplicantsPage = lazy(() => import("../modules/recruiter-jobs/pages/RecruiterApplicantsPage"));
+const TalentFinderPage = lazy(() => import("../modules/recruiter-jobs/pages/TalentFinderPage"));
 const JobBoardPage = lazy(() => import("../modules/student-jobs/pages/JobBoardPage"));
 const MyApplicationsPage = lazy(() => import("../modules/student-jobs/pages/MyApplicationsPage"));
 const RoadmapPage = lazy(() => import("../modules/roadmap/pages/RoadmapPage"));
@@ -162,6 +163,14 @@ function App() {
           element={
             <ProtectedRoute requiredRole="recruiter">
               <RecruiterApplicantsPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/recruiter/talent-finder"
+          element={
+            <ProtectedRoute requiredRole="recruiter">
+              <TalentFinderPage />
             </ProtectedRoute>
           }
         />

--- a/client/src/modules/recruiter-jobs/pages/RecruiterJobsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterJobsPage.jsx
@@ -9,7 +9,6 @@ import LoadingState from "../../../shared/components/LoadingState";
 import ErrorState from "../../../shared/components/ErrorState";
 import EmptyState from "../../../shared/components/EmptyState";
 import JobCardSkeleton from "../../student-jobs/components/JobCardSkeleton";
-import { Pagination } from "../../../shared/components";
 import JobPostingCard from "../components/JobPostingCard";
 import { JobViewerCard, Pagination } from "../../../shared/components";
 import { useDocumentTitle } from "../../../hooks/useDocumentTitle";

--- a/client/src/modules/recruiter-jobs/services/talentFinderService.js
+++ b/client/src/modules/recruiter-jobs/services/talentFinderService.js
@@ -1,0 +1,102 @@
+import { apiRequest, normalizeApiError } from "../../../services/apiClient";
+
+/**
+ * Normalize api errors for recruiter operations
+ */
+const handleServiceError = (error) => {
+  let normalized = normalizeApiError(error);
+
+  if (!normalized || typeof normalized !== "object") {
+    normalized = {
+      message: error?.message || "Something went wrong",
+      status: error?.status || 500,
+      errors: error?.errors || {},
+    };
+  }
+
+  if (normalized.status === 401 || normalized.status === 403) {
+    return {
+      ...normalized,
+      message: "You are not authorized to perform this action. Please log in again.",
+    };
+  }
+
+  return normalized;
+};
+
+/**
+ * Search the student database
+ * @param {Object} filters - Search parameters (q, skills, graduationYear, minAtsScore, page, limit, specialization)
+ * @param {string} token - Auth bearer token
+ * @returns {Promise<Object>}
+ */
+export const searchTalent = async (filters = {}, token) => {
+  try {
+    const params = new URLSearchParams();
+    
+    Object.entries(filters).forEach(([key, val]) => {
+      if (val !== undefined && val !== null && val !== "") {
+        params.append(key, val);
+      }
+    });
+
+    const url = `/api/recruiter/talent-finder?${params.toString()}`;
+    const response = await apiRequest(url, { token });
+
+    return {
+      success: true,
+      candidates: response.data || [],
+      pagination: response.pagination || { page: 1, limit: 10, total: 0, pages: 1 }
+    };
+  } catch (error) {
+    throw handleServiceError(error);
+  }
+};
+
+/**
+ * Run Gemini AI Match for a specific candidate against a job description
+ * @param {string} candidateId - Candidate user ID
+ * @param {string} jobId - Job posting ID
+ * @param {string} token - Auth bearer token
+ * @returns {Promise<Object>}
+ */
+export const matchCandidate = async (candidateId, jobId, token) => {
+  try {
+    const response = await apiRequest("/api/recruiter/match-candidate", {
+      method: "POST",
+      body: { candidateId, jobId },
+      token
+    });
+
+    return {
+      success: true,
+      matchResult: response.data
+    };
+  } catch (error) {
+    throw handleServiceError(error);
+  }
+};
+
+/**
+ * Invite a student candidate to apply for a job posting
+ * @param {string} candidateId - Candidate user ID
+ * @param {string} jobId - Job posting ID
+ * @param {string} token - Auth token
+ * @returns {Promise<Object>}
+ */
+export const inviteCandidate = async (candidateId, jobId, token) => {
+  try {
+    const response = await apiRequest("/api/recruiter/invite-candidate", {
+      method: "POST",
+      body: { candidateId, jobId },
+      token
+    });
+
+    return {
+      success: true,
+      message: response.message || "Invitation sent successfully."
+    };
+  } catch (error) {
+    throw handleServiceError(error);
+  }
+};

--- a/client/src/shared/landing/Navbar.jsx
+++ b/client/src/shared/landing/Navbar.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { Home, FileText, LayoutDashboard, MessageSquare, LogIn, UserPlus, X, Menu, LogOut, User, ChevronDown, Briefcase, Moon, Sun, Sparkles, Rocket, Video, Bell } from 'lucide-react';
+import { Home, FileText, LayoutDashboard, MessageSquare, LogIn, UserPlus, X, Menu, LogOut, User, ChevronDown, Briefcase, Moon, Sun, Sparkles, Rocket, Video, Bell, Search } from 'lucide-react';
 import Button from './Button';
 import { logout } from '../../features/auth/authSlice';
 import { getProtectedAssetUrl } from '../../utils/protectedAssetUrl';
@@ -85,7 +85,10 @@ const Navbar = () => {
   const navLinks = [
     { name: 'Home', path: '/', icon: <Home size={20} /> },
     ...(user?.role === 'recruiter' 
-      ? [{ name: 'Manage Jobs', path: '/recruiter/jobs', icon: <Briefcase size={20} /> }]
+      ? [
+          { name: 'Manage Jobs', path: '/recruiter/jobs', icon: <Briefcase size={20} /> },
+          { name: 'Talent Finder', path: '/recruiter/talent-finder', icon: <Search size={20} /> }
+        ]
       : user?.role === 'tutor'
       ? [{ name: 'Live Classrooms', path: '/classrooms', icon: <Video size={20} /> }]
       : [


### PR DESCRIPTION


## Summary
Integrates the new recruiter endpoints into the frontend client base. It establishes API client requesters, binds routing, updates the navbar navigation structure for recruiters, and fixes a duplicate import compiling warning.

## Type of Change
- [x] Feature
- [x] Bug fix


## Changes Made
- Created [talentFinderService.js](file:///c:/Users/hp/SkillsSphere-AI/client/src/modules/recruiter-jobs/services/talentFinderService.js) to wrap search, match, and invite API requests.
- Bound `/recruiter/talent-finder` as a lazy-loaded route in [App.jsx](file:///c:/Users/hp/SkillsSphere-AI/client/src/app/App.jsx).
- Added the "Talent Finder" search option to the recruiter navigation list in [Navbar.jsx](file:///c:/Users/hp/SkillsSphere-AI/client/src/shared/landing/Navbar.jsx).
- Resolved a duplicate `Pagination` import bug in [RecruiterJobsPage.jsx](file:///c:/Users/hp/SkillsSphere-AI/client/src/modules/recruiter-jobs/pages/RecruiterJobsPage.jsx) that was causing esbuild/Vite build crashes.

## Validation
- [x] Build passes locally



