### PR TITLE
feat: Connect static dashboard components to backend telemetry

### DIFF
--- a/client/src/modules/dashboard/DashboardPage.jsx
+++ b/client/src/modules/dashboard/DashboardPage.jsx
@@ -138,25 +138,25 @@ const DashboardPage = () => {
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
-                    <div className="h-8 w-8 rounded-full bg-emerald-500/20 flex items-center justify-center text-emerald-400">
+                    <div className={`h-8 w-8 rounded-full flex items-center justify-center ${user?.isVerified ? "bg-emerald-500/20 text-emerald-400" : "bg-slate-500/20 text-slate-400"}`}>
                       <BadgeCheck size={16} />
                     </div>
                     <span className="text-sm font-medium">
-                      Verified Account
+                      {user?.isVerified ? "Verified Account" : "Unverified Account"}
                     </span>
                   </div>
-                  <div className="h-1.5 w-1.5 rounded-full bg-emerald-500"></div>
+                  {user?.isVerified && <div className="h-1.5 w-1.5 rounded-full bg-emerald-500"></div>}
                 </div>
 
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
-                    <div className="h-8 w-8 rounded-full bg-blue-500/20 flex items-center justify-center text-blue-400">
+                    <div className={`h-8 w-8 rounded-full flex items-center justify-center ${user?.proFeatures ? "bg-blue-500/20 text-blue-400" : "bg-slate-500/20 text-slate-400"}`}>
                       <Sparkles size={16} />
                     </div>
                     <span className="text-sm font-medium">Pro Features</span>
                   </div>
-                  <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-blue-500 text-white">
-                    ACTIVE
+                  <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${user?.proFeatures ? "bg-blue-500 text-white" : "bg-slate-500/20 text-slate-500"}`}>
+                    {user?.proFeatures ? "ACTIVE" : "INACTIVE"}
                   </span>
                 </div>
               </div>

--- a/client/src/modules/roadmap/components/ContributionSummaryCard.jsx
+++ b/client/src/modules/roadmap/components/ContributionSummaryCard.jsx
@@ -17,8 +17,7 @@ const ContributionSummaryCard = ({ roadmap }) => {
     ? Math.round((completedContributions / totalContributions) * 100) 
     : 0;
 
-  // Simple placeholder formula for "Boost" metric
-  const readinessBoost = completedContributions * 18; 
+  const readinessBoost = roadmap.readinessBoost || 0;
 
   return (
     <div className="bg-[var(--surface)] border border-amber-500/20 p-5 rounded-2xl shadow-[0_0_20px_rgba(245,158,11,0.05)] relative overflow-hidden group hover:border-amber-500/40 transition-all flex flex-col justify-between">

--- a/server/src/database/models/LearningProgress.js
+++ b/server/src/database/models/LearningProgress.js
@@ -108,5 +108,19 @@ learningProgressSchema.pre("save", function (next) {
   next();
 });
 
+// Virtual to calculate readiness boost based on completed contribution milestones
+learningProgressSchema.virtual("readinessBoost").get(function () {
+  if (!this.roadmap) return 0;
+  
+  const contributionTopics = this.roadmap.filter((t) => t.type === "contribution");
+  if (contributionTopics.length === 0) return 0;
+
+  const completedContributions = contributionTopics.filter(
+    (t) => t.status === "completed" || t.isVerified
+  ).length;
+
+  return completedContributions * 5; // Each completed contribution adds 5% boost
+});
+
 const LearningProgress = mongoose.model("LearningProgress", learningProgressSchema);
 export default LearningProgress;

--- a/server/src/database/models/User.js
+++ b/server/src/database/models/User.js
@@ -46,6 +46,11 @@ const userSchema = new mongoose.Schema(
       default: false,
     },
 
+    proFeatures: {
+      type: Boolean,
+      default: false,
+    },
+
     verificationToken: { type: String, default: null },
     verificationTokenExpires: { type: Date, default: null },
     resetPasswordToken: { type: String, default: null },


### PR DESCRIPTION
## Description
This PR resolves the issue where several frontend components were acting as static showcases with hardcoded data. We've wired these components up to their respective backend models to consume and reflect authentic user data and telemetry.

## Resolved Issue
Resolves #891 

## Changes Made
### Backend Updates
- **User Profile**: Added a `proFeatures` boolean field to the `User` mongoose model.
- **Telemetry Aggregation**: Added a new Mongoose virtual (`readinessBoost`) on the `LearningProgress` schema. This properly calculates a dynamic boost score (5% per completed contribution) rather than relying on frontend simulations.

### Frontend Updates
- **Account Status (`DashboardPage.jsx`)**: The "Verified Account" and "Pro Features" badges now correctly toggle based on `user?.isVerified` and `user?.proFeatures` from the active session.
- **Contribution Metrics (`ContributionSummaryCard.jsx`)**: Removed the hardcoded placeholder formula (`completedContributions * 18`) and replaced it with the `readinessBoost` value directly from the `roadmap` API response.

## Validation Details
- [x] Verified that an unverified/free user correctly sees "Unverified Account" and "INACTIVE" badges on the dashboard.
- [x] Verified that updating a user's `isVerified` and `proFeatures` flags in the database successfully updates the frontend UI state on reload.
- [x] Verified that the `ContributionSummaryCard` accurately scales the career boost metric based on the number of completed contribution tasks returned by the backend.