### PR TITLE
chore: add Dependabot automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,106 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:30"
+      timezone: Asia/Kolkata
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - automated
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      root-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /client
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:45"
+      timezone: Asia/Kolkata
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - automated
+      - client
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      client-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /server
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:00"
+      timezone: Asia/Kolkata
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - automated
+      - server
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      server-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /ai-ml
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:15"
+      timezone: Asia/Kolkata
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - automated
+      - ai-ml
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      ai-ml-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:30"
+      timezone: Asia/Kolkata
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - automated
+      - ci
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      github-actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,16 @@ Before opening a PR, ensure:
 - Documentation is updated when behavior changes.
 - No sensitive data, tokens, or secrets are committed.
 
+## Dependency Update Automation
+
+Dependabot is configured in `.github/dependabot.yml` to check the root
+workspace, `client/`, `server/`, `ai-ml/`, and GitHub Actions every Monday
+morning in the Asia/Kolkata timezone.
+
+Minor and patch updates are grouped per workspace so maintainers get useful
+dependency coverage without a flood of small pull requests. Major version
+updates remain separate for easier review and testing.
+
 ## What to Contribute
 
 - Feature scaffolding aligned with modules in `README.md`


### PR DESCRIPTION
## Summary
- add Dependabot coverage for the root npm workspace, `client`, `server`, `ai-ml`, and GitHub Actions
- group minor and patch updates per workspace to reduce noisy dependency PRs
- document the automation schedule and grouping behavior in `CONTRIBUTING.md`

## Validation
- `git diff --check`
- Ruby YAML parse for `.github/dependabot.yml`

Fixes #909
