### PR TITLE
fix(client): add toast notifications to silent catch blocks in CoverL…

### DIFF
--- a/client/src/modules/student-jobs/pages/MyApplicationsPage.jsx
+++ b/client/src/modules/student-jobs/pages/MyApplicationsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useSelector } from "react-redux";
 import { useNavigate, Link } from "react-router-dom";
 import {
@@ -84,6 +84,7 @@ const MyApplicationsPage = () => {
       setTotalCount(data.totalCount || 0);
     } catch (err) {
       setError(err.message || "Failed to load applications.");
+      toast.error(err.message || "Failed to load applications.");
     } finally {
       setLoading(false);
     }

--- a/client/src/shared/components/CoverLetterModal.jsx
+++ b/client/src/shared/components/CoverLetterModal.jsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from "react";
 import { X, Copy, Download, Check, Sparkles, FileText, Loader2, RefreshCw } from "lucide-react";
 import html2pdf from "html2pdf.js";
+import { useToast } from "./toast/ToastProvider";
 
 export default function CoverLetterModal({ isOpen, onClose, initialText, onRegenerate }) {
+  const toast = useToast();
   const [text, setText] = useState(initialText || "");
   const [copied, setCopied] = useState(false);
   const [isExportingPDF, setIsExportingPDF] = useState(false);
@@ -23,8 +25,10 @@ export default function CoverLetterModal({ isOpen, onClose, initialText, onRegen
       await navigator.clipboard.writeText(text);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+      toast.success("Copied to clipboard!");
     } catch (err) {
       console.error("Failed to copy text:", err);
+      toast.error("Failed to copy text. Please try manually.");
     }
   };
 
@@ -57,8 +61,10 @@ export default function CoverLetterModal({ isOpen, onClose, initialText, onRegen
       };
 
       await html2pdf().set(opt).from(htmlContent).save();
+      toast.success("PDF downloaded successfully.");
     } catch (err) {
       console.error("Failed to generate PDF:", err);
+      toast.error("Failed to generate PDF. Please try again.");
     } finally {
       setIsExportingPDF(false);
     }
@@ -71,9 +77,11 @@ export default function CoverLetterModal({ isOpen, onClose, initialText, onRegen
       const newText = await onRegenerate(tone, language);
       if (newText) {
         setText(newText);
+        toast.success("Cover letter regenerated successfully!");
       }
     } catch (err) {
       console.error("Regeneration failed:", err);
+      toast.error(err?.response?.data?.message || err.message || "Failed to regenerate cover letter. Please try again.");
     } finally {
       setIsRegenerating(false);
     }

--- a/client/src/shared/components/StatusUpdateModal.jsx
+++ b/client/src/shared/components/StatusUpdateModal.jsx
@@ -1,11 +1,13 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
-import { X, Send, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { X, Send, AlertCircle } from 'lucide-react';
 import Button from './Button';
 import TextArea from './TextArea';
 import Select from './Select';
+import { useToast } from './toast/ToastProvider';
 
 const StatusUpdateModal = ({ isOpen, onClose, onUpdate, currentStatus, applicantName }) => {
+  const toast = useToast();
   const [status, setStatus] = useState(currentStatus || 'reviewed');
   const [comment, setComment] = useState('');
   const [loading, setLoading] = useState(false);
@@ -22,6 +24,7 @@ const StatusUpdateModal = ({ isOpen, onClose, onUpdate, currentStatus, applicant
       onClose();
     } catch (err) {
       setError(err.message || "Failed to update status.");
+      toast.error(err.message || "Failed to update status.");
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Overview
Several components in the frontend silently swallow API errors — catch blocks only log to `console.error` without any user-visible feedback. This fix adds toast notifications so users are informed when operations fail or succeed.

## Related Issue
Closes #918

## Changes Made

### `CoverLetterModal.jsx`
- Added `useToast` hook
- **Copy to clipboard:** toast.success on copy, toast.error on failure
- **PDF export:** toast.success on download, toast.error on failure
- **Regenerate:** toast.success when new text is received, toast.error with specific message on failure

### `StatusUpdateModal.jsx`
- Added `useToast` hook
- Added `toast.error` alongside existing `setError` when status update fails
- Removed unused `React` and `CheckCircle2` imports (fixes eslint errors)

### `MyApplicationsPage.jsx`
- Added `toast.error` when fetching applications fails
- Removed unused `React` import (fixes eslint error)

## Testing
- All 3 files pass eslint with 0 errors (only pre-existing prop-types warnings remain)
- No new dependencies added — uses existing `useToast` from `ToastProvider`
- No breaking changes — existing error state handling is preserved alongside new toasts
