### PR TITLE
fix: Resume MIME/extension validation is too strict in a way 

### DIFF
--- a/server/src/middleware/__tests__/uploadResume.validation.test.js
+++ b/server/src/middleware/__tests__/uploadResume.validation.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import fs from "fs/promises";
 import path from "path";
 import {
+  fileFilter,
   validateAndPersistResumeFile,
   persistValidatedResumeFile,
   removeUploadedFile,
@@ -30,6 +31,35 @@ const runMiddleware = (middleware, req) =>
       else resolve({ statusCode: 200, body: null, nextCalled: true });
     });
   });
+
+const runFileFilter = (file) =>
+  new Promise((resolve) => {
+    fileFilter(null, file, (error, accepted) => {
+      resolve({ error, accepted });
+    });
+  });
+
+describe("fileFilter", () => {
+  it("accepts allowed extensions even when the mimetype is incorrect", async () => {
+    const result = await runFileFilter({
+      originalname: "resume.docx",
+      mimetype: "application/octet-stream",
+    });
+
+    assert.equal(result.error, null);
+    assert.equal(result.accepted, true);
+  });
+
+  it("rejects files with unsupported extensions", async () => {
+    const result = await runFileFilter({
+      originalname: "resume.exe",
+      mimetype: "application/octet-stream",
+    });
+
+    assert.equal(result.accepted, false);
+    assert.equal(result.error?.code, "INVALID_FILE_TYPE");
+  });
+});
 
 describe("validateAndPersistResumeFile middleware", () => {
   it("returns 400 and never writes spoofed pdf to uploads", async () => {

--- a/server/src/middleware/uploadResume.js
+++ b/server/src/middleware/uploadResume.js
@@ -23,7 +23,7 @@ const allowedMimeTypes = [
 ];
 const allowedExtensions = [".pdf", ".doc", ".docx", ".txt"];
 
-const fileFilter = (_req, file, cb) => {
+export const fileFilter = (_req, file, cb) => {
   const extension = path.extname(file.originalname).toLowerCase();
   const hasAllowedMimeType = allowedMimeTypes.includes(file.mimetype);
   const hasAllowedExtension = allowedExtensions.includes(extension);
@@ -35,7 +35,7 @@ const fileFilter = (_req, file, cb) => {
     return cb(traversalError, false);
   }
 
-  if (hasAllowedMimeType && hasAllowedExtension) {
+  if (hasAllowedExtension) {
     cb(null, true);
   } else {
     const typeError = new Error("Only PDF, DOC, DOCX, and TXT files are allowed");


### PR DESCRIPTION
Loosened the resume upload gate so uploadResume.js now accepts files based on allowed extension alone, which avoids rejecting valid .doc/.docx uploads when the client sends an unreliable MIME type. The content-based signature check still runs afterward, so spoofed files are still blocked before persistence.

I also added a direct regression test in uploadResume.validation.test.js that proves a valid extension with a bad MIME type is accepted, and an unsupported extension is still rejected. Validation passed with `npm test -- --test src/middleware/__tests__/uploadResume.validation.test.js`.


closes #927