### PR TITLE
fix: allow admin to create notifications for any user

### DIFF
--- a/server/src/modules/notifications/controller.js
+++ b/server/src/modules/notifications/controller.js
@@ -86,10 +86,10 @@ export const createNotification = asyncHandler(async (req, res) => {
     throw error;
   }
 
-  if (userId !== req.user._id.toString()) {
-    throw new AppError("You can only create notifications for yourself", 403);
+  if (req.user.role !== "admin" && userId !== req.user._id.toString()) {
+    throw new AppError("Not authorized to create notifications for other users", 403);
   }
-
+  
   const notification = await createNotificationService({
     userId,
     title,


### PR DESCRIPTION
Fixes #940

## Problem
In `server/src/modules/notifications/controller.js`, the `createNotification` 
endpoint had an overly restrictive ownership check:

if (userId !== req.user._id.toString()) {
  throw new AppError("You can only create notifications for yourself", 403);
}

This blocked admins from creating notifications for other users, breaking 
job match alerts, interview reminders, and application updates.

## Fix
Replaced with a role-based check:

if (req.user.role !== "admin" && userId !== req.user._id.toString()) {
  throw new AppError("Not authorized to create notifications for other users", 403);
}

## Changes
- `server/src/modules/notifications/controller.js` — 1 line updated