### PR TITLE
fix: strictly validate recruiter payload schema using Zod to prevent NoSQL injection

### DIFF
--- a/server/src/middleware/__tests__/validation.test.js
+++ b/server/src/middleware/__tests__/validation.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { z } from "zod";
+import { validateBody } from "../validation.js";
+import AppError from "../../utils/AppError.js";
+
+const invokeMiddleware = (middleware, req) =>
+  new Promise((resolve, reject) => {
+    const res = {};
+    middleware(req, res, (err) => {
+      if (err) {
+        resolve({ nextError: err });
+        return;
+      }
+      resolve({ nextCalled: true });
+    });
+  });
+
+const testSchema = z.object({
+  id: z.string().regex(/^[0-9a-fA-F]{24}$/, "Invalid ID format"),
+  name: z.string().min(2),
+});
+
+test("validateBody - accepts valid payload and strips extraneous keys", async () => {
+  const req = {
+    body: {
+      id: "507f1f77bcf86cd799439011",
+      name: "Alice",
+      extraneousKey: "maliciousVal",
+    },
+  };
+
+  const result = await invokeMiddleware(validateBody(testSchema), req);
+
+  assert.equal(result.nextCalled, true);
+  assert.equal(req.body.id, "507f1f77bcf86cd799439011");
+  assert.equal(req.body.name, "Alice");
+  assert.equal(req.body.extraneousKey, undefined); // Extraneous key stripped out successfully!
+});
+
+test("validateBody - rejects missing required fields", async () => {
+  const req = {
+    body: {
+      id: "507f1f77bcf86cd799439011",
+    },
+  };
+
+  const result = await invokeMiddleware(validateBody(testSchema), req);
+
+  assert.ok(result.nextError instanceof AppError);
+  assert.equal(result.nextError.statusCode, 400);
+  assert.match(result.nextError.message, /Required/);
+});
+
+test("validateBody - rejects invalid formats (e.g. malformed ObjectId)", async () => {
+  const req = {
+    body: {
+      id: "invalid-id-format-12345",
+      name: "Alice",
+    },
+  };
+
+  const result = await invokeMiddleware(validateBody(testSchema), req);
+
+  assert.ok(result.nextError instanceof AppError);
+  assert.equal(result.nextError.statusCode, 400);
+  assert.match(result.nextError.message, /Invalid ID format/);
+});
+
+test("validateBody - rejects NoSQL injection nested objects", async () => {
+  const req = {
+    body: {
+      id: { $gt: "" }, // NoSQL injection payload
+      name: "Alice",
+    },
+  };
+
+  const result = await invokeMiddleware(validateBody(testSchema), req);
+
+  assert.ok(result.nextError instanceof AppError);
+  assert.equal(result.nextError.statusCode, 400);
+  // Zod will fail because the type received is object instead of string
+  assert.match(result.nextError.message, /Expected string, received object/);
+});

--- a/server/src/middleware/validation.js
+++ b/server/src/middleware/validation.js
@@ -1,0 +1,27 @@
+import AppError from "../utils/AppError.js";
+
+/**
+ * Reusable Zod validation middleware for incoming request body payloads.
+ * Strips out any unvalidated/extraneous fields to prevent NoSQL injection.
+ * 
+ * @param {z.ZodSchema} schema - Zod validation schema
+ */
+export const validateBody = (schema) => {
+  return (req, res, next) => {
+    const parsed = schema.safeParse(req.body);
+    if (!parsed.success) {
+      const errors = {};
+      parsed.error.issues.forEach((issue) => {
+        const path = issue.path.join(".");
+        errors[path] = issue.message;
+      });
+      const messages = parsed.error.issues.map((issue) => issue.message);
+      const err = new AppError(`Validation failed: ${messages.join(", ")}`, 400);
+      err.errors = errors;
+      return next(err);
+    }
+    // Replace req.body with validated data to prevent extraneous property/NoSQL injection
+    req.body = parsed.data;
+    next();
+  };
+};

--- a/server/src/modules/recruiter/routes.js
+++ b/server/src/modules/recruiter/routes.js
@@ -1,5 +1,7 @@
 import express from "express";
 import { protect, authorizeRoles } from "../../middleware/authMiddleware.js";
+import { validateBody } from "../../middleware/validation.js";
+import { matchCandidateSchema, inviteCandidateSchema } from "../../validations/recruiterValidation.js";
 import {
   searchTalent,
   matchCandidate,
@@ -14,7 +16,7 @@ router.use(authorizeRoles("recruiter"));
 
 // Define routes
 router.get("/talent-finder", searchTalent);
-router.post("/match-candidate", matchCandidate);
-router.post("/invite-candidate", inviteCandidate);
+router.post("/match-candidate", validateBody(matchCandidateSchema), matchCandidate);
+router.post("/invite-candidate", validateBody(inviteCandidateSchema), inviteCandidate);
 
 export default router;

--- a/server/src/validations/recruiterValidation.js
+++ b/server/src/validations/recruiterValidation.js
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+const objectIdRegex = /^[0-9a-fA-F]{24}$/;
+export const objectIdSchema = z
+  .string({ required_error: "ID is required" })
+  .regex(objectIdRegex, "Invalid ID format");
+
+export const matchCandidateSchema = z.object({
+  candidateId: objectIdSchema,
+  jobId: objectIdSchema,
+});
+
+export const inviteCandidateSchema = z.object({
+  candidateId: objectIdSchema,
+  jobId: objectIdSchema,
+});


### PR DESCRIPTION
Enforces strict payload validation on the recruiter endpoints to prevent NoSQL injection vulnerabilities (e.g. passing objects instead of strings in ID query filters).

Closes #917