### PR TITLE
fix: delete temp file after resume upload to prevent disk leak

### DIFF
--- a/server/src/modules/resumes/controller.js
+++ b/server/src/modules/resumes/controller.js
@@ -120,6 +120,10 @@ export const uploadResume = asyncHandler(async (req, res, next) => {
       mimeType: req.file.mimetype,
     },
   });
+
+  if (req.file?.path) {
+    await fsPromises.unlink(req.file.path).catch(() => {});
+  }
 });
 
 const normalizeJobSkills = (rawSkills) => {


### PR DESCRIPTION
Fixes #949

## Problem
In `server/src/modules/resumes/controller.js`, the `uploadResume` 
handler never deleted the temporary file created by multer after 
responding. Every resume upload left an orphaned temp file on disk,
causing disk space exhaustion over time.

## Fix
Added cleanup after the response using `fsPromises.unlink()` 
(already imported in the file):

if (req.file?.path) {
  await fsPromises.unlink(req.file.path).catch(() => {});
}

## Changes
- `server/src/modules/resumes/controller.js` — temp file cleanup added to `uploadResume`