### PR TITLE
fix: implement defensive pagination on Mongoose history, resumes, and cover letters

### DIFF
--- a/client/src/modules/profile/__tests__/ProfilePage.test.jsx
+++ b/client/src/modules/profile/__tests__/ProfilePage.test.jsx
@@ -52,8 +52,6 @@ const createStore = (user = baseUser) =>
 
 import { ToastProvider } from "../../../shared/components/toast/ToastProvider";
 import { ThemeProvider } from "../../../shared/contexts/ThemeContext";
-import { ThemeProvider } from "../../../shared/contexts/ThemeContext";
-import { ToastProvider } from "../../../shared/components/toast/ToastProvider";
 
 const renderProfile = (user = baseUser) =>
   render(

--- a/server/src/modules/coverLetters/controller.js
+++ b/server/src/modules/coverLetters/controller.js
@@ -10,14 +10,25 @@ import AppError from "../../utils/AppError.js";
  */
 export const getCoverLetters = asyncHandler(async (req, res, next) => {
   const userId = req.user._id || req.user.id;
-  
-  const coverLetters = await CoverLetter.find({ user: userId })
-    .sort({ createdAt: -1 })
-    .lean();
+  const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+  const limit = Math.min(50, Math.max(1, parseInt(req.query.limit, 10) || 10));
+  const skip = (page - 1) * limit;
+
+  const [coverLetters, totalCount] = await Promise.all([
+    CoverLetter.find({ user: userId })
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit)
+      .lean(),
+    CoverLetter.countDocuments({ user: userId })
+  ]);
 
   res.status(200).json({
     success: true,
     count: coverLetters.length,
+    totalCount,
+    totalPages: Math.ceil(totalCount / limit),
+    currentPage: page,
     data: coverLetters,
   });
 });

--- a/server/src/modules/dashboard/__tests__/pagination.test.js
+++ b/server/src/modules/dashboard/__tests__/pagination.test.js
@@ -1,0 +1,129 @@
+import test, { mock, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import AnalysisHistory from "../../../database/models/AnalysisHistory.js";
+import CoverLetter from "../../../database/models/CoverLetter.js";
+import Resume from "../../../database/models/Resume.js";
+import { getHistory } from "../controller.js";
+import { getCoverLetters } from "../../coverLetters/controller.js";
+import { listResumes } from "../../resumes/controller.js";
+
+const invokeController = (controller, req) =>
+  new Promise((resolve, reject) => {
+    const res = {
+      statusCode: 200,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload) {
+        resolve({ statusCode: this.statusCode, body: payload });
+      },
+    };
+    controller(req, res, (err) => {
+      if (err) {
+        reject(err);
+      }
+    });
+  });
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+test("getHistory - returns paginated analysis history successfully", async () => {
+  const mockHistory = [{ _id: "h1", score: 80 }, { _id: "h2", score: 90 }];
+  
+  const mockFind = () => ({
+    sort: () => ({
+      skip: () => ({
+        limit: () => ({
+          lean: async () => mockHistory
+        })
+      })
+    })
+  });
+
+  mock.method(AnalysisHistory, "find", mockFind);
+  mock.method(AnalysisHistory, "countDocuments", async () => 20);
+
+  const req = {
+    user: { _id: "user123" },
+    query: { page: "2", limit: "5" }
+  };
+
+  const result = await invokeController(getHistory, req);
+
+  assert.equal(result.statusCode, 200);
+  assert.equal(result.body.success, true);
+  assert.deepEqual(result.body.data, mockHistory);
+  assert.deepEqual(result.body.pagination, {
+    page: 2,
+    limit: 5,
+    total: 20,
+    pages: 4
+  });
+});
+
+test("getCoverLetters - returns paginated cover letters successfully", async () => {
+  const mockLetters = [{ _id: "cl1", content: "Letter 1" }];
+
+  const mockFind = () => ({
+    sort: () => ({
+      skip: () => ({
+        limit: () => ({
+          lean: async () => mockLetters
+        })
+      })
+    })
+  });
+
+  mock.method(CoverLetter, "find", mockFind);
+  mock.method(CoverLetter, "countDocuments", async () => 15);
+
+  const req = {
+    user: { _id: "user123" },
+    query: { page: "1", limit: "10" }
+  };
+
+  const result = await invokeController(getCoverLetters, req);
+
+  assert.equal(result.statusCode, 200);
+  assert.equal(result.body.success, true);
+  assert.deepEqual(result.body.data, mockLetters);
+  assert.equal(result.body.totalCount, 15);
+  assert.equal(result.body.totalPages, 2);
+  assert.equal(result.body.currentPage, 1);
+});
+
+test("listResumes - returns paginated resumes successfully", async () => {
+  const mockResumes = [{ _id: "r1", title: "Resume 1" }];
+
+  const mockFind = () => ({
+    select: () => ({
+      sort: () => ({
+        skip: () => ({
+          limit: () => ({
+            lean: async () => mockResumes
+          })
+        })
+      })
+    })
+  });
+
+  mock.method(Resume, "find", mockFind);
+  mock.method(Resume, "countDocuments", async () => 3);
+
+  const req = {
+    user: { _id: "user123" },
+    query: { page: "1", limit: "2" }
+  };
+
+  const result = await invokeController(listResumes, req);
+
+  assert.equal(result.statusCode, 200);
+  assert.equal(result.body.success, true);
+  assert.deepEqual(result.body.data, mockResumes);
+  assert.equal(result.body.totalCount, 3);
+  assert.equal(result.body.totalPages, 2);
+  assert.equal(result.body.currentPage, 1);
+});

--- a/server/src/modules/dashboard/controller.js
+++ b/server/src/modules/dashboard/controller.js
@@ -3,13 +3,28 @@ import AppError from "../../utils/AppError.js";
 import AnalysisHistory from "../../database/models/AnalysisHistory.js";
 
 export const getHistory = asyncHandler(async (req, res, next) => {
-  const history = await AnalysisHistory.find({ user: req.user._id })
-    .sort({ createdAt: -1 })
-    .lean();
+  const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+  const limit = Math.min(50, Math.max(1, parseInt(req.query.limit, 10) || 10));
+  const skip = (page - 1) * limit;
+
+  const [history, total] = await Promise.all([
+    AnalysisHistory.find({ user: req.user._id })
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit)
+      .lean(),
+    AnalysisHistory.countDocuments({ user: req.user._id })
+  ]);
 
   res.status(200).json({
     success: true,
     message: "Analysis history fetched successfully",
     data: history,
+    pagination: {
+      page,
+      limit,
+      total,
+      pages: Math.ceil(total / limit),
+    }
   });
 });

--- a/server/src/modules/resumes/controller.js
+++ b/server/src/modules/resumes/controller.js
@@ -423,14 +423,26 @@ export const compareVersions = asyncHandler(async (req, res, next) => {
  * List all resumes for the current logged-in student.
  */
 export const listResumes = asyncHandler(async (req, res, next) => {
-  const resumes = await Resume.find({ user: req.user._id })
-    .select("-resumeText")
-    .sort({ createdAt: -1 })
-    .lean();
+  const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+  const limit = Math.min(50, Math.max(1, parseInt(req.query.limit, 10) || 10));
+  const skip = (page - 1) * limit;
+
+  const [resumes, totalCount] = await Promise.all([
+    Resume.find({ user: req.user._id })
+      .select("-resumeText")
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit)
+      .lean(),
+    Resume.countDocuments({ user: req.user._id })
+  ]);
 
   res.status(200).json({
     success: true,
     message: "Resumes listed successfully",
+    totalCount,
+    totalPages: Math.ceil(totalCount / limit),
+    currentPage: page,
     data: resumes,
   });
 });


### PR DESCRIPTION
Implements standard defensive pagination (with skip and limit query controls) on unpaginated collection find queries (AnalysisHistory, Resume, and CoverLetter) to prevent unbounded memory usage and DoS conditions.

Closes #915