### PR TITLE
fix(classroom): prevent high concurrency socket/peer leaks with Mutex and database-driven connection lifecycle (#958)

### DIFF
--- a/server/src/database/models/ClassroomSession.js
+++ b/server/src/database/models/ClassroomSession.js
@@ -57,6 +57,17 @@ const classroomSessionSchema = new mongoose.Schema(
       default: "",
     },
 
+    participants: {
+      type: [
+        {
+          socketId: { type: String, required: true },
+          user: { type: Object, required: true },
+          joinedAt: { type: Date, default: Date.now }
+        }
+      ],
+      default: [],
+    },
+
     endedAt: {
       type: Date,
       default: null,

--- a/server/src/modules/classrooms/socket.js
+++ b/server/src/modules/classrooms/socket.js
@@ -1,5 +1,6 @@
 import ClassroomSession from "../../database/models/ClassroomSession.js";
 import { executeCode } from "../../utils/codeExecutor.js";
+import { getRoomLock, clearRoomLock } from "../../utils/mutex.js";
 
 const roomStates = new Map();
 
@@ -28,13 +29,10 @@ export function initClassroomSockets(io) {
 
     // Join a specific room
     socket.on("join-room", async ({ roomId }) => {
-      try {
-        socket.join(roomId);
-        
-        // Store user info in socket instance to easily retrieve later
-        const user = socket.user; // Secure, derived from JWT
-        socket.data = { roomId, user };
+      const lock = getRoomLock(roomId);
+      const release = await lock.acquire();
 
+      try {
         // Validate session in database
         const session = await ClassroomSession.findOne({
           roomId,
@@ -49,7 +47,7 @@ export function initClassroomSockets(io) {
         }
 
         // Use authenticated user from middleware
-        const currentUser = socket.user || user;
+        const currentUser = socket.user;
         if (!currentUser) {
           socket.emit("unauthorized", {
             message: "User authentication required",
@@ -61,18 +59,32 @@ export function initClassroomSockets(io) {
         socket.join(roomId);
 
         // Store validated user and roomId info in socket instance
+        const userIdStr = (currentUser._id || currentUser.id).toString();
         socket.data = {
           roomId,
           user: {
-            id: currentUser._id || currentUser.id,
+            id: userIdStr,
             name: currentUser.name || currentUser.email,
             role: currentUser.role,
           },
         };
 
         console.log(
-          `User ${socket.data.user.name} (${socket.id}) joined room ${roomId}`,
+          `User ${socket.data.user.name} (${socket.id}) joining room ${roomId}`,
         );
+
+        // Update database: remove any existing/stale socket for this user in this room to prevent duplicates
+        session.participants = (session.participants || []).filter(
+          (p) => p.user.id.toString() !== userIdStr && p.socketId !== socket.id
+        );
+
+        // Add this new active socket participant
+        session.participants.push({
+          socketId: socket.id,
+          user: socket.data.user,
+        });
+
+        await session.save();
 
         // Notify others in the room that a new user joined
         socket.to(roomId).emit("user-joined", {
@@ -80,20 +92,11 @@ export function initClassroomSockets(io) {
           user: socket.data.user,
         });
 
-        // Get all clients currently in the room
-        const clients = io.sockets.adapter.rooms.get(roomId);
-        const participants = [];
-        if (clients) {
-          for (const clientId of clients) {
-            const clientSocket = io.sockets.sockets.get(clientId);
-            if (clientSocket && clientSocket.data?.user) {
-              participants.push({
-                socketId: clientId,
-                user: clientSocket.data.user,
-              });
-            }
-          }
-        }
+        // Get participants list directly from the database for ultimate reliability
+        const participants = session.participants.map((p) => ({
+          socketId: p.socketId,
+          user: p.user,
+        }));
 
         // Send the current participants list to the person who just joined
         socket.emit("room-participants", participants);
@@ -105,6 +108,8 @@ export function initClassroomSockets(io) {
         console.error("Error joining classroom room:", error);
         socket.emit("error", { message: "Internal server error during join" });
         socket.disconnect(true);
+      } finally {
+        release();
       }
     });
 
@@ -287,15 +292,58 @@ export function initClassroomSockets(io) {
     });
 
     // Disconnect
-    socket.on("disconnect", () => {
+    socket.on("disconnect", async () => {
       console.log(`Socket disconnected: ${socket.id}`);
       if (socket.data && socket.data.roomId) {
         const { roomId, user } = socket.data;
+
+        // Broadcast to others in the room first
         socket.to(roomId).emit("user-left", {
           socketId: socket.id,
           user,
         });
+
+        const lock = getRoomLock(roomId);
+        const release = await lock.acquire();
+
+        try {
+          const session = await ClassroomSession.findOne({
+            roomId,
+            status: "active",
+          });
+
+          if (session) {
+            // Atomically remove this participant socket connection
+            session.participants = (session.participants || []).filter(
+              (p) => p.socketId !== socket.id
+            );
+
+            // Automatically teardown/end the classroom session in database if empty
+            if (session.participants.length === 0) {
+              console.log(`Classroom ${roomId} empty. Automatically ending session.`);
+              session.status = "ended";
+              session.endedAt = new Date();
+
+              // Sync transient in-memory state back to DB archive
+              const finalState = getRoomState(roomId);
+              if (finalState) {
+                session.chatHistory = finalState.chatHistory || [];
+                session.codeSnapshot = finalState.code || "";
+              }
+
+              clearRoomState(roomId);
+              clearRoomLock(roomId);
+            }
+
+            await session.save();
+          }
+        } catch (error) {
+          console.error("Error during socket disconnect cleanup:", error);
+        } finally {
+          release();
+        }
       }
     });
   });
 }
+

--- a/server/src/utils/__tests__/mutex.test.js
+++ b/server/src/utils/__tests__/mutex.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert";
+import { Mutex, getRoomLock, clearRoomLock } from "../mutex.js";
+
+test("Mutex lock prevents concurrent overlap (mutual exclusion)", async () => {
+  const mutex = new Mutex();
+  let executionCount = 0;
+  let concurrentExecutions = 0;
+  let maxConcurrent = 0;
+
+  const runTask = async (id, delayMs) => {
+    const release = await mutex.acquire();
+    try {
+      concurrentExecutions += 1;
+      maxConcurrent = Math.max(maxConcurrent, concurrentExecutions);
+      
+      // Artificial delay to simulate asynchronous operations
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      
+      executionCount += 1;
+      concurrentExecutions -= 1;
+    } finally {
+      release();
+    }
+  };
+
+  // Launch 5 asynchronous tasks concurrently
+  await Promise.all([
+    runTask(1, 20),
+    runTask(2, 10),
+    runTask(3, 15),
+    runTask(4, 5),
+    runTask(5, 10)
+  ]);
+
+  assert.strictEqual(executionCount, 5, "All tasks must be executed");
+  assert.strictEqual(maxConcurrent, 1, "Max concurrent executions must be 1 (exclusive)");
+  assert.strictEqual(concurrentExecutions, 0, "No executions should be left active");
+});
+
+test("getRoomLock and clearRoomLock utility functions", () => {
+  const roomId = "test-classroom-room-123";
+  const lock1 = getRoomLock(roomId);
+  const lock2 = getRoomLock(roomId);
+
+  assert.strictEqual(lock1, lock2, "Subsequent calls for the same roomId should return the same Mutex instance");
+
+  clearRoomLock(roomId);
+  const lock3 = getRoomLock(roomId);
+  assert.notStrictEqual(lock1, lock3, "After clearing, a new Mutex instance should be returned");
+  clearRoomLock(roomId);
+});

--- a/server/src/utils/mutex.js
+++ b/server/src/utils/mutex.js
@@ -1,0 +1,76 @@
+/**
+ * A simple, dependency-free asynchronous Mutex (Mutual Exclusion) lock
+ * to prevent race conditions during async-await yield points.
+ */
+export class Mutex {
+  constructor() {
+    this._queue = [];
+    this._locked = false;
+  }
+
+  /**
+   * Acquires the lock. Returns a promise that resolves to a release function.
+   * Usage:
+   *   const release = await mutex.acquire();
+   *   try {
+   *     // critical section
+   *   } finally {
+   *     release();
+   *   }
+   * 
+   * @returns {Promise<Function>} A function to release the lock
+   */
+  acquire() {
+    return new Promise((resolve) => {
+      const run = () => {
+        let released = false;
+        resolve(() => {
+          if (released) return;
+          released = true;
+          this._locked = false;
+          this._next();
+        });
+      };
+
+      if (!this._locked) {
+        this._locked = true;
+        run();
+      } else {
+        this._queue.push(run);
+      }
+    });
+  }
+
+  _next() {
+    if (this._queue.length > 0) {
+      this._locked = true;
+      const nextRun = this._queue.shift();
+      nextRun();
+    }
+  }
+}
+
+// Global registry to store locks per roomId
+const roomLocks = new Map();
+
+/**
+ * Gets or creates a Mutex lock for a specific room.
+ * 
+ * @param {string} roomId - Room identifier
+ * @returns {Mutex} The Mutex lock for the room
+ */
+export const getRoomLock = (roomId) => {
+  if (!roomLocks.has(roomId)) {
+    roomLocks.set(roomId, new Mutex());
+  }
+  return roomLocks.get(roomId);
+};
+
+/**
+ * Removes a Mutex lock for a specific room to prevent memory leaks.
+ * 
+ * @param {string} roomId - Room identifier
+ */
+export const clearRoomLock = (roomId) => {
+  roomLocks.delete(roomId);
+};


### PR DESCRIPTION
### Summary
This PR addresses high-concurrency race conditions and WebRTC socket descriptor leaks in live classrooms as described in #958.

### Key Changes
1. **Asynchronous Mutex Lock Utility**:
   - Developed a lightweight, dependency-free asynchronous `Mutex` locking utility at `server/src/utils/mutex.js` with room-level lock registries.
   - Restricts operations inside `join-room` and `disconnect` to execute mutually exclusively, preventing async-await race conditions during multiple concurrent joins/leaves (e.g., in a 50+ student lecture).

2. **Database-Driven Connection Lifecycle**:
   - Extended the `ClassroomSession` database model with a `participants` array that tracks active participant socket IDs and user metadata in real time directly within the database state.
   - Upon `join-room`, atomically registers the student's active socket connection to the database (automatically cleaning up any duplicate or stale connections for the same user).
   - Serves room participant listings directly from the authoritative database state rather than relying on transient/unreliable in-memory Socket.IO client adapter maps.

3. **Robust Teardown and Graceful Cleanup**:
   - On `disconnect`, atomically pulls the leaving socket from the database participants array.
   - If the participant count drops to 0, automatically handles teardown by ending the classroom session, updating `status: 'ended'`, logging `endedAt`, archiving code and chat histories, and purging local memory states and Mutex locks to prevent descriptor leaks.

4. **Reliability Verification**:
   - Created robust unit tests at `server/src/utils/__tests__/mutex.test.js` to guarantee that the Mutex utility blocks overlapping concurrent executions and cleans up registries correctly.
   - Ran classrooms service and Mutex locks test suite successfully with all cases passing.