### PR TITLE
chore(ci): add PR linting (ESLint + Flake8) and fix server lint errors

### DIFF
--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -75,25 +75,27 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
 
-      - name: Install dependencies
+      - name: Install workspace dependencies
         if: steps.client_check.outputs.exists == 'true'
         run: npm ci
 
       - name: Run lint
         if: steps.client_check.outputs.exists == 'true'
         working-directory: client
-        run: npm run lint --if-present
+        run: npm run lint
 
       - name: Run tests
         if: steps.client_check.outputs.exists == 'true'
         working-directory: client
-        run: npm test --if-present
+        run: npm run test:run
 
       - name: Run build
         if: steps.client_check.outputs.exists == 'true'
         working-directory: client
-        run: npm run build --if-present
+        run: npm run build
 
 
   server_checks:
@@ -123,15 +125,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
 
-      - name: Install dependencies
+      - name: Install workspace dependencies
         if: steps.server_check.outputs.exists == 'true'
         run: npm ci
 
       - name: Run lint
         if: steps.server_check.outputs.exists == 'true'
         working-directory: server
-        run: npm run lint --if-present
+        run: npm run lint
 
       - name: Run tests
         if: steps.server_check.outputs.exists == 'true'
@@ -139,12 +143,33 @@ jobs:
         env:
           MONGO_URI: mongodb://localhost:27017/test_db
           JWT_SECRET: ci_test_secret
-        run: npm test --if-present
+        run: npm test
 
       - name: Run build
         if: steps.server_check.outputs.exists == 'true'
         working-directory: server
         run: npm run build --if-present
+
+
+  interview_ai_service_lint:
+    name: Interview AI Service Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install flake8
+        run: python -m pip install --upgrade pip flake8
+
+      - name: Run flake8
+        working-directory: interview-ai-service
+        run: flake8 . --max-line-length=160 --extend-ignore=E203,W503
 
 
   aiml_checks:

--- a/interview-ai-service/routers/transcription.py
+++ b/interview-ai-service/routers/transcription.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import asyncio
 from fastapi import APIRouter, UploadFile, File, HTTPException, WebSocket, WebSocketDisconnect
 from services.whisper_service import transcribe_audio
 
@@ -102,6 +101,6 @@ async def websocket_transcribe(websocket: WebSocket):
         print(f"WebSocket transcription error: {e}")
         try:
             await websocket.close()
-        except:
+        except Exception:
             pass
 

--- a/server/.eslintrc.cjs
+++ b/server/.eslintrc.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  root: true,
+  env: { node: true, es2024: true },
+  extends: ['eslint:recommended'],
+  ignorePatterns: ['node_modules', 'coverage', 'dist', '.eslintrc.cjs'],
+  parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+  rules: {
+    'no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+  },
+  overrides: [
+    {
+      files: ['**/__tests__/**', '**/*.test.js'],
+      rules: {
+        'no-unused-vars': 'off',
+      },
+    },
+  ],
+}

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "nodemon index.js",
     "start": "node index.js",
-    "test": "node --test"
+    "test": "node --test",
+    "lint": "eslint index.js src scripts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
@@ -37,6 +38,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "eslint": "^8.57.1",
     "nodemon": "^3.1.14"
   }
 }

--- a/server/src/database/models/Resume.js
+++ b/server/src/database/models/Resume.js
@@ -99,10 +99,6 @@ const resumeSchema = new mongoose.Schema(
       get: decrypt,
       set: encrypt,
     },
-    isScannedPdf: {
-      type: Boolean,
-      default: false,
-    },
     jobSkills: {
       type: [String],
       default: [],

--- a/server/src/modules/auth/routes.js
+++ b/server/src/modules/auth/routes.js
@@ -1,4 +1,5 @@
 import express from "express";
+import { getFrontendUrl } from "../../config/env.js";
 import { protect } from "../../middleware/authMiddleware.js";
 import { authRateLimiter, otpRateLimiter } from "../../middleware/rateLimiter.js";
 import {

--- a/server/src/modules/recruiter/controller.js
+++ b/server/src/modules/recruiter/controller.js
@@ -30,7 +30,7 @@ export const searchTalent = asyncHandler(async (req, res, next) => {
       : skills.split(",").map(s => s.trim()).filter(Boolean);
     if (skillsArray.length > 0) {
       matchObj.skills = {
-        $all: skillsArray.map(skill => new RegExp(`^${skill.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')}$`, "i"))
+        $all: skillsArray.map(skill => new RegExp(`^${skill.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}$`, "i"))
       };
     }
   }
@@ -48,7 +48,7 @@ export const searchTalent = asyncHandler(async (req, res, next) => {
     const specSkills = specMap[specialization.toLowerCase()];
     if (specSkills) {
       matchObj.skills = {
-        $in: specSkills.map(s => new RegExp(`^${s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')}$`, "i"))
+        $in: specSkills.map(s => new RegExp(`^${s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}$`, "i"))
       };
     }
   }

--- a/server/src/modules/resumes/controller.js
+++ b/server/src/modules/resumes/controller.js
@@ -1,5 +1,6 @@
 import path from "path";
 import fs from "fs";
+const fsPromises = fs.promises;
 import crypto from "crypto";
 import { parseResume } from "../../utils/parseResume.js";
 import Resume from "../../database/models/Resume.js";

--- a/server/src/utils/cleanText.js
+++ b/server/src/utils/cleanText.js
@@ -11,7 +11,7 @@ export const cleanJDText = (text = "") => {
   if (typeof text !== "string") return "";
 
   return text
-    .replace(/[•\-\*]/g, "")        // Remove bullet points first
+    .replace(/[•\-*]/g, "")        // Remove bullet points first
     .replace(/[\r\n]+/g, " ")      // Replace newlines with spaces
     .replace(/\s+/g, " ")           // Collapse multiple spaces to single space
     .trim();


### PR DESCRIPTION

## Summary

Add High-quality CI checks and make the server lintable so PRs are blocked only by real errors.

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore

## Changes Made

- Added/updated .github/workflows/pr-quality-checks.yml to run:
  - Client ESLint, tests, build
  - Server ESLint (with npm cache, using root lockfile)
  - Python Flake8 for `interview-ai-service` 
- Added server/.eslintrc.cjs and server `lint` script; installed ESLint in workspace.
- Fixed critical server lint errors (duplicate schema key, missing fs.promises, regex escapes, removed bare except), and small Python cleanup.
- Relaxed `no-unused-vars` to warnings and disabled it for tests to avoid blocking CI on non-critical items.

## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated
