### PR TITLE
fix: anchor summary detection to line-start headings only

### DIFF
--- a/ai-ml/evaluators/atsOptimizationEvaluator.js
+++ b/ai-ml/evaluators/atsOptimizationEvaluator.js
@@ -17,7 +17,7 @@ export const atsOptimizationEvaluator = ({ resumeData, weight = 0.15 }) => {
     experience: experience.length > 0,
     education: education.length > 0,
     skills: skills.length > 0,
-    summary: /summary|profile|objective|about me/gi.test(resumeText),
+    summary: /^[^a-z]*(summary|profile|objective|about\s+me)[^a-z]*$/gim.test(resumeText),
   };
 
   const contactResults = {

--- a/ai-ml/evaluators/atsOptimizationEvaluator.js
+++ b/ai-ml/evaluators/atsOptimizationEvaluator.js
@@ -17,7 +17,7 @@ export const atsOptimizationEvaluator = ({ resumeData, weight = 0.15 }) => {
     experience: experience.length > 0,
     education: education.length > 0,
     skills: skills.length > 0,
-    summary: /^[^a-z]*(summary|profile|objective|about\s+me)[^a-z]*$/gim.test(resumeText),
+    summary: /^[^a-z]*(summary|professional summary|profile|professional profile|objective|about\s+me)[^a-z]*$/im.test(resumeText),
   };
 
   const contactResults = {


### PR DESCRIPTION
## Summary

atsOptimizationEvaluator was falsely marking the summary section as present whenever keywords like summary, objective, or about me appeared anywhere in the resume body — including inside experience bullets and mid-sentence prose. This fix replaces the unconstrained regex with one anchored to line-start headings only.


## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #963 

## Changes Made

Replaced `/summary|profile|objective|about me/gi` with /`^[^a-z]*(summary|professional summary|profile|professional profile|objective|about\s+me)\s*:?\s*$/im` in` atsOptimizationEvaluator.js`


