### PR TITLE
fix: await isTokenBlacklisted() in fileAuthMiddleware to fix token bl…

### DIFF
--- a/server/src/middleware/fileAuthMiddleware.js
+++ b/server/src/middleware/fileAuthMiddleware.js
@@ -43,7 +43,7 @@ export const protectFileAccess = asyncHandler(async (req, res, next) => {
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
 
-    if (decoded.jti && isTokenBlacklisted(decoded.jti)) {
+    if (decoded.jti && await isTokenBlacklisted(decoded.jti)) {
       return next(new AppError("Token has been revoked. Please log in again.", 401));
     }
 


### PR DESCRIPTION
## Summary
The isTokenBlacklisted() function in fileAuthMiddleware.js was being called without await. Since it is async, the if condition was always evaluating a Promise object instead of the actual boolean result. A Promise is always truthy so every authenticated file request was getting rejected as revoked even with a valid token. Added await to fix this.

## Type of Change
- [x] Bug fix

## Related Issue
Closes #974 

## Changes Made
Added await before isTokenBlacklisted(decoded.jti) in server/src/middleware/fileAuthMiddleware.js

## Validation
- [x] Build passes locally
