### PR TITLE
feat: merge overlapping date intervals and add concave tiered scoring to experience evaluator

### DIFF
--- a/ai-ml/evaluators/experienceEvaluator.js
+++ b/ai-ml/evaluators/experienceEvaluator.js
@@ -1,6 +1,5 @@
-
-
 const roundToTwo = (value) => Number(value.toFixed(2));
+
 // --- Normalize text ---
 function normalize(text = "") {
   return text.toLowerCase().replace(/\s+/g, " ").trim();
@@ -12,9 +11,45 @@ const MONTH_MAP = {
   jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11
 };
 
+// --- Convert (month, year) to absolute month index ---
+function toAbsolute(month, year) {
+  return year * 12 + month;
+}
+
 // --- Calculate months difference ---
 function calculateMonths(startMonth, startYear, endMonth, endYear) {
   return (endYear - startYear) * 12 + (endMonth - startMonth);
+}
+
+// --- Merge overlapping intervals and sum total months ---
+function mergeAndSumIntervals(intervals) {
+  if (!intervals.length) return 0;
+
+  intervals.sort((a, b) => a.start - b.start);
+
+  const merged = [intervals[0]];
+
+  for (let i = 1; i < intervals.length; i++) {
+    const last = merged[merged.length - 1];
+    const curr = intervals[i];
+
+    if (curr.start <= last.end) {
+      last.end = Math.max(last.end, curr.end);
+    } else {
+      merged.push(curr);
+    }
+  }
+
+  return merged.reduce((sum, iv) => sum + (iv.end - iv.start), 0);
+}
+
+// --- Tiered scoring curve (concave) ---
+function computeScore(candidateYears, requiredYears) {
+  if (requiredYears === 0) return 100;
+  if (candidateYears >= requiredYears) return 100;
+
+  const ratio = candidateYears / requiredYears;
+  return roundToTwo(100 * Math.pow(ratio, 0.75));
 }
 
 // --- Extract experience in YEARS ---
@@ -22,94 +57,105 @@ export function extractExperienceInYears(text = "") {
   if (!text) return 0;
 
   const clean = normalize(text);
-  let maxYears = 0;
-
-  let match;
-
-  // ================================
-  // 1. DATE RANGE HANDLING (NEW 🔥)
-  // ================================
-  const dateRangeRegex =
-    /(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s*(\d{4})\s*[-–]\s*(present|current|(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s*(\d{4}))/gi;
-
   const now = new Date();
   const currentMonth = now.getMonth();
   const currentYear = now.getFullYear();
 
+  const intervals = [];
+  let match;
+
+  // ================================
+  // 1. DATE RANGE HANDLING
+  // ================================
+  const dateRangeRegex =
+    /(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s*'?(\d{2}|\d{4})\s*[-–to]+\s*(present|current|(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s*'?(\d{2}|\d{4}))/gi;
+
   while ((match = dateRangeRegex.exec(clean))) {
-    const startMonth = MONTH_MAP[match[1]];
-    const startYear = parseInt(match[2]);
+    const startMonth = MONTH_MAP[match[1].slice(0, 3).toLowerCase()];
+
+    const rawStartYear = match[2];
+    const startYear =
+      rawStartYear.length === 2
+        ? 2000 + parseInt(rawStartYear)
+        : parseInt(rawStartYear);
 
     let endMonth, endYear;
 
-    if (match[3].includes("present") || match[3].includes("current")) {
+    const endToken = match[3].toLowerCase();
+    if (endToken.includes("present") || endToken.includes("current")) {
       endMonth = currentMonth;
       endYear = currentYear;
     } else {
-      endMonth = MONTH_MAP[match[4]];
-      endYear = parseInt(match[5]);
+      endMonth = MONTH_MAP[match[4].slice(0, 3).toLowerCase()];
+      const rawEndYear = match[5];
+      endYear =
+        rawEndYear.length === 2
+          ? 2000 + parseInt(rawEndYear)
+          : parseInt(rawEndYear);
     }
 
-    const months = calculateMonths(startMonth, startYear, endMonth, endYear);
-    const years = months / 12;
+    const absStart = toAbsolute(startMonth, startYear);
+    const absEnd = toAbsolute(endMonth, endYear);
 
-    maxYears = Math.max(maxYears, years);
+    if (absEnd > absStart) {
+      intervals.push({ start: absStart, end: absEnd });
+    }
+  }
+
+  // If date ranges found, merge and return total
+  if (intervals.length > 0) {
+    const totalMonths = mergeAndSumIntervals(intervals);
+    return roundToTwo(totalMonths / 12);
   }
 
   // ================================
-  // 2. COMBINED (1 year 6 months)
+  // 2. FALLBACK: TEXT-BASED PATTERNS
   // ================================
-  const combinedRegex = /(\d+)\s*(year|years|yr|yrs)\s*(\d+)\s*(month|months|mo|mos)/g;
+  let maxYears = 0;
+  const rangeIndices = [];
+
+  // Combined (1 year 6 months)
+  const combinedRegex =
+    /(\d+)\s*(year|years|yr|yrs)\s*(\d+)\s*(month|months|mo|mos)/g;
   while ((match = combinedRegex.exec(clean))) {
-    const years = parseInt(match[1]);
-    const months = parseInt(match[3]);
-    maxYears = Math.max(maxYears, years + months / 12);
+    maxYears = Math.max(maxYears, parseInt(match[1]) + parseInt(match[3]) / 12);
   }
 
-  // ================================
-  // 3. RANGE (3-5 years)
-  // ================================
-  const rangePattern = /(\d+(?:\.\d+)?)\s*(?:-|–|to)\s*(\d+(?:\.\d+)?)\s*\+?\s*(?:year|years|yr|yrs)/gi;
-  const combinedMatchedIndices = [];
-  
-  for (const match of clean.matchAll(rangePattern)) {
-    const lower = parseFloat(match[1]);
-    const upper = parseFloat(match[2]);
+  // Range (3-5 years)
+  const rangePattern =
+    /(\d+(?:\.\d+)?)\s*(?:-|–|to)\s*(\d+(?:\.\d+)?)\s*\+?\s*(?:year|years|yr|yrs)/gi;
+  for (const m of clean.matchAll(rangePattern)) {
+    const lower = parseFloat(m[1]);
+    const upper = parseFloat(m[2]);
     maxYears = Math.max(maxYears, (lower + upper) / 2);
-    combinedMatchedIndices.push({
-      start: match.index,
-      end: match.index + match[0].length,
-    });
+    rangeIndices.push({ start: m.index, end: m.index + m[0].length });
   }
 
-  const isOverlapping = (index) => 
-    combinedMatchedIndices.some(range => index >= range.start && index <= range.end);
+  const isOverlapping = (idx) =>
+    rangeIndices.some((r) => idx >= r.start && idx <= r.end);
 
-  // ================================
-  // 4. PLUS (2+ years)
-  // ================================
+  // Plus (2+ years)
   const plusRegex = /(\d+)\+?\s*(year|years|yr|yrs)/g;
   while ((match = plusRegex.exec(clean))) {
-    if (isOverlapping(match.index)) continue;
-    maxYears = Math.max(maxYears, parseInt(match[1]));
+    if (!isOverlapping(match.index))
+      maxYears = Math.max(maxYears, parseInt(match[1]));
   }
 
-  // ================================
-  // 5. MONTHS ONLY (18 months)
-  // ================================
+  // Months only (18 months)
   const monthRegex = /(\d+)\s*(month|months|mo|mos)/g;
   while ((match = monthRegex.exec(clean))) {
-    if (isOverlapping(match.index)) continue;
-    maxYears = Math.max(maxYears, parseInt(match[1]) / 12);
+    if (!isOverlapping(match.index))
+      maxYears = Math.max(maxYears, parseInt(match[1]) / 12);
   }
 
-  return maxYears;
+  return roundToTwo(maxYears);
 }
 
 // --- MAIN EVALUATOR ---
 export function experienceEvaluator({
   candidateExperienceText = "",
   jobDescription = "",
+  overqualificationThreshold = 2.5,
 } = {}) {
   const candidateYears = extractExperienceInYears(candidateExperienceText);
   const requiredYears = extractExperienceInYears(jobDescription);
@@ -122,52 +168,67 @@ export function experienceEvaluator({
       summary: "No specific years of experience required for this role.",
       details: {
         feedback: ["Could not detect required experience from the job description"],
-        candidateExperience: Number(candidateYears.toFixed(2)),
+        candidateExperience: candidateYears,
         requiredExperience: 0,
         experienceGap: 0,
+        experienceSurplus: 0,
       },
-      meta: {}
+      meta: {
+        isSeniorRole: false,
+        isOverqualified: false,
+        overqualificationThreshold,
+      },
     };
   }
 
-  let score =
-    candidateYears >= requiredYears
-      ? 100
-      : (candidateYears / requiredYears) * 100;
-
-  score = Math.min(100, Number(score.toFixed(2)));
-
-  const gap = Math.max(0, requiredYears - candidateYears);
+  const score = computeScore(candidateYears, requiredYears);
+  const gap = roundToTwo(Math.max(0, requiredYears - candidateYears));
+  const surplus = roundToTwo(Math.max(0, candidateYears - requiredYears));
+  const isOverqualified =
+    candidateYears >= requiredYears * overqualificationThreshold;
 
   const feedback = [];
 
-  if (score === 100) {
-    feedback.push("Candidate meets or exceeds required experience");
+  if (isOverqualified) {
+    feedback.push(
+      `Candidate may be overqualified — has ${surplus} years more than required`
+    );
+  } else if (score === 100) {
+    feedback.push("Candidate meets or exceeds the required experience");
+  } else if (score >= 75) {
+    feedback.push("Candidate is slightly below the required experience level");
   } else if (score >= 50) {
-    feedback.push("Candidate experience partially matches job requirements");
+    feedback.push("Candidate partially meets experience requirements");
   } else {
     feedback.push("Candidate has significantly less experience than required");
   }
 
-  feedback.push(`Required experience: ${requiredYears} years`);
-  feedback.push(`Candidate experience: ${candidateYears.toFixed(2)} years`);
-  feedback.push(`Experience gap: ${gap.toFixed(2)} years`);
+  feedback.push(`Required: ${requiredYears} yrs | Candidate: ${candidateYears} yrs`);
+  if (gap > 0) feedback.push(`Gap: ${gap} years`);
+  if (surplus > 0 && !isOverqualified) feedback.push(`Surplus: ${surplus} years`);
+
+  const summary = isOverqualified
+    ? `Candidate may be overqualified by ~${surplus} years.`
+    : score === 100
+    ? "Candidate meets the required experience level."
+    : `Candidate is short by approximately ${gap} years.`;
 
   return {
     key: "experience_match",
     label: "Experience Match",
     score,
-    summary: score === 100 
-      ? "Candidate meets the required experience level."
-      : `Candidate is short by approximately ${gap.toFixed(1)} years of experience.`,
+    summary,
     details: {
-      candidateExperience: Number(candidateYears.toFixed(2)),
-      requiredExperience: Number(requiredYears.toFixed(2)),
-      experienceGap: Number(gap.toFixed(2)),
-      feedback
+      candidateExperience: candidateYears,
+      requiredExperience: requiredYears,
+      experienceGap: gap,
+      experienceSurplus: surplus,
+      feedback,
     },
     meta: {
-      isSeniorRole: requiredYears >= 5
-    }
+      isSeniorRole: requiredYears >= 5,
+      isOverqualified,
+      overqualificationThreshold,
+    },
   };
 }


### PR DESCRIPTION
## Summary
Replaced the `maxYears` approach in `extractExperienceInYears` with an interval-merging strategy that correctly sums total experience across multiple jobs. Added support for 2-digit year formats. Replaced linear scoring in `experienceEvaluator` with a concave curve and added overqualification detection.

## Type of Change
[x] Feature — interval merging, overqualification flag
[x] Bug fix — multi-job total experience, 2-digit year parsing

## Related Issue
Closes #976 

## Changes Made
- Added `mergeAndSumIntervals()` to merge overlapping date ranges and sum total months
- Added `toAbsolute()` helper to convert `(month, year)` to absolute month index
- Updated `dateRangeRegex` to support 2-digit year formats (`'22` → `2022`)
- Replaced `maxYears` with interval-based total in `extractExperienceInYears`
- Replaced linear score with concave curve (`100 * ratio^0.75`) via `computeScore()`
- Added `isOverqualified` flag and `overqualificationThreshold` param to evaluator
- Added `experienceSurplus` to evaluator output details

## Validation
- [x] Build passes locally
- [x] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)
N/A