### PR TITLE
fix: count only tutor's students sessions in getTutorSessionsList pagination

### DIFF
--- a/server/src/modules/interviews/service.js
+++ b/server/src/modules/interviews/service.js
@@ -453,7 +453,7 @@ export const getTutorSessionsList = async (tutorId, page, limit) => {
       .skip(skip)
       .limit(limit)
       .lean(),
-    InterviewSession.countDocuments({ status: 'completed' }),
+    InterviewSession.countDocuments({ userId: { $in: studentIds }, status: 'completed' }),
   ]);
   return { sessions, total, page, pages: Math.ceil(total / limit) };
 };


### PR DESCRIPTION
Fixes #984

## Problem
In `server/src/modules/interviews/service.js`, `getTutorSessionsList` 
was fetching sessions only for the tutor's assigned students, but the 
pagination count was using a global count of ALL completed sessions:

InterviewSession.countDocuments({ status: 'completed' })

This caused incorrect pagination totals — tutors would see more pages 
than actually exist for their students.

## Fix
Changed the count query to filter by the tutor's students:

InterviewSession.countDocuments({ 
  userId: { $in: studentIds }, 
  status: 'completed' 
})

## Changes
- `server/src/modules/interviews/service.js` — 1 line fixed