### PR TITLE
fix: move mark-all/read route before dynamic route to fix Express routing conflict

### DIFF
--- a/server/src/modules/notifications/routes.js
+++ b/server/src/modules/notifications/routes.js
@@ -24,10 +24,8 @@ router.post("/", createNotification);
 
 router.get("/:id", getNotification);
 
-router.patch("/:id/read", markAsRead);
-
 router.patch("/mark-all/read", markAllAsRead);
-
+router.patch("/:id/read", markAsRead);
 router.delete("/:id", deleteNotificationById);
 
 router.delete("/", deleteAllNotificationsForUser);


### PR DESCRIPTION
Fixes #988

## Problem
In `server/src/modules/notifications/routes.js`, the specific route 
`PATCH /mark-all/read` was defined AFTER the dynamic route `PATCH /:id/read`:

router.patch("/:id/read", markAsRead);
router.patch("/mark-all/read", markAllAsRead); // never reached!

Express matches routes in order, so `PATCH /mark-all/read` was always 
intercepted by `/:id/read` with id="mark-all", causing a 404 error 
instead of marking all notifications as read.

## Fix
Moved the specific route BEFORE the dynamic route:

router.patch("/mark-all/read", markAllAsRead);
router.patch("/:id/read", markAsRead);

## Changes
- `server/src/modules/notifications/routes.js` — route order fixed