### PR TITLE
fix: move tutor routes before dynamic /:id routes to fix Express routing conflict

### DIFF
--- a/server/src/modules/interviews/routes.js
+++ b/server/src/modules/interviews/routes.js
@@ -105,33 +105,12 @@ router.post("/start", aiActionLimiter, startInterview);
  */
 router.get("/history", getInterviewHistory);
 
-router.get("/:id", getSession);
-router.post("/:id/answer", aiActionLimiter, upload.single("audio"), submitAnswer);
-router.post("/:id/complete", completeInterview);
-
-/**
- * @openapi
- * /api/interviews/{id}/results:
- *   get:
- *     summary: Get final results and feedback for a completed session
- *     tags: [Interviews]
- *     parameters:
- *       - in: path
- *         name: id
- *         required: true
- *         schema:
- *           type: string
- *     security:
- *       - bearerAuth: []
- *     responses:
- *       200:
- *         description: Detailed feedback and scores
- */
-router.get("/:id/results", getSessionResults);
-
-// Tutor routes
+// Tutor routes (must be before /:id to avoid route conflict)
 router.get("/tutor/sessions", authorizeRoles("tutor"), getTutorSessions);
 router.get("/tutor/sessions/:id", authorizeRoles("tutor"), getTutorSession);
 router.post("/tutor/sessions/:id/feedback", authorizeRoles("tutor"), submitTutorFeedback);
 
-export default router;
+router.get("/:id", getSession);
+router.post("/:id/answer", aiActionLimiter, upload.single("audio"), submitAnswer);
+router.post("/:id/complete", completeInterview);
+router.get("/:id/results", getSessionResults);


### PR DESCRIPTION
Fixes #990

## Problem
In `server/src/modules/interviews/routes.js`, tutor routes were 
defined AFTER the dynamic `/:id` route:

router.get("/:id", getSession); // catches everything!
router.get("/tutor/sessions", getTutorSessions); // never reached!
router.get("/tutor/sessions/:id", getTutorSession); // never reached!

Express matches routes in order, so `GET /tutor/sessions` was always 
intercepted by `/:id` with id="tutor", completely blocking tutors 
from accessing their sessions.

## Fix
Moved all tutor routes BEFORE the dynamic /:id routes:

// Tutor routes (must be before /:id to avoid route conflict)
router.get("/tutor/sessions", authorizeRoles("tutor"), getTutorSessions);
router.get("/tutor/sessions/:id", authorizeRoles("tutor"), getTutorSession);
router.post("/tutor/sessions/:id/feedback", authorizeRoles("tutor"), submitTutorFeedback);

router.get("/:id", getSession);
router.get("/:id/results", getSessionResults);

## Changes
- `server/src/modules/interviews/routes.js` — tutor routes moved before dynamic routes