### PR TITLE
feat: add fuzzy skill matching and category-based weighted scoring to skillEvaluator [ GSSOC'26 ]

### DIFF
--- a/ai-ml/evaluators/skillEvaluator.js
+++ b/ai-ml/evaluators/skillEvaluator.js
@@ -1,7 +1,48 @@
 import { normalizeSkillArray } from "../utils/skillNormalizer.js";
 
+// --- Skill category weights ---
+const SKILL_WEIGHTS = {
+  core: 1.0,
+  framework: 0.85,
+  tool: 0.7,
+  soft: 0.5,
+  default: 0.75,
+};
+
+// --- Assign weight based on skill category hint ---
+function getSkillWeight(skill) {
+  const frameworks = ["react", "angular", "vue", "next", "express", "django", "spring", "laravel"];
+  const tools = ["git", "docker", "kubernetes", "jenkins", "webpack", "vite", "figma", "jira"];
+  const soft = ["communication", "leadership", "teamwork", "problem solving", "time management"];
+
+  if (soft.some((s) => skill.includes(s))) return SKILL_WEIGHTS.soft;
+  if (frameworks.some((f) => skill.includes(f))) return SKILL_WEIGHTS.framework;
+  if (tools.some((t) => skill.includes(t))) return SKILL_WEIGHTS.tool;
+  return SKILL_WEIGHTS.default;
+}
+
+// --- Fuzzy match: checks partial overlap for compound skills ---
+function fuzzyMatch(resumeSkill, jobSkill) {
+  if (resumeSkill === jobSkill) return true;
+
+  // "node" matches "node.js", "reactjs" matches "react"
+  const clean = (s) => s.replace(/\.js$|js$/i, "").trim();
+  if (clean(resumeSkill) === clean(jobSkill)) return true;
+
+  // Partial containment for compound skills ("aws lambda" vs "aws")
+  if (resumeSkill.includes(jobSkill) || jobSkill.includes(resumeSkill)) return true;
+
+  return false;
+}
+
+// --- Weighted score computation ---
+function computeWeightedScore(matchedSkills, normJob) {
+  const totalWeight = normJob.reduce((sum, s) => sum + getSkillWeight(s), 0);
+  const matchedWeight = matchedSkills.reduce((sum, s) => sum + getSkillWeight(s), 0);
+  return totalWeight === 0 ? 0 : Math.round((matchedWeight / totalWeight) * 100);
+}
+
 export const skillEvaluator = ({ resumeSkills = [], jobSkills = [] }) => {
-  // Use the optimized normalizer
   const normResume = normalizeSkillArray(resumeSkills);
   const normJob = normalizeSkillArray(jobSkills);
 
@@ -19,46 +60,67 @@ export const skillEvaluator = ({ resumeSkills = [], jobSkills = [] }) => {
       },
       meta: {
         jobSkillCount: 0,
-        resumeSkillCount: normResume.length
-      }
+        resumeSkillCount: normResume.length,
+        isWeighted: false,
+      },
     };
   }
 
-  // Matched: intersection
-  const matched = normJob.filter(s => normResume.includes(s));
+  // --- Fuzzy matched skills ---
+  const matched = normJob.filter((jobSkill) =>
+    normResume.some((resumeSkill) => fuzzyMatch(resumeSkill, jobSkill))
+  );
 
-  // Missing from job
-  const missing = normJob.filter(s => !normResume.includes(s));
+  const missing = normJob.filter(
+    (jobSkill) => !normResume.some((resumeSkill) => fuzzyMatch(resumeSkill, jobSkill))
+  );
 
-  // Extra in resume
-  const extra = normResume.filter(s => !normJob.includes(s));
+  const extra = normResume.filter(
+    (resumeSkill) => !normJob.some((jobSkill) => fuzzyMatch(resumeSkill, jobSkill))
+  );
 
-  // Score: (matched / job.length) * 100, adjusted
-  const score = jobSkills.length > 0 ? Math.round((matched.length / normJob.length) * 100) : 0;
+  // --- Weighted score ---
+  const score = computeWeightedScore(matched, normJob);
 
-  // Feedback
+  // --- Coverage tiers for feedback ---
+  const coverageRatio = matched.length / normJob.length;
+
   const feedback = [];
-  if (matched.length > 0) feedback.push(`Great! ${matched.length}/${normJob.length} job skills match.`);
-  if (missing.length > 0) feedback.push(`Add these job skills: ${missing.slice(0,3).join(', ')}${missing.length > 3 ? '...' : ''}`);
-  if (extra.length > 0) feedback.push(`Consider prioritizing job-relevant skills over extras.`);
+  if (matched.length > 0)
+    feedback.push(`Matched ${matched.length}/${normJob.length} required skills.`);
+  if (coverageRatio >= 0.8)
+    feedback.push("Strong skill alignment with the job requirements.");
+  else if (coverageRatio >= 0.5)
+    feedback.push("Moderate skill overlap — consider upskilling in missing areas.");
+  else
+    feedback.push("Low skill overlap — significant gaps compared to job requirements.");
+  if (missing.length > 0)
+    feedback.push(
+      `Key missing skills: ${missing.slice(0, 3).join(", ")}${missing.length > 3 ? ` and ${missing.length - 3} more` : ""}`
+    );
+  if (extra.length > 0)
+    feedback.push("Resume has additional skills not listed in job requirements — consider tailoring.");
 
   return {
     key: "skill_match",
     label: "Skill Match",
     score,
-    summary: matched.length > 0 
-      ? `Matched ${matched.length} out of ${normJob.length} required skills.`
-      : "No matching skills found for this position.",
+    summary:
+      matched.length > 0
+        ? `Matched ${matched.length} of ${normJob.length} required skills (weighted score: ${score}%).`
+        : "No matching skills found for this position.",
     details: {
       matchedSkills: matched,
       missingSkills: missing,
       extraSkills: extra,
-      feedback
+      feedback,
     },
     meta: {
       jobSkillCount: normJob.length,
-      resumeSkillCount: normResume.length
-    }
+      resumeSkillCount: normResume.length,
+      matchedCount: matched.length,
+      coverageRatio: parseFloat(coverageRatio.toFixed(2)),
+      isWeighted: true,
+    },
   };
 };
-


### PR DESCRIPTION
## Summary
Replaced exact string matching in `skillEvaluator` with fuzzy matching to handle 
skill aliases like "react/reactjs" and "node/node.js". Added a category-based 
weighting system (core, framework, tool, soft) so scores reflect actual technical 
alignment rather than raw skill count.

## Type of Change
- [x] Feature — fuzzy matching, weighted scoring, coverage tiers
- [x] Bug fix — skill aliases treated as mismatches in exact comparison

## Related Issue
Closes #1011 

## Changes Made
- Added `fuzzyMatch()` to handle `.js` suffix variants and compound skill containment
- Added `getSkillWeight()` to categorize skills into core/framework/tool/soft
- Added `computeWeightedScore()` for weight-normalized score computation
- Replaced `normJob.filter(s => normResume.includes(s))` with fuzzy match across all skills
- Added `coverageRatio` and `isWeighted` to evaluator `meta` output
- Added tiered feedback based on coverage ratio (≥0.8 / ≥0.5 / below)

## Validation
- [x] Build passes locally
- [x] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)
N/A