### PR TITLE
fix: remove overly broad status>=500 condition from AI error handler

### DIFF
--- a/server/src/middleware/errorMiddleware.js
+++ b/server/src/middleware/errorMiddleware.js
@@ -55,7 +55,7 @@ const globalErrorHandler = (err, req, res, next) => {
   if (error.name === "ValidationError") error = handleValidationErrorDB(error);
   
   // Handle AI/OpenAI Errors
-  if (error.isAxiosError || error.status >= 500 || error.type === 'invalid_request_error') {
+  if (error.isAxiosError || error.type === 'invalid_request_error') {
     error = handleAIError(error);
   }
   


### PR DESCRIPTION
Fixes #1020

## Problem
In `server/src/middleware/errorMiddleware.js`, the AI error handler 
condition was too broad:

if (error.isAxiosError || error.status >= 500 || error.type === 'invalid_request_error') {
  error = handleAIError(error);
}

The `error.status >= 500` condition was catching ALL server errors 
(MongoDB crashes, unhandled exceptions, etc.) and incorrectly 
returning "AI service is currently unavailable" — completely misleading.

## Fix
Removed the overly broad condition:

if (error.isAxiosError || error.type === 'invalid_request_error') {
  error = handleAIError(error);
}

## Changes
- `server/src/middleware/errorMiddleware.js` — 1 condition removed