### PR TITLE
fix: add missing GEMINI_API_KEY and evaluator config variables to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,18 @@ INTERVIEW_AI_URL=http://localhost:8000
 INTERVIEW_AI_TIMEOUT=10000
 # Timeout for audio transcription requests (ms)
 INTERVIEW_AI_TRANSCRIBE_TIMEOUT=30000
+# ==========================================
+# AI/ML Evaluator Configuration (optional)
+# Defaults are applied if not set
+# ==========================================
+EVALUATOR_SKILL_MATCH_ENABLED=true
+EVALUATOR_KEYWORD_MATCH_ENABLED=true
+EVALUATOR_EXPERIENCE_MATCH_ENABLED=true
+EVALUATOR_SKILL_MATCH_WEIGHT=1.0
+EVALUATOR_KEYWORD_MATCH_WEIGHT=0.2
+EVALUATOR_EXPERIENCE_MATCH_WEIGHT=0.2
+
+# ==========================================
+# Gemini AI Configuration
+# ==========================================
+GEMINI_API_KEY=your_gemini_api_key_here


### PR DESCRIPTION
Fixes #1023

## Problem
Two sets of environment variables were used in the codebase but 
missing from `.env.example`, causing confusion for new developers:

1. `GEMINI_API_KEY` — referenced in `validateEnv.js` under EXTERNAL_KEYS
2. Evaluator config variables — used in `evaluatorConfig.js`:
   - EVALUATOR_SKILL_MATCH_ENABLED
   - EVALUATOR_KEYWORD_MATCH_ENABLED
   - EVALUATOR_EXPERIENCE_MATCH_ENABLED
   - EVALUATOR_SKILL_MATCH_WEIGHT
   - EVALUATOR_KEYWORD_MATCH_WEIGHT
   - EVALUATOR_EXPERIENCE_MATCH_WEIGHT

## Fix
Added all missing variables to `.env.example` with comments.

## Changes
- `.env.example` — 15 lines added