### PR TITLE
fix: replace full collection load with aggregation in tutor analytics

### DIFF
--- a/server/src/modules/analytics/controller.js
+++ b/server/src/modules/analytics/controller.js
@@ -80,24 +80,33 @@ export const getDashboardAnalytics = async (req, res) => {
     } 
     
     if (role === "tutor") {
-      // Tutor: Aggregated performance metrics
-      const allInterviews = await InterviewSession.find({ status: "completed" }).lean();
-      const averagePlatformScore = allInterviews.length > 0
-        ? Math.round(allInterviews.reduce((acc, curr) => acc + curr.overallScore, 0) / allInterviews.length)
-        : 0;
-        
-      const activeStudents = await LearningProgress.countDocuments({ overallProgress: { $gt: 0 } });
+  const [result, activeStudents] = await Promise.all([
+    InterviewSession.aggregate([
+      { $match: { status: "completed" } },
+      { $group: {
+        _id: null,
+        averagePlatformScore: { $avg: "$overallScore" },
+        totalMockInterviewsCompleted: { $sum: 1 }
+      }}
+    ]),
+    LearningProgress.countDocuments({ overallProgress: { $gt: 0 } })
+  ]);
 
-      return res.status(200).json({
-        success: true,
-        data: {
-          role,
-          averagePlatformScore,
-          totalMockInterviewsCompleted: allInterviews.length,
-          activeStudents
-        }
-      });
+  const averagePlatformScore = result[0]
+    ? Math.round(result[0].averagePlatformScore)
+    : 0;
+  const totalMockInterviewsCompleted = result[0]?.totalMockInterviewsCompleted || 0;
+
+  return res.status(200).json({
+    success: true,
+    data: {
+      role,
+      averagePlatformScore,
+      totalMockInterviewsCompleted,
+      activeStudents
     }
+  });
+}
 
     if (role === "recruiter") {
       // Recruiter: Talent pool density map


### PR DESCRIPTION
Fixes #1026

## Problem
In `server/src/modules/analytics/controller.js`, the tutor analytics 
handler was loading ALL completed interviews into Node.js memory:

const allInterviews = await InterviewSession.find({ status: "completed" }).lean();

As the platform scales, this could load thousands of documents into 
memory just to calculate a simple average — causing slow responses 
and potential server crash.

## Fix
Replaced with MongoDB aggregation that computes the average 
server-side, loading only the result:

const [result, activeStudents] = await Promise.all([
  InterviewSession.aggregate([
    { $match: { status: "completed" } },
    { $group: {
      _id: null,
      averagePlatformScore: { $avg: "$overallScore" },
      totalMockInterviewsCompleted: { $sum: 1 }
    }}
  ]),
  LearningProgress.countDocuments({ overallProgress: { $gt: 0 } })
]);

## Changes
- `server/src/modules/analytics/controller.js` — tutor section refactored