### PR TITLE
fix: use valid notification type 'application' in updateApplicationSt…

### DIFF
--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -1020,7 +1020,7 @@ export const updateApplicationStatus = async (applicationId, recruiterId, { stat
   // Create persistent notification for the student
   const notification = await Notification.create({
     userId: application.applicant,
-    type: "application_status",
+    type: "application",
     title: "Application Status Updated",
     message: `Your application for ${application.job.title} has been marked as ${status}.`,
     relatedData: { jobId: application.job._id, studentId: application.applicant, applicationId: application._id }


### PR DESCRIPTION
## Summary
Fixes a Mongoose validation error in `updateApplicationStatus` caused by using `"application_status"` as the notification type, which is not in the valid enum. This silently broke notifications whenever a recruiter updated an application status. Corrected to `"application"`.

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue
Closes #1030

## Changes Made
- Changed `type: "application_status"` → `type: "application"` in `Notification.create()` inside `updateApplicationStatus` in `server/src/modules/jobs/service.js`

## Root Cause
The valid notification types are: `"info"`, `"warning"`, `"success"`, `"error"`, `"job-update"`, `"interview"`, `"application"`, `"new_application"`, `"skill_gap_alert"`. The value `"application_status"` was never in this list, causing Mongoose to throw a validation error on every recruiter status update.

## Validation
- [x] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)