### PR TITLE
fix: return specific error message for expired JWT tokens

### DIFF
--- a/server/src/middleware/authMiddleware.js
+++ b/server/src/middleware/authMiddleware.js
@@ -46,8 +46,11 @@ export const protect = asyncHandler(async (req, res, next) => {
     req.user = currentUser;
     next();
   } catch (error) {
+    if (error.name === "TokenExpiredError") {
+      return next(new AppError("Your session has expired. Please log in again.", 401));
+    }
     return next(new AppError("Invalid token. Please log in again.", 401));
-  }
+}
 });
 
 /**


### PR DESCRIPTION
## Summary
Improves JWT error handling in the `protect` middleware to distinguish between expired tokens and invalid tokens, returning a clear and specific error message for each case.

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue
Closes #1033

## Before / After
**Before:** All JWT errors (expired, malformed, invalid signature) returned the same message:
`"Invalid token. Please log in again."`

**After:**
- Expired token → `"Your session has expired. Please log in again."`
- Invalid/malformed token → `"Invalid token. Please log in again."`

## Changes Made
- Updated the `catch` block in the `protect` function in `server/src/middleware/authMiddleware.js` to check `error.name === "TokenExpiredError"` and return a specific session expiry message

## Validation
- [x] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)
N/A — backend-only change.