### PR TITLE
fix: remove unauthenticated debug-db endpoint that exposed all user e…

### DIFF
--- a/server/src/modules/auth/routes.js
+++ b/server/src/modules/auth/routes.js
@@ -23,14 +23,9 @@ import {
   resetPassword,
   verifyEmail,
 } from "./controller.js";
-import mongoose from "mongoose";
 
 const router = express.Router();
 
-router.get("/debug-db", async (req, res) => {
-  const users = await mongoose.connection.db.collection('users').find({}).toArray();
-  res.json({ count: users.length, emails: users.map(u => u.email) });
-});
 
 /**
  * @openapi


### PR DESCRIPTION
## Summary
Removes a publicly accessible debug endpoint from `server/src/modules/auth/routes.js` that exposed all registered user emails with zero authentication. Also removes the now-unused `mongoose` import that was added solely for this endpoint.

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue
Closes #1029

## Security Impact
- `GET /api/auth/debug-db` was fully public — no token required
- Any anonymous user could retrieve the email address of every registered user
- This is a direct privacy violation affecting all users in the database

## Changes Made
- Removed the unauthenticated `GET /api/auth/debug-db` route entirely from `server/src/modules/auth/routes.js`
- Removed the `import mongoose from "mongoose"` statement that was only used by this debug route

## Validation
- [x] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)
N/A — backend-only change.