### PR TITLE
[BUG] API client error normalization loses real server 

### DIFF
--- a/client/src/services/__tests__/apiClient.test.js
+++ b/client/src/services/__tests__/apiClient.test.js
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { normalizeApiError } from "../apiClient";
+
+describe("normalizeApiError", () => {
+  it("keeps plain-text error responses as the message", () => {
+    const error = new Error("Request failed");
+    error.status = 401;
+    error.data = { message: "Unauthorized" };
+
+    expect(normalizeApiError(error)).toMatchObject({
+      status: 401,
+      message: "Unauthorized",
+      errors: {},
+    });
+  });
+
+  it("prefers FastAPI detail messages over the generic fallback", () => {
+    const error = {
+      status: 422,
+      response: {
+        data: {
+          detail: "Invalid request payload",
+        },
+      },
+    };
+
+    expect(normalizeApiError(error)).toMatchObject({
+      status: 422,
+      message: "Invalid request payload",
+      errors: {},
+    });
+  });
+
+  it("extracts field errors from common detail and error schemas", () => {
+    const error = {
+      status: 400,
+      response: {
+        data: {
+          details: {
+            title: "Title is required",
+            skills: "At least one skill is required",
+          },
+          detail: "Validation failed",
+        },
+      },
+    };
+
+    expect(normalizeApiError(error)).toMatchObject({
+      status: 400,
+      message: "Validation failed",
+      errors: {
+        title: "Title is required",
+        skills: "At least one skill is required",
+      },
+    });
+  });
+
+  it("maps FastAPI validation arrays into field errors", () => {
+    const error = {
+      status: 422,
+      response: {
+        data: {
+          detail: [
+            {
+              loc: ["body", "title"],
+              msg: "Field required",
+            },
+            {
+              loc: ["body", "skills"],
+              msg: "At least one skill is required",
+            },
+          ],
+        },
+      },
+    };
+
+    expect(normalizeApiError(error)).toMatchObject({
+      status: 422,
+      message: "Field required",
+      errors: {
+        title: "Field required",
+        skills: "At least one skill is required",
+      },
+    });
+  });
+
+  it("falls back to nested error objects when the top-level payload uses error", () => {
+    const error = {
+      status: 400,
+      response: {
+        data: {
+          error: {
+            email: "Email is already in use",
+          },
+        },
+      },
+    };
+
+    expect(normalizeApiError(error)).toMatchObject({
+      status: 400,
+      message: "Something went wrong",
+      errors: {
+        email: "Email is already in use",
+      },
+    });
+  });
+});

--- a/client/src/services/apiClient.js
+++ b/client/src/services/apiClient.js
@@ -12,6 +12,130 @@ const toUrl = (path) => {
   return `${baseUrl}${path}`;
 };
 
+const isPlainObject = (value) => {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+};
+
+const extractApiMessage = (value) => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const message = extractApiMessage(item);
+      if (message) {
+        return message;
+      }
+    }
+    return null;
+  }
+
+  if (!isPlainObject(value)) {
+    return null;
+  }
+
+  return (
+    extractApiMessage(value.message) ||
+    extractApiMessage(value.msg) ||
+    extractApiMessage(value.detail) ||
+    extractApiMessage(value.error) ||
+    extractApiMessage(value.details)
+  );
+};
+
+const getValidationFieldName = (location) => {
+  if (typeof location === "string") {
+    return location;
+  }
+
+  if (!Array.isArray(location)) {
+    return null;
+  }
+
+  const segments = location.filter(
+    (segment) =>
+      typeof segment === "string" && !["body", "query", "path", "header"].includes(segment),
+  );
+
+  return segments.length > 0 ? segments.join(".") : null;
+};
+
+const normalizeValidationErrors = (value) => {
+  if (!Array.isArray(value)) {
+    return {};
+  }
+
+  return value.reduce((accumulator, item) => {
+    if (!isPlainObject(item)) {
+      return accumulator;
+    }
+
+    const fieldName =
+      getValidationFieldName(item.loc) ||
+      getValidationFieldName(item.location) ||
+      getValidationFieldName(item.field) ||
+      getValidationFieldName(item.path) ||
+      getValidationFieldName(item.param);
+
+    const message =
+      extractApiMessage(item.msg) ||
+      extractApiMessage(item.message) ||
+      extractApiMessage(item.detail) ||
+      extractApiMessage(item.error);
+
+    if (fieldName && message) {
+      accumulator[fieldName] = message;
+    }
+
+    return accumulator;
+  }, {});
+};
+
+const isFieldErrorObject = (value) => {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  return Object.keys(value).some(
+    (key) => !["message", "detail", "details", "error", "errors", "status", "code"].includes(key),
+  );
+};
+
+const extractApiErrors = (value) => {
+  if (!isPlainObject(value)) {
+    if (Array.isArray(value)) {
+      return normalizeValidationErrors(value);
+    }
+
+    return {};
+  }
+
+  const candidates = [value.errors, value.details, value.error];
+
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) {
+      const normalizedErrors = normalizeValidationErrors(candidate);
+      if (Object.keys(normalizedErrors).length > 0) {
+        return normalizedErrors;
+      }
+    }
+
+    if (isFieldErrorObject(candidate)) {
+      return candidate;
+    }
+
+    if (isPlainObject(candidate)) {
+      const nestedErrors = extractApiErrors(candidate);
+      if (Object.keys(nestedErrors).length > 0) {
+        return nestedErrors;
+      }
+    }
+  }
+
+  return {};
+};
+
 export const apiRequest = async (path, options = {}) => {
   const { method = "GET", body, token, headers = {}, signal } = options;
 
@@ -120,19 +244,13 @@ export const normalizeApiError = (error) => {
   const data = error.data ?? error.response?.data ?? null;
 
   const message =
-    (data &&
-      typeof data === "object" &&
-      typeof data.message === "string" &&
-      data.message) ||
+    extractApiMessage(data) ||
     (typeof error.message === "string" && error.message) ||
     "Something went wrong";
 
   const errors =
-    (data &&
-      typeof data === "object" &&
-      typeof data.errors === "object" &&
-      data.errors) ||
-    (typeof error.errors === "object" && error.errors) ||
+    extractApiErrors(data) ||
+    (isFieldErrorObject(error.errors) && error.errors) ||
     {};
 
   return {


### PR DESCRIPTION
Updated the shared client normalizer in apiClient.js and apiClient.js so it now prefers `detail` and `message`, preserves structured field errors from `errors`, `details`, or `error`, and maps FastAPI-style validation arrays into field-name objects instead of dropping them. I also added regression coverage in apiClient.test.js for plain-text responses, FastAPI detail payloads, nested error objects, and array validation payloads.

closes #1046