### PR TITLE
feat: opt-in Socket.IO per-socket rate limiter with warnings & cooldown

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,19 @@ AUTH_LIMIT_MAX=5
 RESUME_LIMIT_WINDOW=3600000
 RESUME_LIMIT_MAX=10
 
+# Socket rate limiting (per-socket sliding window)
+# `SOCKET_RATE_WINDOW_MS` - time window in milliseconds
+# `SOCKET_RATE_MAX_EVENTS` - max events allowed per socket within the window
+SOCKET_RATE_WINDOW_MS=10000
+SOCKET_RATE_MAX_EVENTS=50
+# Comma-separated event names to ignore from rate limiting (e.g. heartbeats)
+SOCKET_RATE_WHITELIST=ping,pong,connect,disconnect,error
+SOCKET_RATE_ENABLED=true
+# Percentage of max events when the server emits a `rate_warning` event (0-100)
+SOCKET_RATE_WARNING_PERCENT=80
+# Minimum milliseconds between successive `rate_warning` events sent to the same socket
+SOCKET_RATE_WARNING_COOLDOWN_MS=5000
+
 # Frontend URL (used for OAuth callback redirect)
 FRONTEND_URL=http://localhost:5174
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -271,6 +271,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -577,6 +578,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -598,6 +600,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -619,6 +622,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1016,6 +1020,7 @@
     "node_modules/@redis/client": {
       "version": "5.12.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -1398,6 +1403,7 @@
     "node_modules/@types/node": {
       "version": "18.19.130",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1417,8 +1423,7 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/raf": {
       "version": "3.4.3",
@@ -1705,6 +1710,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2127,6 +2133,7 @@
     "node_modules/bare-events": {
       "version": "2.8.3",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -2435,6 +2442,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3108,8 +3116,7 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -3938,6 +3945,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4326,6 +4334,7 @@
     "node_modules/express": {
       "version": "4.22.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4805,6 +4814,7 @@
     "node_modules/gcp-metadata": {
       "version": "5.3.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "gaxios": "^5.0.0",
         "json-bigint": "^1.0.0"
@@ -6019,6 +6029,7 @@
       "version": "1.21.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6045,6 +6056,7 @@
       "version": "24.1.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -6481,7 +6493,6 @@
     "node_modules/marked": {
       "version": "14.0.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -6657,7 +6668,6 @@
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -6666,7 +6676,6 @@
     "node_modules/monaco-editor/node_modules/dompurify": {
       "version": "3.2.7",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -7815,6 +7824,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8154,6 +8164,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8164,6 +8175,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8180,6 +8192,7 @@
     "node_modules/react-redux": {
       "version": "9.3.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -8355,7 +8368,8 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -8518,6 +8532,7 @@
     "node_modules/rollup": {
       "version": "4.60.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9618,6 +9633,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10159,6 +10175,7 @@
     "node_modules/vite": {
       "version": "5.4.21",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -10679,6 +10696,7 @@
     "node_modules/ws": {
       "version": "8.20.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10744,6 +10762,7 @@
     "node_modules/yaml": {
       "version": "2.0.0-1",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -10859,7 +10878,8 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "nodemon": "^3.1.14"
+        "nodemon": "^3.1.14",
+        "socket.io-client": "^4.8.3"
       }
     },
     "server/node_modules/ws": {

--- a/server/index.js
+++ b/server/index.js
@@ -49,6 +49,7 @@ import roadmapRoutes from "./src/modules/roadmap/routes.js";
 import { initRoadmapSockets } from "./src/modules/roadmap/socket.js";
 import userRoutes from "./src/modules/users/routes.js";
 import { setIO } from "./src/utils/socketIO.js";
+import attachSocketRateLimiter from "./src/middleware/socketRateLimiter.js";
 
 const app = express();
 if (process.env.TRUST_PROXY === "true") {
@@ -109,6 +110,8 @@ io.use(async (socket, next) => {
 });
 
 setIO(io);
+// Attach per-socket rate limiter to protect against message floods
+attachSocketRateLimiter(io);
 
 app.use(compression());
 app.use(

--- a/server/package.json
+++ b/server/package.json
@@ -37,6 +37,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "nodemon": "^3.1.14"
+    "nodemon": "^3.1.14",
+    "socket.io-client": "^4.8.3"
   }
 }

--- a/server/src/config/validateEnv.js
+++ b/server/src/config/validateEnv.js
@@ -335,6 +335,40 @@ export const validateExternalApiKeys = (env = process.env) => {
   return { errors, warnings };
 };
 
+export const validateSocketRateLimiterConfig = (env = process.env) => {
+  const errors = [];
+  const warnings = [];
+  const production = isProduction(env);
+
+  const maybeInt = (name) => {
+    const v = env[name];
+    if (isBlank(v)) return null;
+    const n = Number(v);
+    if (!Number.isFinite(n) || n < 0) {
+      addIssue(production ? errors : warnings, name, `must be a non-negative integer.`);
+      return null;
+    }
+    return Math.floor(n);
+  };
+
+  const windowMs = maybeInt("SOCKET_RATE_WINDOW_MS");
+  const maxEvents = maybeInt("SOCKET_RATE_MAX_EVENTS");
+  const warningPercent = maybeInt("SOCKET_RATE_WARNING_PERCENT");
+  const warningCooldown = maybeInt("SOCKET_RATE_WARNING_COOLDOWN_MS");
+
+  if (windowMs !== null && windowMs <= 0) addIssue(production ? errors : warnings, "SOCKET_RATE_WINDOW_MS", "must be greater than 0");
+  if (maxEvents !== null && maxEvents <= 0) addIssue(production ? errors : warnings, "SOCKET_RATE_MAX_EVENTS", "must be greater than 0");
+  if (warningPercent !== null && (warningPercent < 0 || warningPercent > 100)) addIssue(production ? errors : warnings, "SOCKET_RATE_WARNING_PERCENT", "must be between 0 and 100");
+  if (warningCooldown !== null && warningCooldown < 0) addIssue(production ? errors : warnings, "SOCKET_RATE_WARNING_COOLDOWN_MS", "must be non-negative");
+
+  const enabled = env.SOCKET_RATE_ENABLED;
+  if (!isBlank(enabled) && !["true", "false"].includes(String(enabled).toLowerCase())) {
+    addIssue(production ? errors : warnings, "SOCKET_RATE_ENABLED", "must be 'true' or 'false'");
+  }
+
+  return { errors, warnings };
+};
+
 export const collectEnvValidationIssues = (env = process.env) => {
   const checks = [
     validateRequiredEnv,
@@ -343,6 +377,7 @@ export const collectEnvValidationIssues = (env = process.env) => {
     validateEmailConfig,
     validateExternalApiKeys,
     validateFileSigningSecret,
+    validateSocketRateLimiterConfig,
   ];
 
   return checks.reduce(

--- a/server/src/middleware/socketRateLimiter.js
+++ b/server/src/middleware/socketRateLimiter.js
@@ -1,0 +1,79 @@
+const DEFAULT_WINDOW_MS = parseInt(process.env.SOCKET_RATE_WINDOW_MS, 10) || 10000;
+const DEFAULT_MAX_EVENTS = parseInt(process.env.SOCKET_RATE_MAX_EVENTS, 10) || 50;
+const WHITELIST = new Set(
+  (process.env.SOCKET_RATE_WHITELIST || "ping,pong,connect,disconnect,error")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+
+const ENABLED = process.env.SOCKET_RATE_ENABLED !== "false";
+const WARNING_PERCENT = parseInt(process.env.SOCKET_RATE_WARNING_PERCENT, 10) || 80;
+const WARNING_COOLDOWN_MS = parseInt(process.env.SOCKET_RATE_WARNING_COOLDOWN_MS, 10) || 5000;
+
+export function attachSocketRateLimiter(io) {
+  if (!ENABLED) {
+    console.info("Socket rate limiter disabled via SOCKET_RATE_ENABLED=false");
+    return;
+  }
+  const state = new Map();
+  const maxEvents = DEFAULT_MAX_EVENTS;
+  const windowMs = DEFAULT_WINDOW_MS;
+  const refillRatePerMs = maxEvents / windowMs;
+  const warningThreshold = Math.max(1, Math.floor((WARNING_PERCENT / 100) * maxEvents));
+
+  function refillTokens(entry, now) {
+    const elapsed = Math.max(0, now - entry.lastRefill);
+    entry.tokens = Math.min(maxEvents, entry.tokens + elapsed * refillRatePerMs);
+    entry.lastRefill = now;
+  }
+
+  io.on("connection", (socket) => {
+    state.set(socket.id, { tokens: maxEvents, lastRefill: Date.now(), warned: false, lastWarning: 0 });
+
+    socket.onAny((event) => {
+      try {
+        if (WHITELIST.has(event)) return;
+
+        const entry = state.get(socket.id);
+        if (!entry) return;
+
+        refillTokens(entry, Date.now());
+
+        if (entry.tokens >= 1) {
+          entry.tokens -= 1;
+          // Reset warned flag when tokens climb back above threshold
+          if (entry.warned && entry.tokens >= warningThreshold) entry.warned = false;
+          // Emit a soft warning when nearing limit
+          const now = Date.now();
+          if (!entry.warned && entry.tokens < warningThreshold) {
+            const sinceLast = now - (entry.lastWarning || 0);
+            if (sinceLast >= WARNING_COOLDOWN_MS) {
+              entry.warned = true;
+              entry.lastWarning = now;
+              try {
+                socket.emit("rate_warning", { remaining: Math.floor(entry.tokens), threshold: warningThreshold });
+              } catch (e) {}
+            }
+          }
+          return;
+        }
+
+        console.warn(`Socket ${socket.id} rate-limited (events in ${windowMs}ms > ${maxEvents})`);
+        try {
+          socket.emit("rate_limited", {
+            message: "Too many events sent in a short period. Connection will be closed.",
+          });
+        } catch (e) {}
+
+        socket.disconnect(true);
+      } catch (err) {
+        console.error("[socketRateLimiter] error:", err);
+      }
+    });
+
+    socket.on("disconnect", () => state.delete(socket.id));
+  });
+}
+
+export default attachSocketRateLimiter;

--- a/server/test/socketRateLimiter.test.js
+++ b/server/test/socketRateLimiter.test.js
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'assert';
+import http from 'http';
+import { Server } from 'socket.io';
+import { io as Client } from 'socket.io-client';
+
+// Set small limits for the test before importing the limiter module
+process.env.SOCKET_RATE_MAX_EVENTS = process.env.SOCKET_RATE_MAX_EVENTS || '10';
+process.env.SOCKET_RATE_WINDOW_MS = process.env.SOCKET_RATE_WINDOW_MS || '1000';
+process.env.SOCKET_RATE_WARNING_PERCENT = process.env.SOCKET_RATE_WARNING_PERCENT || '50';
+process.env.SOCKET_RATE_WARNING_COOLDOWN_MS = process.env.SOCKET_RATE_WARNING_COOLDOWN_MS || '50';
+process.env.SOCKET_RATE_ENABLED = 'true';
+
+import attachSocketRateLimiter from '../src/middleware/socketRateLimiter.js';
+
+test('socket rate limiter warns then disconnects on flood', async () => {
+  const server = http.createServer();
+  const io = new Server(server, { cors: { origin: '*' } });
+  attachSocketRateLimiter(io);
+
+  await new Promise((res) => server.listen(0, res));
+  const { port } = server.address();
+
+  const client = Client(`http://localhost:${port}`, { transports: ['websocket'], reconnection: false });
+
+  await new Promise((resolve, reject) => {
+    client.on('connect', resolve);
+    client.on('connect_error', reject);
+  });
+
+  let gotWarning = false;
+  let gotLimited = false;
+  let disconnected = false;
+
+  client.on('rate_warning', () => { gotWarning = true; });
+  client.on('rate_limited', () => { gotLimited = true; });
+  client.on('disconnect', () => { disconnected = true; });
+
+  try {
+    // Flood with more events than allowed
+    for (let i = 0; i < 200; i++) client.emit('test_event', { i });
+
+    // Wait up to 5s for a disconnect (preferred) or rate events
+    const ok = await new Promise((resolve) => {
+      const deadline = Date.now() + 5000;
+      (function loop() {
+        if (disconnected) return resolve(true);
+        if ((gotWarning || gotLimited) && disconnected) return resolve(true);
+        if (Date.now() > deadline) return resolve(false);
+        setTimeout(loop, 50);
+      })();
+    });
+
+    assert.ok(ok, 'Expected disconnect and/or rate events during flood');
+  } finally {
+    try { client.disconnect(); } catch (e) {}
+    try { io.close(); } catch (e) {}
+    try { server.close(); } catch (e) {}
+  }
+});


### PR DESCRIPTION
## Summary

Add an opt-in Socket.IO per-socket rate limiter to protect from message floods, with a soft rate_warning and cooldown before rate_limited disconnect. Add env validation and an integration test.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #1051 

## Changes Made

* Added an optional token-bucket socket rate limiter in `server/src/middleware/socketRateLimiter.js`.

* Added pre-disconnect `rate_warning` events with cooldown support via:

  * `SOCKET_RATE_WARNING_COOLDOWN_MS`
  * `SOCKET_RATE_WARNING_PERCENT`

* Added `SOCKET_RATE_ENABLED` flag to enable/disable the limiter (enabled by default).

* Added environment variable validation for all limiter-related configs in `server/src/config/validateEnv.js`.

* Added an integration test (`server/test/socketRateLimiter.test.js`) that simulates socket flooding and verifies limiter behavior.

* Updated `.env.example` with all new limiter environment variables and default values.

* Added `socket.io-client` as a dev dependency for integration testing in `server/package.json`.

* Removed temporary helper logger file to keep the implementation surface minimal and clean.

## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated
