### PR TITLE
test(server): fix tutor analytics and auth validation OTP tests

### DIFF
--- a/server/src/modules/analytics/__tests__/controller.test.js
+++ b/server/src/modules/analytics/__tests__/controller.test.js
@@ -53,12 +53,9 @@ describe("analytics controller", () => {
   });
 
   it("includes the role field in tutor dashboard analytics data", async () => {
-    mock.method(InterviewSession, "find", () => ({
-      lean: mock.fn(async () => [
-        { overallScore: 70 },
-        { overallScore: 90 },
-      ]),
-    }));
+    mock.method(InterviewSession, "aggregate", async () => [
+      { averagePlatformScore: 80, totalMockInterviewsCompleted: 2 },
+    ]);
     mock.method(LearningProgress, "countDocuments", async () => 9);
 
     const req = { user: { _id: "tutor-1", role: "tutor" } };

--- a/server/src/validations/__tests__/authValidation.test.js
+++ b/server/src/validations/__tests__/authValidation.test.js
@@ -165,7 +165,7 @@ describe("auth validation", () => {
       ["OTP with internal space", "12 456"],
       ["OTP with special characters", "!@#$%^"],
       ["six-character SQL-looking input", "admin'"],
-      ["six-character prototype-looking input", "__pro"],
+      ["six-character prototype-looking input", "__prot"],
     ];
 
     for (const [name, otp] of currentlyAcceptedOtps) {


### PR DESCRIPTION

## Summary

Fixes the tutor dashboard analytics test and OTP validation unit tests on the server by aligning the mocked database methods with actual aggregation pipelines and correcting length constraints in test payloads.

## Type of Change


- [x] Bug fix


## Related Issue

Closes #1053

## Changes Made

- **Analytics Test (`controller.test.js`)**: Mocked `InterviewSession.aggregate` instead of `find` to match the query pattern used in the controller.
- **Auth Validation Test (`authValidation.test.js`)**: Corrected dummy OTP test payload from `"__pro"` (5 chars) to `"__prot"` (6 chars) to satisfy the 6-character length constraint schema.

## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated
