### PR TITLE
fix: redact secret logging in scripts (fix #1066)

### DIFF
--- a/check_db.cjs
+++ b/check_db.cjs
@@ -4,6 +4,7 @@ require("dotenv").config({ path: "server/.env" });
 mongoose.connect(process.env.MONGO_URI).then(async () => {
   const users = await mongoose.connection.collection("users").find({ email: /testauth/i }).toArray();
   console.log("Found users:");
-  users.forEach(u => console.log(u.email, u.name, "has password:", !!u.password));
+  // Avoid printing password presence or any sensitive fields.
+  users.forEach(u => console.log(u.email, u.name));
   process.exit(0);
 });

--- a/test_decrypt.cjs
+++ b/test_decrypt.cjs
@@ -1,4 +1,5 @@
 const { decrypt } = require("./server/src/utils/encryption.js");
 require("dotenv").config({ path: "server/.env" });
-const ciphertext = "v1:gcm:a02a19ae8a0e138cf430b563:58cf1207bab9460a08737686f7eda382:0:f1b8a514d7c865db2650080fb05fcecb"; // Just an example, let's just see if getEncryptionKey is consistent.
-console.log(process.env.JWT_SECRET);
+const ciphertext = "v1:gcm:a02a19ae8a0e138cf430b563:58cf1207bab9460a08737686f7eda382:0:f1b8a514d7c865db2650080fb05fcecb"; // Example ciphertext.
+// Avoid printing secrets to stdout. Log only presence of the secret.
+console.log("JWT_SECRET set:", !!process.env.JWT_SECRET);


### PR DESCRIPTION
This PR redacts secret logging in test scripts to avoid leaking sensitive environment variables and user data into logs.

Files changed:
- `test_decrypt.cjs`: avoid printing `JWT_SECRET`, only logs presence.
- `check_db.cjs`: stop printing password presence; only prints email and name.

Closes #1066.