### PR TITLE
fix: remove duplicate notification route registrations

### DIFF
--- a/server/src/modules/notifications/routes.js
+++ b/server/src/modules/notifications/routes.js
@@ -28,8 +28,6 @@ router.get("/:id", getNotification);
 
 router.patch("/:id/read", markAsRead);
 
-router.patch("/mark-all/read", markAllAsRead);
-router.patch("/:id/read", markAsRead);
 router.delete("/:id", deleteNotificationById);
 
 router.delete("/", deleteAllNotificationsForUser);


### PR DESCRIPTION
## 🚀 Description

This PR removes duplicate route registrations in the Notifications module.

### Issue

The notification router contained duplicate registrations for the following endpoints:

```js
router.patch("/mark-all/read", markAllAsRead);
router.patch("/:id/read", markAsRead);
```

The second registrations were duplicates of existing route definitions and provided no additional functionality.

### Changes Made

* Removed duplicate `PATCH /mark-all/read` route registration.
* Removed duplicate `PATCH /:id/read` route registration.
* Preserved the original route definitions and existing route order.

### Why This Fix Is Needed

Registering identical Express routes multiple times can:

* Create unnecessary route matching overhead.
* Cause duplicate middleware execution in future modifications.
* Make routing behavior harder to maintain and debug.
* Introduce confusion for contributors working on the notifications module.

### Why This Fix Is Safe

No functionality was changed.

All notification endpoints remain available exactly once:

* `GET /`
* `GET /unread-count`
* `POST /`
* `PATCH /mark-all/read`
* `GET /:id`
* `PATCH /:id/read`
* `DELETE /:id`
* `DELETE /`

No handlers, middleware, controller logic, or response behavior were modified.

### Verification

* Confirmed duplicate route registrations were removed.
* Verified notification routes remain intact.
* Started the backend successfully and confirmed normal server startup.
* Reviewed routing configuration to ensure each endpoint is registered only once.

### Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

### Checklist

* [x] Code follows project guidelines
* [x] Self-review completed
* [x] No unrelated files modified
* [x] Existing functionality preserved
* [x] Bug fix only (no new features)

### Testing

1. Start the backend server.
2. Access notification endpoints:

   * `GET /api/notifications`
   * `GET /api/notifications/unread-count`
   * `PATCH /api/notifications/mark-all/read`
   * `PATCH /api/notifications/:id/read`
3. Confirm all endpoints function normally.
4. Verify route definitions exist only once in the router configuration.
