### PR TITLE
refactor: deconstruct monolithic InterviewSession page into hooks and…

### DIFF
--- a/client/src/modules/mock-interview/components/AnswerInputSection.jsx
+++ b/client/src/modules/mock-interview/components/AnswerInputSection.jsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { AlertCircle, MicOff, Mic, Loader2, Send } from "lucide-react";
+
+export const AnswerInputSection = ({
+  isObserver,
+  textareaRef,
+  liveTyping,
+  answer,
+  onChange,
+  onKeyDown,
+  submitting,
+  error,
+  failedAction,
+  onRetry,
+  isRecording,
+  startRecording,
+  stopRecording,
+  onSubmit,
+  requestStatus,
+}) => {
+  const getWordCount = (text) => {
+    return text.trim().split(/\s+/).filter(Boolean).length;
+  };
+
+  return (
+    <div className="bg-white dark:bg-slate-900 rounded-3xl p-6 sm:p-8 shadow-sm border border-slate-200 dark:border-white/10 flex flex-col">
+      {isObserver ? (
+        <div className="w-full bg-slate-50 dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 h-56 overflow-y-auto">
+          <span className="text-xs font-bold uppercase tracking-widest text-emerald-600 dark:text-emerald-500 mb-4 flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse"></span> Candidate Typing
+          </span>
+          <p className="text-base text-slate-700 dark:text-slate-300 font-mono leading-relaxed whitespace-pre-wrap">
+            {liveTyping || <span className="text-slate-400 italic">Waiting for input...</span>}
+          </p>
+        </div>
+      ) : (
+        <textarea
+          ref={textareaRef}
+          className="w-full bg-slate-50 dark:bg-slate-950 border border-slate-200 dark:border-white/5 rounded-2xl p-6 text-slate-900 dark:text-slate-100 text-lg leading-relaxed resize-y min-h-[180px] focus:outline-none focus:border-blue-500 dark:focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 placeholder:text-slate-400 dark:placeholder:text-slate-600 transition-all shadow-inner"
+          placeholder="Type your answer here... (Ctrl+Enter to submit)"
+          value={answer}
+          onChange={onChange}
+          onKeyDown={onKeyDown}
+          disabled={submitting}
+          rows={5}
+        />
+      )}
+      
+      <div className="flex flex-col sm:flex-row items-center justify-between mt-6 gap-4">
+        <div className="flex items-center gap-4 w-full sm:w-auto">
+          <span className="text-sm font-semibold text-slate-500 dark:text-slate-400">
+            {isObserver ? getWordCount(liveTyping) : getWordCount(answer)} words
+          </span>
+          {error && (
+            <span className="text-sm font-semibold text-red-500 flex flex-wrap items-center gap-1.5 bg-red-50 dark:bg-red-500/10 px-3 py-1 rounded-lg">
+              <AlertCircle size={16} /> {error}
+              {failedAction && (
+                <button
+                  type="button"
+                  onClick={onRetry}
+                  disabled={submitting || Boolean(requestStatus)}
+                  className="ml-2 underline underline-offset-2 disabled:opacity-50 bg-transparent border-none cursor-pointer text-red-500 font-bold"
+                >
+                  Retry
+                </button>
+              )}
+            </span>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 w-full sm:w-auto">
+          {!isObserver && (
+            <button
+              className={`flex-1 sm:flex-none flex items-center justify-center gap-2 px-6 py-3.5 rounded-xl font-bold transition-all border-none cursor-pointer ${
+                isRecording 
+                  ? "bg-red-100 dark:bg-red-500/20 text-red-600 dark:text-red-400 border border-red-200 dark:border-red-500/30 animate-[pulse_1.5s_ease-in-out_infinite]" 
+                  : "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700"
+              }`}
+              onClick={isRecording ? stopRecording : startRecording}
+              disabled={submitting || Boolean(requestStatus)}
+            >
+              {isRecording ? <><MicOff size={18} /> Stop</> : <><Mic size={18} /> Record</>}
+            </button>
+          )}
+
+          {!isObserver && (
+            <button
+              className="flex-1 sm:flex-none flex items-center justify-center gap-2 px-8 py-3.5 rounded-xl font-bold text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all shadow-lg hover:shadow-blue-500/25 hover:-translate-y-0.5 border-none cursor-pointer"
+              onClick={onSubmit}
+              disabled={!answer.trim() || submitting || Boolean(requestStatus)}
+            >
+              {submitting ? (
+                <><Loader2 className="animate-spin" size={18} /> Evaluating</>
+              ) : (
+                <><Send size={18} /> Submit</>
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+export default AnswerInputSection;

--- a/client/src/modules/mock-interview/hooks/useInterviewAudio.js
+++ b/client/src/modules/mock-interview/hooks/useInterviewAudio.js
@@ -1,0 +1,141 @@
+import { useState, useRef, useCallback } from "react";
+import logger from "../../../utils/logger";
+
+export const useInterviewAudio = ({
+  sessionId,
+  socket,
+  socketStatus,
+  setUploadStatus,
+  setError,
+  setMediaWarning,
+  persistBackup,
+  setRecoveryMessage,
+  setFailedAction,
+}) => {
+  const [isRecording, setIsRecording] = useState(false);
+  const mediaRecorderRef = useRef(null);
+  const mediaStreamRef = useRef(null);
+  const mediaTrackCleanupRef = useRef([]);
+
+  const clearMediaTrackListeners = useCallback(() => {
+    mediaTrackCleanupRef.current.forEach((cleanup) => cleanup());
+    mediaTrackCleanupRef.current = [];
+  }, []);
+
+  const attachMediaTrackListeners = useCallback(
+    (stream) => {
+      clearMediaTrackListeners();
+      const handleEnded = () => {
+        setIsRecording(false);
+        setUploadStatus("failed");
+        setFailedAction("media");
+        setMediaWarning(
+          "Audio input was disconnected. Your answer is saved, and you can retry the microphone.",
+        );
+        persistBackup({ uploadStatus: "failed" });
+      };
+
+      stream.getTracks().forEach((track) => {
+        track.addEventListener("ended", handleEnded);
+        mediaTrackCleanupRef.current.push(() => {
+          track.removeEventListener("ended", handleEnded);
+        });
+      });
+    },
+    [clearMediaTrackListeners, persistBackup, setMediaWarning, setUploadStatus],
+  );
+
+  const startRecording = async () => {
+    try {
+      setMediaWarning(null);
+      setError(null);
+      setFailedAction(null);
+      setUploadStatus("starting");
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mediaRecorder = new MediaRecorder(stream, { mimeType: "audio/webm" });
+      mediaRecorderRef.current = mediaRecorder;
+      mediaStreamRef.current = stream;
+      attachMediaTrackListeners(stream);
+
+      if (socket && socketStatus === "connected") {
+        socket.emit("start-audio-stream", { sessionId });
+      }
+
+      mediaRecorder.ondataavailable = (event) => {
+        try {
+          if (event.data.size > 0 && socket && socketStatus === "connected") {
+            setUploadStatus("uploading");
+            socket.emit("audio-chunk", { sessionId, chunk: event.data });
+          } else if (event.data.size > 0) {
+            setUploadStatus("queued");
+            setRecoveryMessage("Audio upload paused until the connection recovers.");
+          }
+        } catch (err) {
+          setUploadStatus("failed");
+          setError("Audio upload failed. Your typed answer is still saved.");
+          logger.error("[InterviewSessionAudio] Audio chunk error:", err);
+        }
+      };
+
+      mediaRecorder.onerror = (event) => {
+        setUploadStatus("failed");
+        setFailedAction("media");
+        setError("Recording failed. Your answer is saved, and you can retry recording.");
+        logger.error("[InterviewSessionAudio] Media recorder error:", event.error || event);
+      };
+
+      mediaRecorder.onstop = () => {
+        setUploadStatus((status) => (status === "failed" ? "failed" : "idle"));
+      };
+
+      mediaRecorder.start(1000);
+      setIsRecording(true);
+      setUploadStatus("uploading");
+      persistBackup({ uploadStatus: "uploading" });
+    } catch (err) {
+      logger.error("Error accessing microphone:", err);
+      setIsRecording(false);
+      setUploadStatus("failed");
+      setFailedAction("media");
+      setMediaWarning("Microphone access was denied or unavailable. Check your device and retry.");
+      setError("Microphone access denied or unavailable.");
+      persistBackup({ uploadStatus: "failed" });
+    }
+  };
+
+  const stopRecording = useCallback(() => {
+    if (mediaRecorderRef.current && mediaRecorderRef.current.state !== "inactive") {
+      mediaRecorderRef.current.stop();
+      mediaRecorderRef.current.stream.getTracks().forEach((track) => track.stop());
+    }
+    clearMediaTrackListeners();
+    mediaStreamRef.current = null;
+    if (socket && socketStatus === "connected") {
+      socket.emit("end-audio-stream", { sessionId });
+    }
+    setUploadStatus("idle");
+    setIsRecording(false);
+  }, [clearMediaTrackListeners, sessionId, socket, socketStatus, setUploadStatus]);
+
+  const cleanupAudio = useCallback(() => {
+    if (mediaRecorderRef.current) {
+      if (mediaRecorderRef.current.state !== "inactive") {
+        mediaRecorderRef.current.stop();
+      }
+      if (mediaRecorderRef.current.stream) {
+        mediaRecorderRef.current.stream.getTracks().forEach((track) => track.stop());
+      }
+    }
+    clearMediaTrackListeners();
+    if (socket && socketStatus === "connected") {
+      socket.emit("end-audio-stream", { sessionId });
+    }
+  }, [clearMediaTrackListeners, sessionId, socket, socketStatus]);
+
+  return {
+    isRecording,
+    startRecording,
+    stopRecording,
+    cleanupAudio,
+  };
+};

--- a/client/src/modules/mock-interview/hooks/useInterviewSocket.js
+++ b/client/src/modules/mock-interview/hooks/useInterviewSocket.js
@@ -1,0 +1,202 @@
+import { useState, useEffect, useRef } from "react";
+import { io } from "socket.io-client";
+import { SOCKET_URL } from "../../../config/env";
+import { loadInterviewSession } from "../../../utils/interviewSessionStorage";
+import logger from "../../../utils/logger";
+
+const TOKEN_KEY = "skillssphere.auth.token";
+
+export const useInterviewSocket = ({
+  sessionId,
+  user,
+  session,
+  isObserver,
+  elapsedTime,
+  uploadStatus,
+  setAnswer,
+  setError,
+  setSubmitting,
+  setUploadStatus,
+  setRecoveryMessage,
+  handleEvaluationResult,
+  persistBackup,
+  textareaRef,
+  setFailedAction,
+}) => {
+  const [socket, setSocket] = useState(null);
+  const [participants, setParticipants] = useState([]);
+  const [liveTyping, setLiveTyping] = useState("");
+  const [socketStatus, setSocketStatus] = useState("connecting");
+  
+  const messageQueue = useRef([]);
+  const wasConnected = useRef(false);
+
+  useEffect(() => {
+    if (!session || !user) return;
+    const token = localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY);
+    
+    const newSocket = io(SOCKET_URL, {
+      auth: { token },
+      reconnection: true,
+      reconnectionAttempts: 10,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 5000
+    });
+
+    const handleConnect = () => {
+      setSocketStatus("connected");
+      newSocket.emit("join-interview", { sessionId });
+      
+      if (wasConnected.current) {
+        const savedSession = loadInterviewSession();
+        if (savedSession && savedSession.sessionId === sessionId) {
+          newSocket.emit("rehydrate-interview", {
+            sessionId,
+            currentIndex: savedSession.currentIndex,
+            previousMessages: savedSession.messages,
+            activeTopic: session?.topic,
+            lastAiResponse: session?.answers?.[savedSession.currentIndex]?.questionText,
+            elapsedTime: savedSession.elapsedTime,
+            uploadStatus: savedSession.uploadStatus,
+          });
+          setRecoveryMessage("Reconnected and resynced interview progress.");
+          setTimeout(() => setRecoveryMessage(null), 3000);
+          
+          if (messageQueue.current.length > 0) {
+            messageQueue.current.forEach(msg => newSocket.emit("submit-answer", msg));
+            messageQueue.current = [];
+            setUploadStatus("submitted");
+          }
+        }
+      }
+      wasConnected.current = true;
+    };
+
+    const handleDisconnect = () => {
+      setSocketStatus("disconnected");
+      setRecoveryMessage("Connection lost. Your answer is saved locally.");
+      persistBackup();
+    };
+
+    const handleReconnectAttempt = () => {
+      setSocketStatus("reconnecting");
+      setRecoveryMessage("Reconnecting to the interview room...");
+    };
+
+    const handleParticipants = (pts) => {
+      setParticipants(pts.filter(p => p.user.id !== user._id));
+    };
+
+    const handleParticipantJoined = (data) => {
+      setParticipants(prev => [...prev.filter(p => p.socketId !== data.socketId), data]);
+    };
+
+    const handleParticipantLeft = (data) => {
+      setParticipants(prev => prev.filter(p => p.socketId !== data.socketId));
+    };
+
+    const handleTyping = ({ text }) => {
+      setLiveTyping(text);
+    };
+
+    const handleAnswerEvaluated = (data) => {
+      handleEvaluationResult(data, textareaRef);
+      setUploadStatus("idle");
+    };
+
+    const handleLiveTranscript = (data) => {
+      if (data.transcript) {
+        setAnswer((prev) => (prev ? prev + " " + data.transcript : data.transcript));
+      }
+    };
+
+    const handleEvaluationError = (err) => {
+      setError(err.message || "Failed to submit answer.");
+      setUploadStatus("failed");
+      setFailedAction("submit");
+      logger.error("[InterviewSessionSocket] Evaluation error:", err);
+      setSubmitting(false);
+    };
+
+    newSocket.on("connect", handleConnect);
+    newSocket.on("disconnect", handleDisconnect);
+    newSocket.io.on("reconnect_attempt", handleReconnectAttempt);
+    newSocket.on("interview-participants", handleParticipants);
+    newSocket.on("participant-joined", handleParticipantJoined);
+    newSocket.on("participant-left", handleParticipantLeft);
+    newSocket.on("interview-typing", handleTyping);
+    newSocket.on("answer-evaluated", handleAnswerEvaluated);
+    newSocket.on("live-transcript", handleLiveTranscript);
+    newSocket.on("evaluation-error", handleEvaluationError);
+
+    setSocket(newSocket);
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        if (newSocket && newSocket.disconnected) {
+          newSocket.connect();
+        }
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      newSocket.off("connect", handleConnect);
+      newSocket.off("disconnect", handleDisconnect);
+      newSocket.io.off("reconnect_attempt", handleReconnectAttempt);
+      newSocket.off("interview-participants", handleParticipants);
+      newSocket.off("participant-joined", handleParticipantJoined);
+      newSocket.off("participant-left", handleParticipantLeft);
+      newSocket.off("interview-typing", handleTyping);
+      newSocket.off("answer-evaluated", handleAnswerEvaluated);
+      newSocket.off("live-transcript", handleLiveTranscript);
+      newSocket.off("evaluation-error", handleEvaluationError);
+      
+      newSocket.close();
+    };
+  }, [
+    sessionId,
+    user,
+    session,
+    handleEvaluationResult,
+    persistBackup,
+    setAnswer,
+    setError,
+    setRecoveryMessage,
+    setSubmitting,
+    setUploadStatus,
+    textareaRef,
+    setFailedAction,
+  ]);
+
+  const submitSocketAnswer = (transcript) => {
+    if (socket && socketStatus === "connected") {
+      socket.emit("submit-answer", { sessionId, transcript, audioBuffer: null });
+      return true;
+    } else if (socket && (socketStatus === "disconnected" || socketStatus === "reconnecting")) {
+      messageQueue.current.push({ sessionId, transcript, audioBuffer: null });
+      setUploadStatus("queued");
+      setRecoveryMessage("Offline: answer queued and saved locally.");
+      setTimeout(() => setRecoveryMessage(null), 3000);
+      setSubmitting(false);
+      return true;
+    }
+    return false;
+  };
+
+  const handleSendFeedback = (note) => {
+    if (socket) {
+      socket.emit("save-private-note", { sessionId, note });
+    }
+  };
+
+  return {
+    socket,
+    socketStatus,
+    participants,
+    liveTyping,
+    submitSocketAnswer,
+    handleSendFeedback,
+  };
+};

--- a/client/src/modules/mock-interview/hooks/useInterviewState.js
+++ b/client/src/modules/mock-interview/hooks/useInterviewState.js
@@ -1,0 +1,355 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { submitAnswer, completeInterview } from "../services/interviewService";
+import { apiRequest } from "../../../services/apiClient";
+import {
+  saveInterviewSession,
+  loadInterviewSession,
+  clearInterviewSession
+} from "../../../utils/interviewSessionStorage";
+import { analyzeText, debounce } from "../utils/sentiment";
+import logger from "../../../utils/logger";
+
+const TOKEN_KEY = "skillssphere.auth.token";
+const REQUEST_TIMEOUT_MS = 20000;
+const MAX_RETRY_ATTEMPTS = 3;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const isRecoverableError = (error) => {
+  const status = Number(error?.status || 0);
+  return (
+    error?.name === "AbortError" ||
+    error?.message === "Request timeout" ||
+    status === 0 ||
+    status >= 500
+  );
+};
+
+const withTimeout = async (operation, timeoutMs = REQUEST_TIMEOUT_MS) => {
+  let timeoutId;
+  try {
+    return await Promise.race([
+      operation(),
+      new Promise((_, reject) => {
+        timeoutId = window.setTimeout(() => {
+          const error = new Error("Request timeout");
+          error.status = 0;
+          reject(error);
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+};
+
+const retryRecoverable = async (operation, onRetry) => {
+  let lastError;
+
+  for (let attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      return await withTimeout(operation);
+    } catch (error) {
+      lastError = error;
+      if (!isRecoverableError(error) || attempt === MAX_RETRY_ATTEMPTS) {
+        throw error;
+      }
+
+      const delay = 500 * 2 ** (attempt - 1);
+      onRetry?.(attempt + 1, delay);
+      await sleep(delay);
+    }
+  }
+
+  throw lastError;
+};
+
+export const useInterviewState = (sessionId, isObserver) => {
+  const navigate = useNavigate();
+  const [session, setSession] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [elapsedTime, setElapsedTime] = useState(0);
+  const [currentQuestion, setCurrentQuestion] = useState(null);
+  const [isLastQuestion, setIsLastQuestion] = useState(false);
+  const [lastScores, setLastScores] = useState(null);
+  const [showScores, setShowScores] = useState(false);
+  const [answer, setAnswer] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [completing, setCompleting] = useState(false);
+  const [analysis, setAnalysis] = useState(null);
+  const [requestStatus, setRequestStatus] = useState(null);
+  const [uploadStatus, setUploadStatus] = useState("idle");
+  const [mediaWarning, setMediaWarning] = useState(null);
+  const [recoveryMessage, setRecoveryMessage] = useState(null);
+  const [failedAction, setFailedAction] = useState(null);
+
+  const debouncedAnalyze = useRef(
+    debounce((text) => {
+      setAnalysis(analyzeText(text));
+    }, 500)
+  ).current;
+
+  // Persist backup to LocalStorage
+  const persistBackup = useCallback(
+    (overrides = {}) => {
+      if (!sessionId) return;
+
+      const transcriptMap = session?.answers?.reduce((acc, item, index) => {
+        if (item?.transcript) {
+          acc[index] = item.transcript;
+        }
+        return acc;
+      }, {}) || {};
+
+      saveInterviewSession({
+        sessionId,
+        currentIndex,
+        answer,
+        transcripts: transcriptMap,
+        messages: answer
+          ? [{ role: "candidate", content: answer, timestamp: Date.now() }]
+          : [],
+        elapsedTime,
+        uploadStatus,
+        currentQuestion,
+        ...overrides,
+      });
+    },
+    [
+      answer,
+      currentIndex,
+      currentQuestion,
+      elapsedTime,
+      session,
+      sessionId,
+      uploadStatus,
+    ],
+  );
+
+  // Timer progression
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setElapsedTime((prev) => prev + 1);
+    }, 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  // Sync state with localStorage backup
+  useEffect(() => {
+    if (session && !isObserver) {
+      persistBackup();
+    }
+  }, [session, isObserver, persistBackup]);
+
+  // Load session from API or localStorage rehydration
+  useEffect(() => {
+    if (!sessionId) return;
+
+    const fetchSession = async () => {
+      try {
+        const token =
+          localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY);
+        setRequestStatus("Loading interview session...");
+        const res = await retryRecoverable(
+          () =>
+            apiRequest(`/api/interviews/${sessionId}`, {
+              method: "GET",
+              token,
+            }),
+          (attempt) => setRequestStatus(`Retrying session load (${attempt}/${MAX_RETRY_ATTEMPTS})...`),
+        );
+        const data = res.data;
+        setSession(data);
+
+        let idx = 0;
+        const savedSession = loadInterviewSession();
+        if (savedSession && savedSession.sessionId === sessionId) {
+          idx = Math.min(savedSession.currentIndex, data.answers.length - 1);
+          setElapsedTime(savedSession.elapsedTime || 0);
+          setUploadStatus(savedSession.uploadStatus || "idle");
+          setAnswer(savedSession.answer || savedSession.messages?.at(-1)?.content || "");
+          setRecoveryMessage("Recovered saved interview progress.");
+          setTimeout(() => setRecoveryMessage(null), 3000);
+        } else {
+          const unansweredIdx = data.answers.findIndex(
+            (a) => !a.transcript && !a.scores,
+          );
+          idx = unansweredIdx >= 0 ? unansweredIdx : 0;
+        }
+
+        setCurrentIndex(idx);
+        setCurrentQuestion({
+          questionText: data.answers[idx]?.questionText,
+          questionId: data.answers[idx]?.questionId,
+        });
+        setIsLastQuestion(idx === data.answers.length - 1);
+        
+        saveInterviewSession({
+          sessionId,
+          currentIndex: idx,
+          answer: savedSession?.answer || "",
+          elapsedTime: savedSession?.elapsedTime || 0,
+          uploadStatus: savedSession?.uploadStatus || "idle",
+          currentQuestion: {
+            questionText: data.answers[idx]?.questionText,
+            questionId: data.answers[idx]?.questionId,
+          },
+          messages: savedSession?.messages || [],
+        });
+      } catch (err) {
+        setError(
+          err.message === "Request timeout"
+            ? "The interview session request timed out. Please check your connection and try again."
+            : "Failed to load interview session.",
+        );
+        logger.error("[InterviewSessionState] Fetch Error:", err);
+      } finally {
+        setRequestStatus(null);
+        setLoading(false);
+      }
+    };
+    fetchSession();
+  }, [sessionId]);
+
+  const handleEvaluationResult = useCallback((data, textareaRef) => {
+    setLastScores(data.scores);
+    setShowScores(true);
+    setAnswer("");
+    setSubmitting(false);
+    setRequestStatus(null);
+    setUploadStatus("idle");
+    setFailedAction(null);
+
+    if (data.isLastQuestion) {
+      setIsLastQuestion(true);
+    } else if (data.nextQuestion) {
+      setTimeout(() => {
+        setCurrentQuestion(data.nextQuestion);
+        setCurrentIndex(data.nextQuestion.index);
+        setShowScores(false);
+        setLastScores(null);
+        if (textareaRef?.current) textareaRef.current.focus();
+      }, 3000);
+    }
+  }, []);
+
+  const handleAnswerChange = (e, socket) => {
+    const nextAnswer = e.target.value;
+    setAnswer(nextAnswer);
+    debouncedAnalyze(nextAnswer);
+    
+    persistBackup({
+      answer: nextAnswer,
+      messages: [{ role: "candidate", content: nextAnswer, timestamp: Date.now() }],
+    });
+
+    if (socket && !isObserver) {
+      socket.emit("interview-typing", { sessionId, text: nextAnswer });
+    }
+  };
+
+  const submitAnswerApi = async (textareaRef) => {
+    if (!answer.trim() || submitting || requestStatus) return;
+    const transcript = answer.trim();
+    setSubmitting(true);
+    setError(null);
+    setRequestStatus(null);
+    setUploadStatus("submitting");
+    persistBackup({
+      answer: transcript,
+      uploadStatus: "submitting",
+      messages: [{ role: "candidate", content: transcript, timestamp: Date.now() }],
+    });
+
+    try {
+      const res = await retryRecoverable(
+        () => submitAnswer(sessionId, transcript),
+        (attempt) => setRequestStatus(`Retrying answer submission (${attempt}/${MAX_RETRY_ATTEMPTS})...`),
+      );
+      handleEvaluationResult(res.data, textareaRef);
+    } catch (err) {
+      setUploadStatus("failed");
+      setFailedAction("submit");
+      setError(
+        err.message === "Request timeout"
+          ? "Answer submission timed out. Your answer is saved and can be retried."
+          : err.message || "Failed to submit answer. Your answer is saved and can be retried.",
+      );
+      logger.error("[InterviewSessionState] Submit error:", err);
+      setSubmitting(false);
+      setRequestStatus(null);
+      throw err; // throw so socket handler caller knows
+    }
+  };
+
+  const completeInterviewApi = async () => {
+    if (completing || requestStatus) return;
+    setCompleting(true);
+    setError(null);
+
+    try {
+      await retryRecoverable(
+        () => completeInterview(sessionId),
+        (attempt) => setRequestStatus(`Retrying final submission (${attempt}/${MAX_RETRY_ATTEMPTS})...`),
+      );
+      clearInterviewSession();
+      navigate(`/mock-interview/${sessionId}/results`, { replace: true });
+    } catch (err) {
+      setFailedAction("complete");
+      setError(
+        err.message === "Request timeout"
+          ? "Saving results timed out. Please retry when your connection is stable."
+          : err.message || "Failed to complete interview.",
+      );
+      logger.error("[InterviewSessionState] Complete error:", err);
+      setCompleting(false);
+      setRequestStatus(null);
+      throw err;
+    }
+  };
+
+  return {
+    session,
+    setSession,
+    loading,
+    error,
+    setError,
+    currentIndex,
+    setCurrentIndex,
+    elapsedTime,
+    setElapsedTime,
+    currentQuestion,
+    setCurrentQuestion,
+    isLastQuestion,
+    setIsLastQuestion,
+    lastScores,
+    setLastScores,
+    showScores,
+    setShowScores,
+    answer,
+    setAnswer,
+    submitting,
+    setSubmitting,
+    completing,
+    setCompleting,
+    analysis,
+    requestStatus,
+    setRequestStatus,
+    uploadStatus,
+    setUploadStatus,
+    mediaWarning,
+    setMediaWarning,
+    recoveryMessage,
+    setRecoveryMessage,
+    persistBackup,
+    handleAnswerChange,
+    submitAnswerApi,
+    completeInterviewApi,
+    handleEvaluationResult,
+    failedAction,
+    setFailedAction,
+  };
+};

--- a/client/src/modules/mock-interview/pages/InterviewSession.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewSession.jsx
@@ -1,98 +1,32 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useRef, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
-import { io } from "socket.io-client";
-import { submitAnswer, completeInterview } from "../services/interviewService";
-import { apiRequest } from "../../../services/apiClient";
-import { SOCKET_URL } from "../../../config/env";
+import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
+
+// Hooks
+import { useInterviewState } from "../hooks/useInterviewState";
+import { useInterviewSocket } from "../hooks/useInterviewSocket";
+import { useInterviewAudio } from "../hooks/useInterviewAudio";
+
+// Presentational Components
+import { SessionSidebar } from "../components/SessionSidebar";
+import { AnswerInputSection } from "../components/AnswerInputSection";
 import InterviewSessionSkeleton from "../components/InterviewSessionSkeleton";
 import ObserverPanel from "../components/ObserverPanel";
 import RealtimeSentimentIndicator from "../components/RealtimeSentimentIndicator";
-import { analyzeText, debounce } from "../utils/sentiment";
 import Navbar from "../../../shared/components/Navbar";
 import Footer from "../../../shared/components/Footer";
 
+// Icons & Utilities
 import {
-  saveInterviewSession,
-  loadInterviewSession,
-  clearInterviewSession
-} from "../../../utils/interviewSessionStorage";
-import logger from "../../../utils/logger";
-import {
-  Send,
   CheckCircle,
-  Clock,
-  ChevronRight,
   Trophy,
   Loader2,
   AlertCircle,
   Target,
   MessageSquare,
-  Brain,
-  Mic,
-  MicOff,
-  Activity,
-  Wifi,
-  WifiOff,
-  RefreshCw,
-  Info
+  Brain
 } from "lucide-react";
-import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
-
-const TOKEN_KEY = "skillssphere.auth.token";
-const REQUEST_TIMEOUT_MS = 20000;
-const MAX_RETRY_ATTEMPTS = 3;
-
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-const isRecoverableError = (error) => {
-  const status = Number(error?.status || 0);
-  return (
-    error?.name === "AbortError" ||
-    error?.message === "Request timeout" ||
-    status === 0 ||
-    status >= 500
-  );
-};
-
-const withTimeout = async (operation, timeoutMs = REQUEST_TIMEOUT_MS) => {
-  let timeoutId;
-  try {
-    return await Promise.race([
-      operation(),
-      new Promise((_, reject) => {
-        timeoutId = window.setTimeout(() => {
-          const error = new Error("Request timeout");
-          error.status = 0;
-          reject(error);
-        }, timeoutMs);
-      }),
-    ]);
-  } finally {
-    window.clearTimeout(timeoutId);
-  }
-};
-
-const retryRecoverable = async (operation, onRetry) => {
-  let lastError;
-
-  for (let attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt += 1) {
-    try {
-      return await withTimeout(operation);
-    } catch (error) {
-      lastError = error;
-      if (!isRecoverableError(error) || attempt === MAX_RETRY_ATTEMPTS) {
-        throw error;
-      }
-
-      const delay = 500 * 2 ** (attempt - 1);
-      onRetry?.(attempt + 1, delay);
-      await sleep(delay);
-    }
-  }
-
-  throw lastError;
-};
 
 const InterviewSession = () => {
   useDocumentTitle("Interview Session");
@@ -101,537 +35,86 @@ const InterviewSession = () => {
   const textareaRef = useRef(null);
   const { user } = useSelector((state) => state.auth);
 
-  const [session, setSession] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [answer, setAnswer] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [completing, setCompleting] = useState(false);
-  const [error, setError] = useState(null);
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [lastScores, setLastScores] = useState(null);
-  const [showScores, setShowScores] = useState(false);
-  const [elapsedTime, setElapsedTime] = useState(0);
-  const [isLastQuestion, setIsLastQuestion] = useState(false);
-  const [currentQuestion, setCurrentQuestion] = useState(null);
-  const [analysis, setAnalysis] = useState(null);
-  const [requestStatus, setRequestStatus] = useState(null);
-  const [uploadStatus, setUploadStatus] = useState("idle");
-  const [mediaWarning, setMediaWarning] = useState(null);
+  // 1. Manage State, Timers, Persistence, and API operations
+  const state = useInterviewState(sessionId, false);
+  const isObserver = state.session && user && user._id !== state.session.userId;
 
-  const debouncedAnalyze = useRef(
-    debounce((text) => {
-      setAnalysis(analyzeText(text));
-    }, 500)
-  ).current;
+  // 2. Manage Socket.IO Network Connectivity
+  const socketState = useInterviewSocket({
+    sessionId,
+    user,
+    session: state.session,
+    isObserver,
+    elapsedTime: state.elapsedTime,
+    uploadStatus: state.uploadStatus,
+    setAnswer: state.setAnswer,
+    setError: state.setError,
+    setSubmitting: state.setSubmitting,
+    setUploadStatus: state.setUploadStatus,
+    setRecoveryMessage: state.setRecoveryMessage,
+    handleEvaluationResult: state.handleEvaluationResult,
+    persistBackup: state.persistBackup,
+    textareaRef,
+    setFailedAction: state.setFailedAction,
+  });
 
-  const messageQueue = useRef([]);
-  const wasConnected = useRef(false);
-  const [recoveryMessage, setRecoveryMessage] = useState(null);
+  // 3. Manage Microphone voice inputs (MediaRecorder API)
+  const audioState = useInterviewAudio({
+    sessionId,
+    socket: socketState.socket,
+    socketStatus: socketState.socketStatus,
+    setUploadStatus: state.setUploadStatus,
+    setError: state.setError,
+    setMediaWarning: state.setMediaWarning,
+    persistBackup: state.persistBackup,
+    setRecoveryMessage: state.setRecoveryMessage,
+    setFailedAction: state.setFailedAction,
+  });
 
-  // Socket & Multi-role state
-  const [socket, setSocket] = useState(null);
-  const [participants, setParticipants] = useState([]);
-  const [liveTyping, setLiveTyping] = useState("");
-  const [socketStatus, setSocketStatus] = useState("connecting");
-  const [isRecording, setIsRecording] = useState(false);
-  const mediaRecorderRef = useRef(null);
-  const mediaStreamRef = useRef(null);
-  const mediaTrackCleanupRef = useRef([]);
-  const failedActionRef = useRef(null);
-
-  const isObserver = user && session && user._id !== session.userId;
-
-  const persistBackup = useCallback(
-    (overrides = {}) => {
-      if (!sessionId) return;
-
-      const transcriptMap = session?.answers?.reduce((acc, item, index) => {
-        if (item?.transcript) {
-          acc[index] = item.transcript;
-        }
-        return acc;
-      }, {}) || {};
-
-      saveInterviewSession({
-        sessionId,
-        currentIndex,
-        answer,
-        transcripts: transcriptMap,
-        messages: answer
-          ? [{ role: "candidate", content: answer, timestamp: Date.now() }]
-          : [],
-        elapsedTime,
-        uploadStatus,
-        currentQuestion,
-        ...overrides,
-      });
-    },
-    [
-      answer,
-      currentIndex,
-      currentQuestion,
-      elapsedTime,
-      session,
-      sessionId,
-      uploadStatus,
-    ],
-  );
-
-  const clearMediaTrackListeners = useCallback(() => {
-    mediaTrackCleanupRef.current.forEach((cleanup) => cleanup());
-    mediaTrackCleanupRef.current = [];
-  }, []);
-
-  const attachMediaTrackListeners = useCallback(
-    (stream) => {
-      clearMediaTrackListeners();
-      const handleEnded = () => {
-        setIsRecording(false);
-        setUploadStatus("failed");
-        setMediaWarning(
-          "Audio input was disconnected. Your answer is saved, and you can retry the microphone.",
-        );
-        persistBackup({ uploadStatus: "failed" });
-      };
-
-      stream.getTracks().forEach((track) => {
-        track.addEventListener("ended", handleEnded);
-        mediaTrackCleanupRef.current.push(() => {
-          track.removeEventListener("ended", handleEnded);
-        });
-      });
-    },
-    [clearMediaTrackListeners, persistBackup],
-  );
-
-  // Timer
+  // Cleanup audio tracks on unmount
   useEffect(() => {
-    const timer = setInterval(() => {
-      setElapsedTime((prev) => prev + 1);
-    }, 1000);
-    return () => clearInterval(timer);
-  }, []);
-
-  useEffect(() => {
-    if (session && !isObserver) {
-      persistBackup();
-    }
-  }, [session, isObserver, persistBackup]);
-
-  // Fetch session on mount
-  useEffect(() => {
-    const fetchSession = async () => {
-      try {
-        const token =
-          localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY);
-        setRequestStatus("Loading interview session...");
-        const res = await retryRecoverable(
-          () =>
-            apiRequest(`/api/interviews/${sessionId}`, {
-              method: "GET",
-              token,
-            }),
-          (attempt) => setRequestStatus(`Retrying session load (${attempt}/${MAX_RETRY_ATTEMPTS})...`),
-        );
-        const data = res.data;
-        setSession(data);
-
-        let idx = 0;
-        const savedSession = loadInterviewSession();
-        if (savedSession && savedSession.sessionId === sessionId) {
-           idx = Math.min(savedSession.currentIndex, data.answers.length - 1);
-           setElapsedTime(savedSession.elapsedTime || 0);
-           setUploadStatus(savedSession.uploadStatus || "idle");
-           setAnswer(savedSession.answer || savedSession.messages?.at(-1)?.content || "");
-           setRecoveryMessage("Recovered saved interview progress.");
-           setTimeout(() => setRecoveryMessage(null), 3000);
-        } else {
-          const unansweredIdx = data.answers.findIndex(
-            (a) => !a.transcript && !a.scores,
-          );
-          idx = unansweredIdx >= 0 ? unansweredIdx : 0;
-        }
-
-        setCurrentIndex(idx);
-        setCurrentQuestion({
-          questionText: data.answers[idx]?.questionText,
-          questionId: data.answers[idx]?.questionId,
-        });
-        setIsLastQuestion(idx === data.answers.length - 1);
-        
-        saveInterviewSession({
-          sessionId,
-          currentIndex: idx,
-          answer: savedSession?.answer || "",
-          elapsedTime: savedSession?.elapsedTime || 0,
-          uploadStatus: savedSession?.uploadStatus || "idle",
-          currentQuestion: {
-            questionText: data.answers[idx]?.questionText,
-            questionId: data.answers[idx]?.questionId,
-          },
-          messages: savedSession?.messages || [],
-        });
-      } catch (err) {
-        setError(
-          err.message === "Request timeout"
-            ? "The interview session request timed out. Please check your connection and try again."
-            : "Failed to load interview session.",
-        );
-        logger.error("[InterviewSession] Error:", err);
-      } finally {
-        setRequestStatus(null);
-        setLoading(false);
-      }
-    };
-    fetchSession();
-  }, [sessionId]);
-
-  // Socket Connection
-  useEffect(() => {
-    if (!session || !user) return;
-    const token = localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY);
-    
-    const newSocket = io(SOCKET_URL, {
-      auth: { token },
-      reconnection: true,
-      reconnectionAttempts: 10,
-      reconnectionDelay: 1000,
-      reconnectionDelayMax: 5000
-    });
-
-    const handleConnect = () => {
-      setSocketStatus("connected");
-      newSocket.emit("join-interview", { sessionId });
-      
-      if (wasConnected.current) {
-        const savedSession = loadInterviewSession();
-        if (savedSession && savedSession.sessionId === sessionId) {
-          newSocket.emit("rehydrate-interview", {
-            sessionId,
-            currentIndex: savedSession.currentIndex,
-            previousMessages: savedSession.messages,
-            activeTopic: session?.topic,
-            lastAiResponse: session?.answers?.[savedSession.currentIndex]?.questionText,
-            elapsedTime: savedSession.elapsedTime,
-            uploadStatus: savedSession.uploadStatus,
-          });
-          setRecoveryMessage("Reconnected and resynced interview progress.");
-          setTimeout(() => setRecoveryMessage(null), 3000);
-          
-          if (messageQueue.current.length > 0) {
-            messageQueue.current.forEach(msg => newSocket.emit("submit-answer", msg));
-            messageQueue.current = [];
-            setUploadStatus("submitted");
-          }
-        }
-      }
-      wasConnected.current = true;
-    };
-
-    const handleDisconnect = () => {
-      setSocketStatus("disconnected");
-      setRecoveryMessage("Connection lost. Your answer is saved locally.");
-      persistBackup();
-    };
-
-    const handleReconnectAttempt = () => {
-      setSocketStatus("reconnecting");
-      setRecoveryMessage("Reconnecting to the interview room...");
-    };
-
-    const handleParticipants = (pts) => {
-      setParticipants(pts.filter(p => p.user.id !== user._id));
-    };
-
-    const handleParticipantJoined = (data) => {
-      setParticipants(prev => [...prev.filter(p => p.socketId !== data.socketId), data]);
-    };
-
-    const handleParticipantLeft = (data) => {
-      setParticipants(prev => prev.filter(p => p.socketId !== data.socketId));
-    };
-
-    const handleTyping = ({ text }) => {
-      setLiveTyping(text);
-    };
-
-    const handleAnswerEvaluated = (data) => {
-      handleEvaluationResult(data);
-      setUploadStatus("idle");
-    };
-
-    const handleLiveTranscript = (data) => {
-      if (data.transcript) {
-        setAnswer((prev) => (prev ? prev + " " + data.transcript : data.transcript));
-      }
-    };
-
-    const handleEvaluationError = (err) => {
-      setError(err.message || "Failed to submit answer.");
-      setUploadStatus("failed");
-      failedActionRef.current = "submit";
-      logger.error("[InterviewSession] Socket evaluation error:", err);
-      setSubmitting(false);
-    };
-
-    newSocket.on("connect", handleConnect);
-    newSocket.on("disconnect", handleDisconnect);
-    newSocket.io.on("reconnect_attempt", handleReconnectAttempt);
-    newSocket.on("interview-participants", handleParticipants);
-    newSocket.on("participant-joined", handleParticipantJoined);
-    newSocket.on("participant-left", handleParticipantLeft);
-    newSocket.on("interview-typing", handleTyping);
-    newSocket.on("answer-evaluated", handleAnswerEvaluated);
-    newSocket.on("live-transcript", handleLiveTranscript);
-    newSocket.on("evaluation-error", handleEvaluationError);
-
-    setSocket(newSocket);
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        if (newSocket && newSocket.disconnected) {
-          newSocket.connect();
-        }
-      }
-    };
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
     return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-      newSocket.off("connect", handleConnect);
-      newSocket.off("disconnect", handleDisconnect);
-      newSocket.io.off("reconnect_attempt", handleReconnectAttempt);
-      newSocket.off("interview-participants", handleParticipants);
-      newSocket.off("participant-joined", handleParticipantJoined);
-      newSocket.off("participant-left", handleParticipantLeft);
-      newSocket.off("interview-typing", handleTyping);
-      newSocket.off("answer-evaluated", handleAnswerEvaluated);
-      newSocket.off("live-transcript", handleLiveTranscript);
-      newSocket.off("evaluation-error", handleEvaluationError);
-      if (mediaRecorderRef.current) {
-        if (mediaRecorderRef.current.state !== "inactive") {
-          mediaRecorderRef.current.stop();
-        }
-        if (mediaRecorderRef.current.stream) {
-          mediaRecorderRef.current.stream.getTracks().forEach((track) => track.stop());
-        }
-      }
-      clearMediaTrackListeners();
-      if (newSocket && newSocket.connected) {
-        newSocket.emit("end-audio-stream", { sessionId });
-      }
-      newSocket.close();
+      audioState.cleanupAudio();
     };
-  }, [clearMediaTrackListeners, persistBackup, session, user, sessionId]);
-
-  const formatTime = (seconds) => {
-    const m = Math.floor(seconds / 60);
-    const s = seconds % 60;
-    return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
-  };
-
-  const handleEvaluationResult = (data) => {
-    setLastScores(data.scores);
-    setShowScores(true);
-    setAnswer("");
-    setSubmitting(false);
-    setRequestStatus(null);
-    setUploadStatus("idle");
-    failedActionRef.current = null;
-
-    if (data.isLastQuestion) {
-      setIsLastQuestion(true);
-    } else if (data.nextQuestion) {
-      setTimeout(() => {
-        setCurrentQuestion(data.nextQuestion);
-        setCurrentIndex(data.nextQuestion.index);
-        setShowScores(false);
-        setLastScores(null);
-        if (textareaRef.current) textareaRef.current.focus();
-      }, 3000);
-    }
-  };
-
-  const handleSubmitAnswer = async () => {
-    if (!answer.trim() || submitting || requestStatus) return;
-    const transcript = answer.trim();
-    setSubmitting(true);
-    setError(null);
-    setRequestStatus(null);
-    setUploadStatus("submitting");
-    persistBackup({
-      answer: transcript,
-      uploadStatus: "submitting",
-      messages: [{ role: "candidate", content: transcript, timestamp: Date.now() }],
-    });
-
-    if (socket && socketStatus === "connected") {
-      socket.emit("submit-answer", { sessionId, transcript, audioBuffer: null });
-    } else if (socket && (socketStatus === "disconnected" || socketStatus === "reconnecting")) {
-      messageQueue.current.push({ sessionId, transcript, audioBuffer: null });
-      setUploadStatus("queued");
-      setRecoveryMessage("Offline: answer queued and saved locally.");
-      setTimeout(() => setRecoveryMessage(null), 3000);
-      setSubmitting(false);
-      return;
-    } else {
-      try {
-        const res = await retryRecoverable(
-          () => submitAnswer(sessionId, transcript),
-          (attempt) => setRequestStatus(`Retrying answer submission (${attempt}/${MAX_RETRY_ATTEMPTS})...`),
-        );
-        handleEvaluationResult(res.data);
-      } catch (err) {
-        failedActionRef.current = "submit";
-        setUploadStatus("failed");
-        setError(
-          err.message === "Request timeout"
-            ? "Answer submission timed out. Your answer is saved and can be retried."
-            : err.message || "Failed to submit answer. Your answer is saved and can be retried.",
-        );
-        logger.error("[InterviewSession] Submit error:", err);
-        setSubmitting(false);
-        setRequestStatus(null);
-      }
-    }
-  };
-
-  const handleComplete = async () => {
-    if (completing || requestStatus) return;
-    setCompleting(true);
-    setError(null);
-
-    try {
-      await retryRecoverable(
-        () => completeInterview(sessionId),
-        (attempt) => setRequestStatus(`Retrying final submission (${attempt}/${MAX_RETRY_ATTEMPTS})...`),
-      );
-      clearInterviewSession();
-      navigate(`/mock-interview/${sessionId}/results`, { replace: true });
-    } catch (err) {
-      failedActionRef.current = "complete";
-      setError(
-        err.message === "Request timeout"
-          ? "Saving results timed out. Please retry when your connection is stable."
-          : err.message || "Failed to complete interview.",
-      );
-      logger.error("[InterviewSession] Complete error:", err);
-    } finally {
-      setCompleting(false);
-      setRequestStatus(null);
-    }
-  };
+  }, [audioState]);
 
   const handleManualRetry = () => {
-    if (failedActionRef.current === "submit") {
-      handleSubmitAnswer();
-    } else if (failedActionRef.current === "complete") {
-      handleComplete();
-    } else if (failedActionRef.current === "media") {
-      startRecording();
+    if (state.failedAction === "submit") {
+      handleSubmit();
+    } else if (state.failedAction === "complete") {
+      state.completeInterviewApi();
+    } else if (state.failedAction === "media") {
+      audioState.startRecording();
     }
   };
 
   const handleKeyDown = (e) => {
-    if (e.key === "Enter" && e.ctrlKey && !submitting) {
-      handleSubmitAnswer();
+    if (e.key === "Enter" && e.ctrlKey && !state.submitting) {
+      handleSubmit();
     }
   };
 
-  const handleAnswerChange = (e) => {
-    const nextAnswer = e.target.value;
-    setAnswer(nextAnswer);
-    debouncedAnalyze(nextAnswer);
+  const handleSubmit = async () => {
+    if (!state.answer.trim() || state.submitting || state.requestStatus) return;
+    const isSocketSubmitted = socketState.submitSocketAnswer(state.answer.trim());
     
-    persistBackup({
-      answer: nextAnswer,
-      messages: [{ role: "candidate", content: nextAnswer, timestamp: Date.now() }],
-    });
-
-    if (socket && !isObserver) {
-      socket.emit("interview-typing", { sessionId, text: nextAnswer });
-    }
-  };
-
-  const handleSendFeedback = (note) => {
-    if (socket) {
-      socket.emit("save-private-note", { sessionId, note });
-    }
-  };
-
-  const startRecording = async () => {
-    try {
-      setMediaWarning(null);
-      setError(null);
-      setUploadStatus("starting");
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      const mediaRecorder = new MediaRecorder(stream, { mimeType: "audio/webm" });
-      mediaRecorderRef.current = mediaRecorder;
-      mediaStreamRef.current = stream;
-      attachMediaTrackListeners(stream);
-
-      if (socket && socketStatus === "connected") {
-        socket.emit("start-audio-stream", { sessionId });
+    if (isSocketSubmitted) {
+      state.setSubmitting(true);
+      state.persistBackup({
+        answer: state.answer.trim(),
+        uploadStatus: "submitting",
+        messages: [{ role: "candidate", content: state.answer.trim(), timestamp: Date.now() }],
+      });
+    } else {
+      try {
+        await state.submitAnswerApi(textareaRef);
+      } catch (err) {
+        state.setFailedAction("submit");
       }
-
-      mediaRecorder.ondataavailable = (event) => {
-        try {
-          if (event.data.size > 0 && socket && socketStatus === "connected") {
-            setUploadStatus("uploading");
-            socket.emit("audio-chunk", { sessionId, chunk: event.data });
-          } else if (event.data.size > 0) {
-            setUploadStatus("queued");
-            setRecoveryMessage("Audio upload paused until the connection recovers.");
-          }
-        } catch (err) {
-          setUploadStatus("failed");
-          failedActionRef.current = "media";
-          setError("Audio upload failed. Your typed answer is still saved.");
-          logger.error("[InterviewSession] Audio chunk error:", err);
-        }
-      };
-
-      mediaRecorder.onerror = (event) => {
-        setUploadStatus("failed");
-        failedActionRef.current = "media";
-        setError("Recording failed. Your answer is saved, and you can retry recording.");
-        logger.error("[InterviewSession] Media recorder error:", event.error || event);
-      };
-
-      mediaRecorder.onstop = () => {
-        setUploadStatus((status) => (status === "failed" ? "failed" : "idle"));
-      };
-
-      mediaRecorder.start(1000);
-      setIsRecording(true);
-      setUploadStatus("uploading");
-      persistBackup({ uploadStatus: "uploading" });
-    } catch (err) {
-      logger.error("Error accessing microphone:", err);
-      setIsRecording(false);
-      setUploadStatus("failed");
-      failedActionRef.current = "media";
-      setMediaWarning("Microphone access was denied or unavailable. Check your device and retry.");
-      setError("Microphone access denied or unavailable.");
-      persistBackup({ uploadStatus: "failed" });
     }
   };
 
-  const stopRecording = () => {
-    if (mediaRecorderRef.current && mediaRecorderRef.current.state !== "inactive") {
-      mediaRecorderRef.current.stop();
-      mediaRecorderRef.current.stream.getTracks().forEach((track) => track.stop());
-    }
-    clearMediaTrackListeners();
-    mediaStreamRef.current = null;
-    if (socket && socketStatus === "connected") {
-      socket.emit("end-audio-stream", { sessionId });
-    }
-    setUploadStatus("idle");
-    setIsRecording(false);
-  };
-
-  if (loading) {
+  if (state.loading) {
     return (
       <div className="min-h-screen bg-slate-50 dark:bg-[#020617] pt-24">
         <Navbar />
@@ -640,7 +123,7 @@ const InterviewSession = () => {
     );
   }
 
-  if (error && !session) {
+  if (state.error && !state.session) {
     return (
       <div className="min-h-screen bg-slate-50 dark:bg-[#020617] flex flex-col pt-24">
         <Navbar />
@@ -648,9 +131,9 @@ const InterviewSession = () => {
           <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-white/10 p-10 rounded-3xl flex flex-col items-center max-w-md text-center shadow-xl">
             <AlertCircle size={56} className="text-red-500 mb-6" />
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-2">Session Error</h2>
-            <p className="text-slate-600 dark:text-slate-400 mb-8">{error}</p>
+            <p className="text-slate-600 dark:text-slate-400 mb-8">{state.error}</p>
             <button
-              className="w-full bg-blue-600 hover:bg-blue-700 text-white py-3.5 rounded-xl font-bold transition-all shadow-lg hover:shadow-blue-500/25"
+              className="w-full bg-blue-600 hover:bg-blue-700 text-white py-3.5 rounded-xl font-bold border-none cursor-pointer transition-all shadow-lg hover:shadow-blue-500/25"
               onClick={() => navigate("/mock-interview")}
             >
               Return to Dashboard
@@ -661,9 +144,9 @@ const InterviewSession = () => {
     );
   }
 
-  const totalQuestions = session?.totalQuestions || session?.answers?.length || 0;
+  const totalQuestions = state.session?.totalQuestions || state.session?.answers?.length || 0;
   const progressPercent = totalQuestions
-    ? ((currentIndex + 1) / totalQuestions) * 100
+    ? ((state.currentIndex + 1) / totalQuestions) * 100
     : 0;
 
   return (
@@ -673,221 +156,87 @@ const InterviewSession = () => {
       <main className="flex-1 w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pb-12 mt-24 sm:mt-28 flex flex-col lg:flex-row gap-8 items-start">
         
         {/* LEFT COLUMN: Telemetry & Status */}
-        <div className="w-full lg:w-1/3 flex flex-col gap-6">
-          <div className="flex justify-start">
-            <button
-              onClick={() => {
-                if (window.confirm("Are you sure you want to exit? Your progress may be lost.")) {
-                  navigate("/dashboard");
-                }
-              }}
-              className="inline-flex items-center gap-2 text-sm text-red-500 hover:text-red-400 transition-colors"
-            >
-              <AlertCircle size={16} />
-              Exit Session
-            </button>
-          </div>
-          
-          {/* Status Card */}
-          <div className="bg-white dark:bg-slate-900 rounded-3xl p-6 shadow-sm border border-slate-200 dark:border-white/10 flex flex-col gap-6">
-            <div className="flex items-center gap-4 border-b border-slate-100 dark:border-white/5 pb-5">
-              <div className="w-14 h-14 rounded-2xl bg-blue-50 dark:bg-blue-500/10 flex items-center justify-center border border-blue-100 dark:border-blue-500/20">
-                <Activity className="text-blue-600 dark:text-blue-400" size={28} />
-              </div>
-              <div>
-                <h3 className="text-sm font-bold text-slate-900 dark:text-white capitalize">{session?.topic}</h3>
-                <span className="text-xs font-semibold px-2 py-0.5 rounded-md bg-slate-100 dark:bg-white/5 text-slate-600 dark:text-slate-400 mt-1 inline-block uppercase tracking-wider">
-                  {session?.difficulty}
-                </span>
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-4">
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-slate-500 dark:text-slate-400 font-medium">Session Time</span>
-                <div className="flex items-center gap-2 font-mono text-lg font-bold text-slate-900 dark:text-white">
-                  <Clock size={16} className="text-slate-400" />
-                  {formatTime(elapsedTime)}
-                </div>
-              </div>
-              
-              <div className="flex justify-between items-center">
-                <span className="text-sm text-slate-500 dark:text-slate-400 font-medium">Connection</span>
-                <div className="flex items-center gap-2">
-                  {socketStatus === "connected" ? <Wifi size={16} className="text-emerald-500" /> : <WifiOff size={16} className="text-red-500" />}
-                  <span className={`text-sm font-bold capitalize ${socketStatus === "connected" ? "text-emerald-600 dark:text-emerald-400" : "text-red-600 dark:text-red-400"}`}>
-                    {socketStatus}
-                  </span>
-                </div>
-              </div>
-              {recoveryMessage && (
-                <div className="text-xs text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10 p-2 rounded-lg flex items-center gap-2" role="status">
-                  <RefreshCw size={14} className={socketStatus === "connected" ? "" : "animate-spin"} /> {recoveryMessage}
-                </div>
-              )}
-              {requestStatus && (
-                <div className="text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-500/10 p-2 rounded-lg flex items-center gap-2" role="status">
-                  <Loader2 size={14} className="animate-spin" /> {requestStatus}
-                </div>
-              )}
-              {mediaWarning && (
-                <div className="text-xs text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10 p-2 rounded-lg flex items-center gap-2" role="alert">
-                  <MicOff size={14} /> {mediaWarning}
-                </div>
-              )}
-              {uploadStatus !== "idle" && (
-                <div className="text-xs text-slate-600 dark:text-slate-400 bg-slate-50 dark:bg-white/5 p-2 rounded-lg">
-                  Audio status: <span className="font-bold capitalize">{uploadStatus}</span>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Progress Card */}
-          <div className="bg-white dark:bg-slate-900 rounded-3xl p-6 shadow-sm border border-slate-200 dark:border-white/10 flex flex-col gap-4">
-            <div className="flex justify-between items-end mb-2">
-              <h3 className="text-sm font-bold text-slate-900 dark:text-white">Interview Progress</h3>
-              <span className="text-sm font-bold text-blue-600 dark:text-blue-400 font-mono">
-                {currentIndex + 1} / {totalQuestions}
-              </span>
-            </div>
-            <div className="h-2.5 bg-slate-100 dark:bg-slate-800 rounded-full overflow-hidden shadow-inner">
-              <div
-                className="h-full bg-blue-600 dark:bg-blue-500 rounded-full transition-all duration-500"
-                style={{ width: `${progressPercent}%` }}
-              />
-            </div>
-            <p className="text-xs text-slate-500 dark:text-slate-400 mt-1 flex items-center gap-1.5">
-              <Info size={14} /> Answer all questions to see final analytics.
-            </p>
-          </div>
-
-        </div>
-
+        <SessionSidebar
+          session={state.session}
+          elapsedTime={state.elapsedTime}
+          socketStatus={socketState.socketStatus}
+          recoveryMessage={state.recoveryMessage}
+          requestStatus={state.requestStatus}
+          mediaWarning={state.mediaWarning}
+          uploadStatus={state.uploadStatus}
+          currentIndex={state.currentIndex}
+          totalQuestions={totalQuestions}
+          progressPercent={progressPercent}
+          onExit={() => {
+            if (window.confirm("Are you sure you want to exit? Your progress may be lost.")) {
+              navigate("/dashboard");
+            }
+          }}
+        />
+        
         {/* RIGHT COLUMN: Interaction Zone */}
         <div className="flex-1 w-full flex flex-col gap-6">
           
           {/* Question Card */}
           <div className="bg-white dark:bg-slate-900 rounded-3xl p-8 sm:p-10 shadow-sm border border-slate-200 dark:border-white/10 flex flex-col">
             <div className="inline-flex self-start items-center gap-2 px-3 py-1 rounded-lg bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400 text-xs font-bold tracking-wide uppercase mb-6">
-              Question {currentIndex + 1}
+              Question {state.currentIndex + 1}
             </div>
             <h2 className="text-2xl sm:text-3xl font-semibold leading-relaxed text-slate-900 dark:text-white tracking-tight">
-              {currentQuestion?.questionText || "Loading question..."}
+              {state.currentQuestion?.questionText || "Loading question..."}
             </h2>
           </div>
 
-          {!showScores && !isObserver && (
+          {!state.showScores && !isObserver && (
             <div className="w-full">
-              <RealtimeSentimentIndicator analysis={analysis} />
+              <RealtimeSentimentIndicator analysis={state.analysis} />
             </div>
           )}
 
           {/* Score Flash */}
-          {showScores && lastScores && (
+          {state.showScores && state.lastScores && (
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 animate-[fadeInUp_0.4s_ease-out]">
               <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-white/10 rounded-3xl p-6 flex flex-col items-center text-center shadow-sm hover:border-blue-500/30 transition-colors">
                 <Brain size={24} className="text-blue-500 mb-3" />
                 <span className="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-1">Technical</span>
-                <strong className="text-3xl font-black text-slate-900 dark:text-white">{lastScores.technical}%</strong>
+                <strong className="text-3xl font-black text-slate-900 dark:text-white">{state.lastScores.technical}%</strong>
               </div>
               <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-white/10 rounded-3xl p-6 flex flex-col items-center text-center shadow-sm hover:border-emerald-500/30 transition-colors">
                 <MessageSquare size={24} className="text-emerald-500 mb-3" />
                 <span className="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-1">Communication</span>
-                <strong className="text-3xl font-black text-slate-900 dark:text-white">{lastScores.communication}%</strong>
+                <strong className="text-3xl font-black text-slate-900 dark:text-white">{state.lastScores.communication}%</strong>
               </div>
               <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-white/10 rounded-3xl p-6 flex flex-col items-center text-center shadow-sm hover:border-amber-500/30 transition-colors">
                 <Target size={24} className="text-amber-500 mb-3" />
                 <span className="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-1">Relevance</span>
-                <strong className="text-3xl font-black text-slate-900 dark:text-white">{lastScores.relevance}%</strong>
+                <strong className="text-3xl font-black text-slate-900 dark:text-white">{state.lastScores.relevance}%</strong>
               </div>
             </div>
           )}
 
           {/* Answer Input */}
-          {!showScores && (
-            <div className="bg-white dark:bg-slate-900 rounded-3xl p-6 sm:p-8 shadow-sm border border-slate-200 dark:border-white/10 flex flex-col">
-              
-              {isObserver ? (
-                <div className="w-full bg-slate-50 dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 h-56 overflow-y-auto">
-                  <span className="text-xs font-bold uppercase tracking-widest text-emerald-600 dark:text-emerald-500 mb-4 flex items-center gap-2">
-                    <span className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse"></span> Candidate Typing
-                  </span>
-                  <p className="text-base text-slate-700 dark:text-slate-300 font-mono leading-relaxed whitespace-pre-wrap">
-                    {liveTyping || <span className="text-slate-400 italic">Waiting for input...</span>}
-                  </p>
-                </div>
-              ) : (
-                <textarea
-                  ref={textareaRef}
-                  className="w-full bg-slate-50 dark:bg-slate-950 border border-slate-200 dark:border-white/5 rounded-2xl p-6 text-slate-900 dark:text-slate-100 text-lg leading-relaxed resize-y min-h-[180px] focus:outline-none focus:border-blue-500 dark:focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 placeholder:text-slate-400 dark:placeholder:text-slate-600 transition-all shadow-inner"
-                  placeholder="Type your answer here... (Ctrl+Enter to submit)"
-                  value={answer}
-                  onChange={handleAnswerChange}
-                  onKeyDown={handleKeyDown}
-                  disabled={submitting}
-                  rows={5}
-                />
-              )}
-              
-              <div className="flex flex-col sm:flex-row items-center justify-between mt-6 gap-4">
-                
-                <div className="flex items-center gap-4 w-full sm:w-auto">
-                  <span className="text-sm font-semibold text-slate-500 dark:text-slate-400">
-                    {isObserver ? liveTyping.trim().split(/\s+/).filter(Boolean).length : answer.trim().split(/\s+/).filter(Boolean).length} words
-                  </span>
-                  {error && (
-                    <span className="text-sm font-semibold text-red-500 flex flex-wrap items-center gap-1.5 bg-red-50 dark:bg-red-500/10 px-3 py-1 rounded-lg">
-                      <AlertCircle size={16} /> {error}
-                      {failedActionRef.current && (
-                        <button
-                          type="button"
-                          onClick={handleManualRetry}
-                          disabled={submitting || completing || Boolean(requestStatus)}
-                          className="ml-2 underline underline-offset-2 disabled:opacity-50"
-                        >
-                          Retry
-                        </button>
-                      )}
-                    </span>
-                  )}
-                </div>
-
-                <div className="flex flex-wrap items-center gap-3 w-full sm:w-auto">
-                  {!isObserver && (
-                    <button
-                      className={`flex-1 sm:flex-none flex items-center justify-center gap-2 px-6 py-3.5 rounded-xl font-bold transition-all ${
-                        isRecording 
-                          ? "bg-red-100 dark:bg-red-500/20 text-red-600 dark:text-red-400 border border-red-200 dark:border-red-500/30 animate-[pulse_1.5s_ease-in-out_infinite]" 
-                          : "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 border border-slate-200 dark:border-white/5"
-                      }`}
-                      onClick={isRecording ? stopRecording : startRecording}
-                      disabled={submitting || Boolean(requestStatus)}
-                    >
-                      {isRecording ? <><MicOff size={18} /> Stop</> : <><Mic size={18} /> Record</>}
-                    </button>
-                  )}
-
-                  {!isObserver && (
-                    <button
-                      className="flex-1 sm:flex-none flex items-center justify-center gap-2 px-8 py-3.5 rounded-xl font-bold text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all shadow-lg hover:shadow-blue-500/25 hover:-translate-y-0.5"
-                      onClick={handleSubmitAnswer}
-                      disabled={!answer.trim() || submitting || Boolean(requestStatus)}
-                    >
-                      {submitting ? (
-                        <><Loader2 className="animate-spin" size={18} /> Evaluating</>
-                      ) : (
-                        <><Send size={18} /> Submit</>
-                      )}
-                    </button>
-                  )}
-                </div>
-              </div>
-            </div>
+          {!state.showScores && (
+            <AnswerInputSection
+              isObserver={isObserver}
+              textareaRef={textareaRef}
+              liveTyping={socketState.liveTyping}
+              answer={state.answer}
+              onChange={(e) => state.handleAnswerChange(e, socketState.socket)}
+              onKeyDown={handleKeyDown}
+              submitting={state.submitting}
+              error={state.error}
+              failedAction={state.failedAction}
+              onRetry={handleManualRetry}
+              isRecording={audioState.isRecording}
+              startRecording={audioState.startRecording}
+              stopRecording={audioState.stopRecording}
+              onSubmit={handleSubmit}
+              requestStatus={state.requestStatus}
+            />
           )}
 
           {/* Completion State */}
-          {showScores && isLastQuestion && (
+          {state.showScores && state.isLastQuestion && (
             <div className="mt-4 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-200 dark:border-emerald-500/20 rounded-3xl p-8 flex flex-col items-center gap-6 text-center shadow-sm">
               <div className="w-16 h-16 rounded-full bg-emerald-100 dark:bg-emerald-500/20 flex items-center justify-center">
                 <CheckCircle size={32} className="text-emerald-600 dark:text-emerald-400" />
@@ -898,24 +247,24 @@ const InterviewSession = () => {
               </div>
               <button
                 className="w-full sm:w-auto bg-slate-900 dark:bg-white text-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-slate-100 border-none py-3.5 px-8 rounded-xl font-bold cursor-pointer flex justify-center items-center gap-2 transition-all shadow-lg hover:-translate-y-0.5 disabled:opacity-50"
-                onClick={handleComplete}
-                disabled={completing || Boolean(requestStatus)}
+                onClick={state.completeInterviewApi}
+                disabled={state.completing || Boolean(state.requestStatus)}
               >
-                {completing ? (
+                {state.completing ? (
                   <><Loader2 className="animate-spin" size={18} /> Saving Results...</>
                 ) : (
                   <><Trophy size={18} /> View Detailed Analytics</>
                 )}
               </button>
-              {error && (
+              {state.error && (
                 <span className="text-sm font-semibold text-red-500 flex items-center justify-center gap-1.5 bg-red-50 dark:bg-red-500/10 px-3 py-2 rounded-lg mt-2">
-                  <AlertCircle size={16} /> {error}
-                  {failedActionRef.current && (
+                  <AlertCircle size={16} /> {state.error}
+                  {state.failedAction && (
                     <button
                       type="button"
                       onClick={handleManualRetry}
-                      disabled={submitting || completing || Boolean(requestStatus)}
-                      className="ml-2 underline underline-offset-2 disabled:opacity-50"
+                      disabled={state.submitting || state.completing || Boolean(state.requestStatus)}
+                      className="ml-2 underline underline-offset-2 disabled:opacity-50 bg-transparent border-none cursor-pointer text-red-500 font-bold"
                     >
                       Retry
                     </button>
@@ -925,7 +274,7 @@ const InterviewSession = () => {
             </div>
           )}
 
-          {showScores && !isLastQuestion && (
+          {state.showScores && !state.isLastQuestion && (
             <div className="mt-4 p-4 flex items-center justify-center gap-3 text-slate-500 dark:text-slate-400 font-medium">
               <Loader2 className="animate-spin text-blue-500" size={18} />
               Loading next question...
@@ -937,12 +286,12 @@ const InterviewSession = () => {
       {/* Observer Panel */}
       {isObserver && (
         <ObserverPanel 
-          participants={participants} 
-          onSendFeedback={handleSendFeedback} 
+          participants={socketState.participants} 
+          onSendFeedback={socketState.handleSendFeedback} 
           isConductor={true} 
         />
       )}
-          <Footer />
+      <Footer />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Deconstructs the monolithic `InterviewSession.jsx` component (~950 lines) in the mock-interview module. Logic for audio processing, Socket.IO connections, and local storage state persistence has been decoupled into dedicated reusable hooks, and UI layouts have been split into presenter subcomponents.

## Type of Change

- [x] Refactor

## Related Issue

Closes #1095 

## Changes Made

- Created `useInterviewState.js` hook to manage elapsed timers, local storage backups, and REST API triggers.
- Created `useInterviewSocket.js` hook to isolate Socket.IO connection boots, rehydration payloads, typing updates, and evaluation events.
- Created `useInterviewAudio.js` hook to handle microphone capture, MediaRecorder lifecycles, and streaming chunk exports.
- Created `SessionSidebar.jsx` presenter component for left sidebar metrics (time, connection state, progress).
- Created `AnswerInputSection.jsx` presenter component for text inputs, voice triggers, word counts, and evaluations.
- Rewrote `InterviewSession.jsx` to coordinate these hooks and render presentation elements, decreasing file size to under 300 lines.

## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated (Client vitest suite passes, including `InterviewSession.test.jsx`)
