### PR TITLE
feat(client): upgrade whiteboard drawing tools, text overlay, and und…

### DIFF
--- a/client/src/modules/classrooms/components/Whiteboard.jsx
+++ b/client/src/modules/classrooms/components/Whiteboard.jsx
@@ -1,12 +1,46 @@
-import React, { useRef, useState, useEffect } from "react";
-import { Trash2, Eraser, Edit2 } from "lucide-react";
+import React, { useRef, useState, useEffect, useCallback } from "react";
+import {
+  Trash2,
+  Eraser,
+  Edit2,
+  Undo,
+  Redo,
+  Type,
+  Square,
+  Circle,
+  ArrowUpRight,
+  Minus
+} from "lucide-react";
+
 export default function Whiteboard({ socket, roomId, userRole }) {
   const canvasRef = useRef(null);
-  const [isDrawing, setIsDrawing] = useState(false);
+  
+  // State for canvas configuration and tool selections
+  const [tool, setTool] = useState("pen"); // pen, line, rect, circle, arrow, text, eraser
   const [color, setColor] = useState("#38bdf8"); // Neon Blue default
   const [lineWidth, setLineWidth] = useState(4);
-  const [isEraser, setIsEraser] = useState(false);
+  
+  // State lists for action undo-redo sync
+  const [rawEvents, setRawEvents] = useState([]);
+  const [undoStack, setUndoStack] = useState([]); // holds arrays of undone raw events
+  
+  // Text input overlay state
+  const [textInput, setTextInput] = useState({
+    visible: false,
+    x: 0,
+    y: 0,
+    normX: 0,
+    normY: 0,
+    value: ""
+  });
+  const textInputRef = useRef(null);
+
+  // Drawing state
+  const [isDrawing, setIsDrawing] = useState(false);
+  const startPosRef = useRef({ x: 0, y: 0 });
   const prevPositionRef = useRef({ x: 0, y: 0 });
+  const currentPointsRef = useRef([]);
+  const currentActionIdRef = useRef(null);
 
   const colors = [
     { name: "Sky Blue", value: "#38bdf8" },
@@ -17,142 +51,424 @@ export default function Whiteboard({ socket, roomId, userRole }) {
     { name: "White", value: "#ffffff" }
   ];
 
-  // Set up Canvas dimensions and event listeners
+  // Helper to compile raw events list into logical drawings
+  const compileActions = useCallback((events) => {
+    const actionMap = {};
+    const compiled = [];
+
+    events.forEach((item) => {
+      const data = item.strokeData;
+      if (!data) return;
+
+      if (data.type === "shape" || data.type === "text") {
+        compiled.push(data);
+      } else {
+        // Freehand or Eraser segment
+        const actionId = data.actionId || "legacy";
+        if (!actionMap[actionId]) {
+          actionMap[actionId] = {
+            type: "freehand",
+            points: [],
+            color: data.color || "#38bdf8",
+            width: data.width || 4,
+            isEraser: data.isEraser,
+            actionId
+          };
+          compiled.push(actionMap[actionId]);
+        }
+        actionMap[actionId].points.push({ x: data.x, y: data.y });
+        if (actionMap[actionId].points.length === 1 && data.prevX !== undefined) {
+          actionMap[actionId].points.unshift({ x: data.prevX, y: data.prevY });
+        }
+      }
+    });
+
+    return compiled;
+  }, []);
+
+  // Draw a single action onto the context
+  const drawAction = useCallback((ctx, canvas, action) => {
+    ctx.strokeStyle = action.isEraser ? "#0b0f19" : action.color; // Match background
+    ctx.lineWidth = action.width;
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+
+    if (action.type === "freehand") {
+      const pts = action.points;
+      if (!pts || pts.length === 0) return;
+      ctx.beginPath();
+      ctx.moveTo(pts[0].x * canvas.width, pts[0].y * canvas.height);
+      for (let i = 1; i < pts.length; i++) {
+        ctx.lineTo(pts[i].x * canvas.width, pts[i].y * canvas.height);
+      }
+      ctx.stroke();
+    } else if (action.type === "shape") {
+      const startX = action.startX * canvas.width;
+      const startY = action.startY * canvas.height;
+      const endX = action.endX * canvas.width;
+      const endY = action.endY * canvas.height;
+
+      ctx.beginPath();
+      if (action.shape === "line") {
+        ctx.moveTo(startX, startY);
+        ctx.lineTo(endX, endY);
+        ctx.stroke();
+      } else if (action.shape === "rect") {
+        ctx.strokeRect(startX, startY, endX - startX, endY - startY);
+      } else if (action.shape === "circle") {
+        const dx = endX - startX;
+        const dy = endY - startY;
+        const radius = Math.sqrt(dx * dx + dy * dy);
+        ctx.arc(startX, startY, radius, 0, 2 * Math.PI);
+        ctx.stroke();
+      } else if (action.shape === "arrow") {
+        ctx.moveTo(startX, startY);
+        ctx.lineTo(endX, endY);
+        ctx.stroke();
+
+        // Arrowhead wings
+        const angle = Math.atan2(endY - startY, endX - startX);
+        const headlen = Math.max(12, action.width * 3);
+        ctx.beginPath();
+        ctx.moveTo(endX, endY);
+        ctx.lineTo(endX - headlen * Math.cos(angle - Math.PI / 6), endY - headlen * Math.sin(angle - Math.PI / 6));
+        ctx.moveTo(endX, endY);
+        ctx.lineTo(endX - headlen * Math.cos(angle + Math.PI / 6), endY - headlen * Math.sin(angle + Math.PI / 6));
+        ctx.stroke();
+      }
+    } else if (action.type === "text") {
+      ctx.font = `${action.size}px sans-serif`;
+      ctx.fillStyle = action.color;
+      ctx.fillText(action.text, action.x * canvas.width, action.y * canvas.height);
+    }
+  }, []);
+
+  // Redraw the entire canvas from compiled actions
+  const redrawCanvas = useCallback((events) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    const compiledActions = compileActions(events);
+    compiledActions.forEach((action) => {
+      drawAction(ctx, canvas, action);
+    });
+  }, [compileActions, drawAction]);
+
+  // Handle canvas sizing and sockets synchronization
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    const ctx = canvas.getContext("2d");
-    ctx.lineCap = "round";
-    ctx.lineJoin = "round";
-
-    // Handle canvas resizing
     const resizeCanvas = () => {
-      // Save canvas contents before resize
-      const tempCanvas = document.createElement("canvas");
-      tempCanvas.width = canvas.width;
-      tempCanvas.height = canvas.height;
-      const tempCtx = tempCanvas.getContext("2d");
-      tempCtx.drawImage(canvas, 0, 0);
-
       const parent = canvas.parentElement;
       canvas.width = parent.clientWidth;
       canvas.height = parent.clientHeight || 500;
-
-      // Restore contents
-      ctx.drawImage(tempCanvas, 0, 0, tempCanvas.width, tempCanvas.height, 0, 0, canvas.width, canvas.height);
-      ctx.lineCap = "round";
-      ctx.lineJoin = "round";
+      redrawCanvas(rawEvents);
     };
 
     resizeCanvas();
     window.addEventListener("resize", resizeCanvas);
 
-    // Socket listeners for drawing
+    // Socket Event listeners
     if (socket) {
-      socket.on("draw-stroke", ({ strokeData }) => {
-        drawRemoteStroke(strokeData);
+      socket.on("sync-state", ({ whiteboard }) => {
+        if (whiteboard) {
+          setRawEvents(whiteboard);
+          redrawCanvas(whiteboard);
+        }
+      });
+
+      socket.on("draw-stroke", (payload) => {
+        setRawEvents((prev) => {
+          const next = [...prev, payload];
+          redrawCanvas(next);
+          return next;
+        });
+      });
+
+      socket.on("undo-whiteboard", ({ actionId }) => {
+        setRawEvents((prev) => {
+          let next;
+          if (actionId) {
+            next = prev.filter((item) => item.strokeData?.actionId !== actionId);
+          } else {
+            next = prev.slice(0, -1);
+          }
+          redrawCanvas(next);
+          return next;
+        });
       });
 
       socket.on("clear-canvas", () => {
-        clearLocalCanvas();
+        setRawEvents([]);
+        const ctx = canvas.getContext("2d");
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
       });
     }
 
     return () => {
       window.removeEventListener("resize", resizeCanvas);
       if (socket) {
+        socket.off("sync-state");
         socket.off("draw-stroke");
+        socket.off("undo-whiteboard");
         socket.off("clear-canvas");
       }
     };
-  }, [socket]);
+  }, [socket, rawEvents, redrawCanvas]);
 
-  // Draw stroke received from another participant
-  const drawRemoteStroke = (strokeData) => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext("2d");
-
-    const { x, y, prevX, prevY, color, width } = strokeData;
-
-    ctx.strokeStyle = color;
-    ctx.lineWidth = width;
-    ctx.beginPath();
-    ctx.moveTo(prevX * canvas.width, prevY * canvas.height);
-    ctx.lineTo(x * canvas.width, y * canvas.height);
-    ctx.stroke();
-  };
-
-  const clearLocalCanvas = () => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext("2d");
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-  };
+  // Focus inline text input when it opens
+  useEffect(() => {
+    if (textInput.visible && textInputRef.current) {
+      textInputRef.current.focus();
+    }
+  }, [textInput.visible]);
 
   // Drawing event handlers
   const startDrawing = (e) => {
     const canvas = canvasRef.current;
-    if (!canvas) return;
+    if (!canvas || textInput.visible) return;
 
     const rect = canvas.getBoundingClientRect();
     const clientX = e.clientX || (e.touches && e.touches[0].clientX);
     const clientY = e.clientY || (e.touches && e.touches[0].clientY);
 
-    prevPositionRef.current = {
-      x: (clientX - rect.left) / rect.width,
-      y: (clientY - rect.top) / rect.height
-    };
+    const normX = (clientX - rect.left) / rect.width;
+    const normY = (clientY - rect.top) / rect.height;
+
+    // Handle Text tool selection immediately
+    if (tool === "text") {
+      setTextInput({
+        visible: true,
+        x: clientX - rect.left,
+        y: clientY - rect.top,
+        normX,
+        normY,
+        value: ""
+      });
+      return;
+    }
+
     setIsDrawing(true);
+    startPosRef.current = { x: normX, y: normY };
+    prevPositionRef.current = { x: normX, y: normY };
+    currentActionIdRef.current = Date.now().toString() + Math.random().toString(36).substring(2, 9);
+    currentPointsRef.current = [{ x: normX, y: normY }];
   };
 
   const draw = (e) => {
     if (!isDrawing) return;
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext("2d");
 
     const rect = canvas.getBoundingClientRect();
     const clientX = e.clientX || (e.touches && e.touches[0].clientX);
     const clientY = e.clientY || (e.touches && e.touches[0].clientY);
-
     if (!clientX || !clientY) return;
 
-    const currentX = (clientX - rect.left) / rect.width;
-    const currentY = (clientY - rect.top) / rect.height;
+    const normX = (clientX - rect.left) / rect.width;
+    const normY = (clientY - rect.top) / rect.height;
 
-    const strokeColor = isEraser ? "#0f172a" : color; // Slate-900 for background matching
+    const ctx = canvas.getContext("2d");
+    const strokeColor = tool === "eraser" ? "#0b0f19" : color;
 
-    ctx.strokeStyle = strokeColor;
-    ctx.lineWidth = lineWidth;
-    ctx.beginPath();
-    ctx.moveTo(prevPositionRef.current.x * canvas.width, prevPositionRef.current.y * canvas.height);
-    ctx.lineTo(currentX * canvas.width, currentY * canvas.height);
-    ctx.stroke();
+    if (tool === "pen" || tool === "eraser") {
+      // Draw segment locally immediately for responsive feedback
+      ctx.strokeStyle = strokeColor;
+      ctx.lineWidth = lineWidth;
+      ctx.lineCap = "round";
+      ctx.lineJoin = "round";
+      ctx.beginPath();
+      ctx.moveTo(prevPositionRef.current.x * canvas.width, prevPositionRef.current.y * canvas.height);
+      ctx.lineTo(normX * canvas.width, normY * canvas.height);
+      ctx.stroke();
 
-    const strokeData = {
-      x: currentX,
-      y: currentY,
-      prevX: prevPositionRef.current.x,
-      prevY: prevPositionRef.current.y,
-      color: strokeColor,
-      width: lineWidth
-    };
+      const strokeData = {
+        x: normX,
+        y: normY,
+        prevX: prevPositionRef.current.x,
+        prevY: prevPositionRef.current.y,
+        color: strokeColor,
+        width: lineWidth,
+        isEraser: tool === "eraser",
+        actionId: currentActionIdRef.current,
+        type: "freehand"
+      };
 
-    if (socket) {
-      socket.emit("draw-stroke", { roomId, strokeData });
+      // Emit segment
+      if (socket) {
+        socket.emit("draw-stroke", { roomId, strokeData });
+      }
+
+      currentPointsRef.current.push({ x: normX, y: normY });
+      prevPositionRef.current = { x: normX, y: normY };
+    } else {
+      // For shapes, render a real-time drag preview on top of compiled canvas
+      redrawCanvas(rawEvents);
+      drawAction(ctx, canvas, {
+        type: "shape",
+        shape: tool,
+        startX: startPosRef.current.x,
+        startY: startPosRef.current.y,
+        endX: normX,
+        endY: normY,
+        color: strokeColor,
+        width: lineWidth
+      });
+    }
+  };
+
+  const stopDrawing = (e) => {
+    if (!isDrawing) return;
+    setIsDrawing(false);
+
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const rect = canvas.getBoundingClientRect();
+    let clientX = e.clientX;
+    let clientY = e.clientY;
+    
+    if (e.changedTouches && e.changedTouches[0]) {
+      clientX = e.changedTouches[0].clientX;
+      clientY = e.changedTouches[0].clientY;
     }
 
-    prevPositionRef.current = { x: currentX, y: currentY };
+    const normX = clientX ? (clientX - rect.left) / rect.width : prevPositionRef.current.x;
+    const normY = clientY ? (clientY - rect.top) / rect.height : prevPositionRef.current.y;
+
+    const strokeColor = tool === "eraser" ? "#0b0f19" : color;
+
+    // For shapes, commit the finalized action path on mouse release
+    if (tool !== "pen" && tool !== "eraser") {
+      const shapeAction = {
+        type: "shape",
+        shape: tool,
+        startX: startPosRef.current.x,
+        startY: startPosRef.current.y,
+        endX: normX,
+        endY: normY,
+        color: strokeColor,
+        width: lineWidth,
+        actionId: currentActionIdRef.current
+      };
+
+      const payload = { strokeData: shapeAction, sender: socket?.user };
+      
+      setRawEvents((prev) => {
+        const next = [...prev, payload];
+        redrawCanvas(next);
+        return next;
+      });
+
+      if (socket) {
+        socket.emit("draw-stroke", { roomId, strokeData: shapeAction });
+      }
+    } else {
+      // Append completed freehand path locally for local sync state
+      const freehandAction = {
+        type: "freehand",
+        points: currentPointsRef.current,
+        color: strokeColor,
+        width: lineWidth,
+        isEraser: tool === "eraser",
+        actionId: currentActionIdRef.current
+      };
+      
+      const payload = { strokeData: freehandAction, sender: socket?.user };
+      setRawEvents((prev) => [...prev, payload]);
+    }
+    setUndoStack([]); // Clear redo stack on new action
   };
 
-  const stopDrawing = () => {
-    setIsDrawing(false);
+  // Commit text inputs on Enter
+  const handleTextSubmit = (e) => {
+    if (e.key === "Enter" && textInput.value.trim()) {
+      const textAction = {
+        type: "text",
+        text: textInput.value,
+        x: textInput.normX,
+        y: textInput.normY,
+        color: color,
+        size: 16 + lineWidth
+      };
+
+      const payload = { strokeData: textAction, sender: socket?.user };
+
+      setRawEvents((prev) => {
+        const next = [...prev, payload];
+        redrawCanvas(next);
+        return next;
+      });
+
+      if (socket) {
+        socket.emit("draw-stroke", { roomId, strokeData: textAction });
+      }
+
+      setTextInput({ visible: false, x: 0, y: 0, normX: 0, normY: 0, value: "" });
+      setUndoStack([]);
+    } else if (e.key === "Escape") {
+      setTextInput({ visible: false, x: 0, y: 0, normX: 0, normY: 0, value: "" });
+    }
   };
 
+  // Undo last local/remote action
+  const handleUndo = () => {
+    if (rawEvents.length === 0) return;
+    
+    // Save last action details locally to support Redo
+    const lastEvent = rawEvents[rawEvents.length - 1];
+    const lastActionId = lastEvent?.strokeData?.actionId;
+    
+    let undoneEvents;
+    if (lastActionId) {
+      undoneEvents = rawEvents.filter((item) => item.strokeData?.actionId === lastActionId);
+    } else {
+      undoneEvents = [lastEvent];
+    }
+    
+    setUndoStack((prev) => [...prev, undoneEvents]);
+
+    if (socket) {
+      socket.emit("undo-whiteboard", { roomId });
+    }
+  };
+
+  // Redo last undone action
+  const handleRedo = () => {
+    if (undoStack.length === 0) return;
+
+    const nextUndone = undoStack[undoStack.length - 1];
+    setUndoStack((prev) => prev.slice(0, -1));
+
+    nextUndone.forEach((event) => {
+      const payload = { strokeData: event.strokeData, sender: socket?.user };
+      setRawEvents((prev) => {
+        const next = [...prev, payload];
+        redrawCanvas(next);
+        return next;
+      });
+      if (socket) {
+        socket.emit("draw-stroke", { roomId, strokeData: event.strokeData });
+      }
+    });
+  };
+
+  // Clear canvas
   const handleClear = () => {
-    clearLocalCanvas();
+    if (rawEvents.length === 0) return;
+    if (!window.confirm("Clear the entire whiteboard canvas?")) return;
+
+    setRawEvents([]);
+    setUndoStack([]);
+    const canvas = canvasRef.current;
+    if (canvas) {
+      const ctx = canvas.getContext("2d");
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    }
+
     if (socket) {
       socket.emit("clear-canvas", { roomId });
     }
@@ -160,15 +476,16 @@ export default function Whiteboard({ socket, roomId, userRole }) {
 
   return (
     <div className="flex-1 flex flex-col bg-[#0b0f19] rounded-2xl overflow-hidden border border-slate-800 relative h-full">
-      {/* Controls Overlay */}
+      
+      {/* Absolute Toolbar overlay */}
       <div className="absolute top-4 left-4 right-4 bg-slate-900/90 backdrop-blur-md border border-slate-800 rounded-xl p-3 flex flex-wrap items-center justify-between z-10 gap-3">
         {/* Colors Selection */}
         <div className="flex items-center space-x-2">
-          {!isEraser && colors.map((c) => (
+          {tool !== "eraser" && colors.map((c) => (
             <button
               key={c.value}
               onClick={() => setColor(c.value)}
-              className={`w-6 h-6 rounded-full border-2 transition-transform duration-150 ${color === c.value ? "scale-125 border-white" : "border-transparent"}`}
+              className={`w-6 h-6 rounded-full border-2 transition-transform duration-150 cursor-pointer ${color === c.value ? "scale-125 border-white" : "border-transparent"}`}
               style={{ backgroundColor: c.value }}
               title={c.name}
             />
@@ -176,27 +493,62 @@ export default function Whiteboard({ socket, roomId, userRole }) {
         </div>
 
         {/* Toolbar controls */}
-        <div className="flex items-center space-x-4">
-          {/* Pen or Eraser Toggle */}
+        <div className="flex flex-wrap items-center gap-3">
+          {/* Active drawing tools selection */}
           <div className="flex bg-slate-800 rounded-lg p-1 border border-slate-700">
             <button
-              onClick={() => setIsEraser(false)}
-              className={`p-2 rounded-md transition-colors ${!isEraser ? "bg-indigo-600 text-white" : "text-slate-400 hover:text-white"}`}
-              title="Pen Tool"
+              onClick={() => { setTool("pen"); setTextInput({ visible: false }); }}
+              className={`p-2 rounded-md transition-colors cursor-pointer ${tool === "pen" ? "bg-indigo-600 text-white" : "text-slate-400 hover:text-white"}`}
+              title="Pencil Tool"
             >
               <Edit2 size={16} />
             </button>
             <button
-              onClick={() => setIsEraser(true)}
-              className={`p-2 rounded-md transition-colors ${isEraser ? "bg-indigo-600 text-white" : "text-slate-400 hover:text-white"}`}
+              onClick={() => { setTool("line"); setTextInput({ visible: false }); }}
+              className={`p-2 rounded-md transition-colors cursor-pointer ${tool === "line" ? "bg-indigo-600 text-white" : "text-slate-400 hover:text-white"}`}
+              title="Draw Line"
+            >
+              <Minus size={16} />
+            </button>
+            <button
+              onClick={() => { setTool("rect"); setTextInput({ visible: false }); }}
+              className={`p-2 rounded-md transition-colors cursor-pointer ${tool === "rect" ? "bg-indigo-600 text-white" : "text-slate-400 hover:text-white"}`}
+              title="Draw Rectangle"
+            >
+              <Square size={16} />
+            </button>
+            <button
+              onClick={() => { setTool("circle"); setTextInput({ visible: false }); }}
+              className={`p-2 rounded-md transition-colors cursor-pointer ${tool === "circle" ? "bg-indigo-600 text-white" : "text-slate-400 hover:text-white"}`}
+              title="Draw Circle"
+            >
+              <Circle size={16} />
+            </button>
+            <button
+              onClick={() => { setTool("arrow"); setTextInput({ visible: false }); }}
+              className={`p-2 rounded-md transition-colors cursor-pointer ${tool === "arrow" ? "bg-indigo-600 text-white" : "text-slate-400 hover:text-white"}`}
+              title="Draw Arrow"
+            >
+              <ArrowUpRight size={16} />
+            </button>
+            <button
+              onClick={() => { setTool("text"); setTextInput({ visible: false }); }}
+              className={`p-2 rounded-md transition-colors cursor-pointer ${tool === "text" ? "bg-indigo-600 text-white" : "text-slate-400 hover:text-white"}`}
+              title="Add Text"
+            >
+              <Type size={16} />
+            </button>
+            <button
+              onClick={() => { setTool("eraser"); setTextInput({ visible: false }); }}
+              className={`p-2 rounded-md transition-colors cursor-pointer ${tool === "eraser" ? "bg-indigo-600 text-white" : "text-slate-400 hover:text-white"}`}
               title="Eraser Tool"
             >
               <Eraser size={16} />
             </button>
           </div>
 
-          {/* Width slider */}
-          <div className="flex items-center space-x-2">
+          {/* Width brush size slider */}
+          <div className="flex items-center space-x-2 bg-slate-800 rounded-lg p-1.5 px-3 border border-slate-700">
             <span className="text-xs text-slate-400 font-medium">Size</span>
             <input
               type="range"
@@ -204,15 +556,36 @@ export default function Whiteboard({ socket, roomId, userRole }) {
               max="20"
               value={lineWidth}
               onChange={(e) => setLineWidth(Number(e.target.value))}
-              className="w-20 accent-indigo-500 h-1 bg-slate-800 rounded-lg appearance-none cursor-pointer"
+              className="w-16 accent-indigo-500 h-1 bg-slate-750 rounded-lg appearance-none cursor-pointer"
             />
             <span className="text-xs text-slate-400 font-mono w-4">{lineWidth}</span>
           </div>
 
-          {/* Clear board (Allowed for all but tutor is marked clearly) */}
+          {/* Undo and Redo control buttons */}
+          <div className="flex bg-slate-800 rounded-lg p-1 border border-slate-700">
+            <button
+              onClick={handleUndo}
+              disabled={rawEvents.length === 0}
+              className="p-2 rounded-md text-slate-400 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+              title="Undo Last Action"
+            >
+              <Undo size={16} />
+            </button>
+            <button
+              onClick={handleRedo}
+              disabled={undoStack.length === 0}
+              className="p-2 rounded-md text-slate-400 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+              title="Redo Undone Action"
+            >
+              <Redo size={16} />
+            </button>
+          </div>
+
+          {/* Clear board trigger */}
           <button
             onClick={handleClear}
-            className="p-2 px-3 rounded-lg bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-all border border-red-500/20 text-xs font-semibold flex items-center space-x-1"
+            disabled={rawEvents.length === 0}
+            className="p-2 px-3 rounded-lg bg-red-500/20 text-red-400 hover:bg-red-500/30 disabled:opacity-35 disabled:cursor-not-allowed transition-all border border-red-500/20 text-xs font-semibold flex items-center space-x-1 cursor-pointer"
             title="Clear Entire Canvas"
           >
             <Trash2 size={14} />
@@ -220,6 +593,26 @@ export default function Whiteboard({ socket, roomId, userRole }) {
           </button>
         </div>
       </div>
+
+      {/* Inline absolute text input overlay */}
+      {textInput.visible && (
+        <input
+          ref={textInputRef}
+          type="text"
+          value={textInput.value}
+          onChange={(e) => setTextInput((prev) => ({ ...prev, value: e.target.value }))}
+          onKeyDown={handleTextSubmit}
+          onBlur={() => setTextInput({ visible: false, x: 0, y: 0, normX: 0, normY: 0, value: "" })}
+          className="absolute bg-slate-900 border border-indigo-500 text-white rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500 z-25"
+          style={{
+            left: `${textInput.x}px`,
+            top: `${textInput.y}px`,
+            color: color,
+            font: `${16 + lineWidth}px sans-serif`
+          }}
+          placeholder="Type label & Enter"
+        />
+      )}
 
       {/* HTML5 Canvas */}
       <canvas

--- a/client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx
@@ -159,7 +159,7 @@ const TalentFinderPage = () => {
       } catch (err) {
         console.error("[Workspace Exception] Error retrieving job listings registry:", err);
         logger.error("Failed to load recruiter jobs:", err);
-*      } finally {
+      } finally {
         setJobsLoading(false);
       }
     };


### PR DESCRIPTION
## Summary
Upgrades the client whiteboard component to support advanced vector shapes, inline text overlay, and responsive Undo/Redo command stacks. Also resolves a compiler syntax typo in TalentFinderPage to ensure Vite builds compile cleanly.

## Type of Change
- [x] Feature
- [x] Refactor


## Related Issue
Closes #1098 

## Changes Made
- Integrated shapes toolbar (Pen, Line, Rect, Circle, Arrow, Eraser, Text, Clear) in [Whiteboard.jsx](file:///client/src/modules/classrooms/components/Whiteboard.jsx).
- Implemented drag preview rendering and proportional coordinate scaling across different client viewports.
- Integrated `actionId` stroke categorization supporting atomic Undo/Redo command stacks.
- Removed compile blocker syntax asterisk in [TalentFinderPage.jsx](file:///client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx).

## Validation
- [x] Build passes locally
- [x] Relevant tests added/updated


## Screenshots 
<img width="1894" height="770" alt="Screenshot 2026-06-02 035520" src="https://github.com/user-attachments/assets/29ca24c8-c63d-47ff-8b58-60e4da88d393" />
