### PR TITLE
fix; Interview AI service router prefixes + expected client route mismatch risk  

### DIFF
--- a/interview-ai-service/main.py
+++ b/interview-ai-service/main.py
@@ -1,7 +1,8 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from routers.transcription import router as transcription_router
 from routers.evaluation import router as evaluation_router
+
 
 app = FastAPI(
     title="Interview AI Service",
@@ -31,6 +32,41 @@ async def health_check():
     return {"status": "ok", "service": "interview-ai-service"}
 
 
+@app.get("/api/health")
+async def api_health_check():
+    """Health check endpoint under the same /api prefix used by service routers."""
+    return {"status": "ok", "service": "interview-ai-service", "prefix": "/api"}
+
+
+@app.middleware("http")
+async def log_404_path(request: Request, call_next):
+    response = await call_next(request)
+    if response.status_code == 404:
+        # Helpful when Node calls the wrong path (e.g. /evaluate vs /api/evaluate)
+        print(f"[interview-ai-service] 404 Not Found: {request.method} {request.url}")
+    return response
+
+
+@app.get("/api/routes")
+async def routes():
+    """Return the expected public routes for Node clients.
+
+    This helps prevent route prefix mismatches like:
+    - calling /evaluate instead of /api/evaluate
+    - calling /transcribe instead of /api/transcribe
+    """
+    return {
+        "service": "interview-ai-service",
+        "routes": {
+            "health": "/api/health",
+            "evaluate": "/api/evaluate",
+            "transcribe": "/api/transcribe",
+            "transcription_ws": "/api/ws/transcribe",
+        }
+    }
+
+
 # Register routers
 app.include_router(transcription_router, prefix="/api")
 app.include_router(evaluation_router, prefix="/api")
+


### PR DESCRIPTION
Implemented Python-side route contract/discovery and improved mismatch visibility in interview-ai-service/main.py.

Changes:

Added GET /api/health (mirrors existing /health but under /api).
Added GET /api/routes that documents the exact expected client paths:
POST /api/evaluate
POST /api/transcribe
websocket: /api/ws/transcribe
health: /api/health
Added an HTTP middleware that logs any 404 with method + full URL to make prefix/base-path mismatches obvious in logs (e.g., calling /evaluate instead of /api/evaluate).


closes #1131