### PR TITLE
Feat: Upgrade Resume Analyzer History Page to Production Level with Tabs & Pagination

### DIFF
--- a/client/src/app/App.jsx
+++ b/client/src/app/App.jsx
@@ -11,7 +11,7 @@ const BlogPage = lazy(() => import("../modules/landing/pages/BlogPage"));
 const CareersPage = lazy(() => import("../modules/landing/pages/CareersPage"));
 const ApiStatusPage = lazy(() => import("../modules/landing/pages/ApiStatusPage"));
 const DashboardPage = lazy(() => import("../modules/dashboard/DashboardPage"));
-const CoverLetterHistoryPage = lazy(() => import("../modules/dashboard/pages/CoverLetterHistoryPage"));
+const ResumeAnalyzerHistoryPage = lazy(() => import("../modules/dashboard/pages/ResumeAnalyzerHistoryPage"));
 const ResumeAnalyzerPage = lazy(() => import("../modules/resume-analyzer/pages/ResumeAnalyzerPage"));
 const JobMatcherPage = lazy(() => import("../modules/job-matcher/pages/JobMatcherPage"));
 const ComponentDemo = lazy(() => import("../modules/auth/components/ComponentDemo"));
@@ -118,13 +118,13 @@ function App() {
             </ProtectedRoute>
           }
         />
-        <Route
-          path="/cover-letters"
+        <Route 
+          path="/resume-history" 
           element={
             <ProtectedRoute requiredRole="student">
-              <CoverLetterHistoryPage />
+              <ResumeAnalyzerHistoryPage />
             </ProtectedRoute>
-          }
+          } 
         />
         <Route
           path="/dashboard"

--- a/client/src/modules/analytics/TutorAnalyticsDashboard.jsx
+++ b/client/src/modules/analytics/TutorAnalyticsDashboard.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Treemap } from "recharts";
-import { TrendingUp, Users, AlertCircle, ArrowLeft } from "lucide-react";
+import { TrendingUp, Users, AlertCircle, ArrowLeft, Sparkles } from "lucide-react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import { apiRequest } from "../../services/apiClient.js";
@@ -100,9 +100,9 @@ const TutorAnalyticsDashboard = () => {
         <div className="max-w-7xl mx-auto space-y-8">
         
         {/* Header Section */}
-        <div>
-          {/* Back to Dashboard Link */}
-          <div className="py-6">
+        <div className="text-center space-y-4 mb-10 relative">
+          {/* Back to Dashboard Link (Left aligned) */}
+          <div className="py-6 flex justify-start">
             <Link 
               to="/dashboard" 
               className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
@@ -111,8 +111,25 @@ const TutorAnalyticsDashboard = () => {
               Back to Dashboard
             </Link>
           </div>
-          <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Tutor Analytics Dashboard</h1>
-          <p className="text-slate-500 dark:text-slate-400 mt-2">Class-wide skill gaps and candidate proficiencies.</p>
+
+          <div className="hidden md:flex absolute top-16 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+             <Users className="w-6 h-6 text-purple-600" />
+          </div>
+          <div className="hidden md:flex absolute top-20 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+             <TrendingUp className="w-6 h-6 text-emerald-600" />
+          </div>
+
+          <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+            <Sparkles size={12} className="text-purple-500" /> PERFORMANCE METRICS
+          </div>
+          
+          <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+            <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Tutor Analytics</span> Dashboard
+          </h1>
+          
+          <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
+            Class-wide skill gaps and candidate proficiencies.
+          </p>
         </div>
 
         {/* Top KPIs */}

--- a/client/src/modules/analytics/TutorAnalyticsDashboard.jsx
+++ b/client/src/modules/analytics/TutorAnalyticsDashboard.jsx
@@ -101,13 +101,16 @@ const TutorAnalyticsDashboard = () => {
         
         {/* Header Section */}
         <div>
-          <Link 
-            to="/dashboard" 
-            className="inline-flex items-center gap-2 text-sm text-indigo-600 hover:text-indigo-500 mb-4 transition-colors"
-          >
-            <ArrowLeft size={16} />
-            Back to Dashboard
-          </Link>
+          {/* Back to Dashboard Link */}
+          <div className="py-6">
+            <Link 
+              to="/dashboard" 
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
+            >
+              <ArrowLeft size={16} />
+              Back to Dashboard
+            </Link>
+          </div>
           <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Tutor Analytics Dashboard</h1>
           <p className="text-slate-500 dark:text-slate-400 mt-2">Class-wide skill gaps and candidate proficiencies.</p>
         </div>

--- a/client/src/modules/classrooms/components/ActiveSessionsList.jsx
+++ b/client/src/modules/classrooms/components/ActiveSessionsList.jsx
@@ -36,39 +36,8 @@ export const ActiveSessionsList = ({
             <BookOpen size={48} className="text-gray-400 dark:text-slate-700 mb-4" />
             <p className="font-semibold text-gray-600 dark:text-slate-400">No active classrooms right now</p>
             <p className="text-xs text-gray-500 dark:text-slate-600 max-w-xs mt-1">
-              Tutors haven't started any public classes yet. Check out the guidelines below on how to join a custom room.
+              Tutors haven't started any public classes yet. Check out the guidelines on the left to join a custom room.
             </p>
-          </div>
-          
-          {/* Fallback guidelines */}
-          <div className="border-t border-gray-200 dark:border-slate-800/60 pt-6 space-y-4 text-left">
-            <h4 className="text-sm font-bold text-gray-700 dark:text-slate-300 uppercase tracking-wider">How to Join a Session</h4>
-            
-            <div className="space-y-4">
-              <div className="flex gap-3">
-                <div className="w-6 h-6 rounded-full bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 flex items-center justify-center font-bold font-mono text-xs flex-shrink-0">
-                  1
-                </div>
-                <div>
-                  <h5 className="text-xs font-semibold text-gray-800 dark:text-slate-200">Get the Room ID</h5>
-                  <p className="text-[11px] text-gray-600 dark:text-slate-400 mt-0.5 leading-relaxed">
-                    Ask your tutor for the unique, secure session UUID. They can copy this directly from their dashboard.
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex gap-3">
-                <div className="w-6 h-6 rounded-full bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 flex items-center justify-center font-bold font-mono text-xs flex-shrink-0">
-                  2
-                </div>
-                <div>
-                  <h5 className="text-xs font-semibold text-gray-800 dark:text-slate-200">Paste & Connect</h5>
-                  <p className="text-[11px] text-gray-600 dark:text-slate-400 mt-0.5 leading-relaxed">
-                    Enter the UUID in the input form on the left, then click "Join Classroom" to connect your camera/mic.
-                  </p>
-                </div>
-              </div>
-            </div>
           </div>
         </div>
       ) : (

--- a/client/src/modules/classrooms/components/CreateSessionForm.jsx
+++ b/client/src/modules/classrooms/components/CreateSessionForm.jsx
@@ -12,7 +12,7 @@ export const CreateSessionForm = ({
   onSubmit,
 }) => {
   return (
-    <div className="bg-gray-100 dark:bg-slate-900/60 backdrop-blur-md border border-gray-200 dark:border-slate-800/80 rounded-2xl p-6 shadow-xl">
+    <div className="bg-gray-100 dark:bg-slate-900/60 backdrop-blur-md border border-gray-200 dark:border-slate-800/80 rounded-2xl p-6 shadow-xl flex flex-col h-full">
       <div className="bg-indigo-500/10 w-12 h-12 rounded-xl flex items-center justify-center text-indigo-400 border border-indigo-500/20 mb-6">
         <Video size={24} />
       </div>
@@ -83,6 +83,38 @@ export const CreateSessionForm = ({
           )}
         </button>
       </form>
+
+      <div className="mt-auto pt-8">
+        <div className="border-t border-gray-200 dark:border-slate-800/60 pt-6 space-y-4 text-left">
+          <h4 className="text-sm font-bold text-gray-700 dark:text-slate-300 uppercase tracking-wider">Host Capabilities</h4>
+          
+          <div className="space-y-4">
+            <div className="flex gap-3">
+              <div className="w-6 h-6 rounded-full bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 flex items-center justify-center font-bold font-mono text-xs flex-shrink-0">
+                🚀
+              </div>
+              <div>
+                <h5 className="text-xs font-semibold text-gray-800 dark:text-slate-200">Interactive Workspaces</h5>
+                <p className="text-[11px] text-gray-600 dark:text-slate-400 mt-0.5 leading-relaxed">
+                  Switch instantly between video layout, an infinite collaborative whiteboard, and a real-time live code editor with your students.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-3">
+              <div className="w-6 h-6 rounded-full bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 flex items-center justify-center font-bold font-mono text-xs flex-shrink-0">
+                🔒
+              </div>
+              <div>
+                <h5 className="text-xs font-semibold text-gray-800 dark:text-slate-200">Session Controls</h5>
+                <p className="text-[11px] text-gray-600 dark:text-slate-400 mt-0.5 leading-relaxed">
+                  You have full control. You can safely screen share, observe students, and when finished, explicitly end the session to automatically disconnect all peers.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/client/src/modules/classrooms/components/JoinSessionForm.jsx
+++ b/client/src/modules/classrooms/components/JoinSessionForm.jsx
@@ -7,7 +7,7 @@ export const JoinSessionForm = ({
   onSubmit,
 }) => {
   return (
-    <div className="bg-gray-100 dark:bg-slate-900/60 backdrop-blur-md border border-gray-200 dark:border-slate-800/80 rounded-2xl p-8 shadow-xl">
+    <div className="bg-gray-100 dark:bg-slate-900/60 backdrop-blur-md border border-gray-200 dark:border-slate-800/80 rounded-2xl p-8 shadow-xl flex flex-col h-full">
       <div className="bg-purple-500/10 w-12 h-12 rounded-xl flex items-center justify-center text-purple-400 border border-purple-500/20 mb-6">
         <Users size={24} />
       </div>
@@ -33,6 +33,38 @@ export const JoinSessionForm = ({
           <ArrowRight size={18} />
         </button>
       </form>
+
+      <div className="mt-auto pt-8">
+        <div className="border-t border-gray-200 dark:border-slate-800/60 pt-6 space-y-4 text-left">
+          <h4 className="text-sm font-bold text-gray-700 dark:text-slate-300 uppercase tracking-wider">How to Join a Session</h4>
+          
+          <div className="space-y-4">
+            <div className="flex gap-3">
+              <div className="w-6 h-6 rounded-full bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 flex items-center justify-center font-bold font-mono text-xs flex-shrink-0">
+                1
+              </div>
+              <div>
+                <h5 className="text-xs font-semibold text-gray-800 dark:text-slate-200">Get the Room ID</h5>
+                <p className="text-[11px] text-gray-600 dark:text-slate-400 mt-0.5 leading-relaxed">
+                  Ask your tutor for the unique, secure session UUID. They can copy this directly from their dashboard.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-3">
+              <div className="w-6 h-6 rounded-full bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 flex items-center justify-center font-bold font-mono text-xs flex-shrink-0">
+                2
+              </div>
+              <div>
+                <h5 className="text-xs font-semibold text-gray-800 dark:text-slate-200">Paste & Connect</h5>
+                <p className="text-[11px] text-gray-600 dark:text-slate-400 mt-0.5 leading-relaxed">
+                  Enter the UUID in the input form above, then click "Join Classroom" to connect your camera/mic.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/client/src/modules/classrooms/components/SharedCodeEditor.jsx
+++ b/client/src/modules/classrooms/components/SharedCodeEditor.jsx
@@ -151,7 +151,7 @@ export default function SharedCodeEditor({ socket, roomId, userRole, initialCode
   };
 
   return (
-    <div className="flex-1 flex flex-col bg-[#0b0f19] rounded-2xl overflow-hidden border border-slate-800 h-full relative">
+    <div className="w-full h-full flex flex-col bg-[#0b0f19] rounded-2xl overflow-hidden border border-slate-800 relative shadow-2xl">
       {/* Editor Header / Controls */}
       <div className="bg-slate-900 border-b border-slate-800 p-4 flex items-center justify-between z-10 flex-wrap gap-3">
         <div className="flex items-center space-x-2 text-indigo-400">
@@ -205,7 +205,7 @@ export default function SharedCodeEditor({ socket, roomId, userRole, initialCode
       </div>
 
       {/* Monaco Editor Container */}
-      <div className="flex-1 min-h-[400px] h-full relative">
+      <div className="flex-1 w-full relative min-h-0">
         <Editor
           height="100%"
           language={language}

--- a/client/src/modules/classrooms/components/VideoTile.jsx
+++ b/client/src/modules/classrooms/components/VideoTile.jsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect } from "react";
-import { Hand, MicOff, VideoOff } from "lucide-react";
+import { Hand, MicOff, VideoOff, PictureInPicture2 } from "lucide-react";
 export default function VideoTile({ stream, user, isMuted, isHandRaised, isScreenShare, isVideoOff, isLocal }) {
   const videoRef = useRef();
 
@@ -14,8 +14,22 @@ export default function VideoTile({ stream, user, isMuted, isHandRaised, isScree
     };
   }, [stream]);
 
+  const handlePiP = async (e) => {
+    e.stopPropagation();
+    if (!videoRef.current) return;
+    try {
+      if (document.pictureInPictureElement === videoRef.current) {
+        await document.exitPictureInPicture();
+      } else {
+        await videoRef.current.requestPictureInPicture();
+      }
+    } catch (err) {
+      // Failed to enter PiP
+    }
+  };
+
   return (
-    <div className="relative rounded-xl overflow-hidden bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 shadow-lg aspect-video flex items-center justify-center">
+    <div className="relative rounded-xl overflow-hidden bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 shadow-lg aspect-video flex items-center justify-center group">
       {stream ? (
         <video
           ref={videoRef}
@@ -34,13 +48,23 @@ export default function VideoTile({ stream, user, isMuted, isHandRaised, isScree
       )}
 
       {/* Overlay controls */}
-      <div className="absolute bottom-3 left-3 flex items-center space-x-2 bg-black/60 px-3 py-1.5 rounded-lg backdrop-blur-sm">
+      <div className="absolute bottom-3 left-3 flex items-center space-x-2 bg-black/60 px-3 py-1.5 rounded-lg backdrop-blur-sm group-hover:bg-black/70 transition-colors">
         <span className="text-sm font-medium text-white truncate max-w-[120px]">
           {user?.name || "Participant"} {isLocal ? "(You)" : ""}
         </span>
         {isMuted && <MicOff size={14} className="text-red-400" />}
         {(isVideoOff || !stream) && <VideoOff size={14} className="text-red-400" />}
       </div>
+
+      {stream && (
+        <button
+          onClick={handlePiP}
+          className="absolute bottom-3 right-3 bg-black/50 hover:bg-black/80 text-white p-2 rounded-lg backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-opacity focus:opacity-100"
+          title="Picture in Picture"
+        >
+          <PictureInPicture2 size={16} />
+        </button>
+      )}
 
       {isScreenShare && (
         <div className="absolute top-3 left-3 bg-blue-500/80 text-white px-2 py-1 text-xs font-semibold rounded border border-blue-400 shadow-lg backdrop-blur-sm z-10">

--- a/client/src/modules/classrooms/components/Whiteboard.jsx
+++ b/client/src/modules/classrooms/components/Whiteboard.jsx
@@ -163,13 +163,19 @@ export default function Whiteboard({ socket, roomId, userRole, initialStrokes })
 
     const resizeCanvas = () => {
       const parent = canvas.parentElement;
+      if (!parent || parent.clientWidth === 0) return;
       canvas.width = parent.clientWidth;
-      canvas.height = parent.clientHeight || 500;
+      canvas.height = parent.clientHeight;
       redrawCanvas(rawEvents);
     };
 
-    resizeCanvas();
-    window.addEventListener("resize", resizeCanvas);
+    const resizeObserver = new ResizeObserver(() => {
+      resizeCanvas();
+    });
+
+    if (canvas.parentElement) {
+      resizeObserver.observe(canvas.parentElement);
+    }
 
     // Socket Event listeners
     if (socket) {
@@ -220,7 +226,7 @@ export default function Whiteboard({ socket, roomId, userRole, initialStrokes })
     }
 
     return () => {
-      window.removeEventListener("resize", resizeCanvas);
+      resizeObserver.disconnect();
       if (socket) {
         socket.off("sync-state");
         socket.off("draw-stroke");
@@ -486,7 +492,7 @@ export default function Whiteboard({ socket, roomId, userRole, initialStrokes })
   };
 
   return (
-    <div className="flex-1 flex flex-col bg-[#0b0f19] rounded-2xl overflow-hidden border border-slate-800 relative h-full">
+    <div className="w-full h-full flex flex-col bg-[#0b0f19] rounded-2xl overflow-hidden border border-slate-800 relative shadow-2xl">
       
       {/* Absolute Toolbar overlay */}
       <div className="absolute top-4 left-4 right-4 bg-slate-900/90 backdrop-blur-md border border-slate-800 rounded-xl p-3 flex flex-wrap items-center justify-between z-10 gap-3">
@@ -625,18 +631,20 @@ export default function Whiteboard({ socket, roomId, userRole, initialStrokes })
         />
       )}
 
-      {/* HTML5 Canvas */}
-      <canvas
-        ref={canvasRef}
-        className="flex-1 bg-slate-950 cursor-crosshair h-full"
-        onMouseDown={startDrawing}
-        onMouseMove={draw}
-        onMouseUp={stopDrawing}
-        onMouseLeave={stopDrawing}
-        onTouchStart={startDrawing}
-        onTouchMove={draw}
-        onTouchEnd={stopDrawing}
-      />
+      {/* HTML5 Canvas wrapper to ensure accurate flex box sizing */}
+      <div className="flex-1 w-full relative min-h-0">
+        <canvas
+          ref={canvasRef}
+          className="absolute inset-0 w-full h-full bg-slate-950 cursor-crosshair"
+          onMouseDown={startDrawing}
+          onMouseMove={draw}
+          onMouseUp={stopDrawing}
+          onMouseLeave={stopDrawing}
+          onTouchStart={startDrawing}
+          onTouchMove={draw}
+          onTouchEnd={stopDrawing}
+        />
+      </div>
     </div>
   );
 }

--- a/client/src/modules/classrooms/pages/ClassroomRoom.jsx
+++ b/client/src/modules/classrooms/pages/ClassroomRoom.jsx
@@ -541,7 +541,7 @@ export default function ClassroomRoom() {
             )}
 
             {/* Main workspace container */}
-            <div className="flex-1 bg-gray-50/50 dark:bg-slate-900/40 rounded-[2rem] overflow-hidden p-6 border border-gray-200 dark:border-slate-800/60 shadow-inner flex flex-col min-h-0">
+            <div className={`flex-1 overflow-hidden flex flex-col min-h-0 ${activeWorkspace === "video" ? "bg-gray-50/50 dark:bg-slate-900/40 rounded-[2rem] p-6 border border-gray-200 dark:border-slate-800/60 shadow-inner" : ""}`}>
               {activeWorkspace === "video" && (
                 /* Grid Layout for Videos */
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/client/src/modules/classrooms/pages/ClassroomRoom.jsx
+++ b/client/src/modules/classrooms/pages/ClassroomRoom.jsx
@@ -22,6 +22,7 @@ import { io } from "socket.io-client";
 import SharedCodeEditor from "../components/SharedCodeEditor";
 import VideoTile from "../components/VideoTile";
 import Whiteboard from "../components/Whiteboard";
+import { endClassroomSession } from "../services/classroomService";
 
 import { SOCKET_URL } from "../../../config/env";
 import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
@@ -81,6 +82,12 @@ export default function ClassroomRoom() {
         s.emit("join-room", {
           roomId,
           user: { id: user._id, name: user.name || user.email },
+        });
+
+        // Listen for graceful session termination
+        s.on("session-ended", () => {
+          toast.error("The host has ended this live classroom session.");
+          navigate("/classrooms");
         });
 
         // When we get the current participants list, we act as the "caller" and initiate peer connections
@@ -434,8 +441,26 @@ export default function ClassroomRoom() {
     setChatInput("");
   };
 
-  const handleLeave = () => {
-    navigate("/classrooms");
+  const handleLeave = async () => {
+    if (user?.role === "tutor") {
+      const choice = window.confirm("Tutors: Click OK to END the session for everyone, or Cancel to just Leave.");
+      if (choice) {
+        try {
+          await endClassroomSession(roomId, token);
+          toast.success("Session ended successfully.");
+          navigate("/classrooms");
+        } catch (err) {
+          logger.error("Failed to end session", err);
+          toast.error("Failed to end session.");
+        }
+      } else {
+        navigate("/classrooms");
+      }
+    } else {
+      if (window.confirm("Are you sure you want to leave the classroom?")) {
+        navigate("/classrooms");
+      }
+    }
   };
 
   const copyRoomId = () => {
@@ -621,7 +646,7 @@ export default function ClassroomRoom() {
               className="p-4 rounded-full bg-red-600 hover:bg-red-700 transition-all text-white px-8 font-bold flex items-center space-x-2 shadow-lg shadow-red-600/20 hover:-translate-y-0.5"
             >
               <PhoneOff size={20} />
-              <span>Leave Session</span>
+              <span>{user?.role === "tutor" ? "End / Leave" : "Leave Session"}</span>
             </button>
           </div>
         </div>

--- a/client/src/modules/classrooms/pages/ClassroomRoom.jsx
+++ b/client/src/modules/classrooms/pages/ClassroomRoom.jsx
@@ -437,18 +437,18 @@ export default function ClassroomRoom() {
   };
 
   return (
-    <div className="h-screen bg-white dark:bg-[#020617] text-gray-900 dark:text-white flex flex-col pt-16">
+    <div className="h-screen bg-white dark:bg-[#0B0F19] text-slate-900 dark:text-white flex flex-col pt-16 font-sans">
       <div className="flex-1 flex overflow-hidden">
         {/* Main Video Area */}
-        <div className="flex-1 p-4 flex flex-col min-h-0">
+        <div className="flex-1 p-6 flex flex-col min-h-0 gap-4">
           {/* Workspace Switcher Bar */}
-          <div className="flex items-center space-x-2 mb-4 bg-gray-100 dark:bg-slate-900/60 p-1 border border-gray-200 dark:border-slate-800 rounded-xl max-w-fit">
+          <div className="flex items-center space-x-1 mb-2 bg-white dark:bg-slate-900/60 p-1 border border-gray-200 dark:border-slate-800 rounded-xl max-w-fit shadow-sm backdrop-blur-md">
             <button
               onClick={() => setActiveWorkspace("video")}
-              className={`flex items-center space-x-2 px-4 py-2 rounded-lg text-xs font-semibold transition-all ${
+              className={`flex items-center space-x-2 px-5 py-2.5 rounded-lg text-sm font-bold transition-all ${
                 activeWorkspace === "video"
-                  ? "bg-indigo-600 text-white shadow-md shadow-indigo-600/10"
-                  : "text-gray-600 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white"
+                  ? "bg-indigo-600 text-white shadow-lg shadow-indigo-600/20"
+                  : "text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800/50"
               }`}
             >
               <Video size={14} />
@@ -456,10 +456,10 @@ export default function ClassroomRoom() {
             </button>
             <button
               onClick={() => setActiveWorkspace("whiteboard")}
-              className={`flex items-center space-x-2 px-4 py-2 rounded-lg text-xs font-semibold transition-all ${
+              className={`flex items-center space-x-2 px-5 py-2.5 rounded-lg text-sm font-bold transition-all ${
                 activeWorkspace === "whiteboard"
-                  ? "bg-indigo-600 text-white shadow-md shadow-indigo-600/10"
-                  : "text-gray-600 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white"
+                  ? "bg-indigo-600 text-white shadow-lg shadow-indigo-600/20"
+                  : "text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800/50"
               }`}
             >
               <Palette size={14} />
@@ -467,10 +467,10 @@ export default function ClassroomRoom() {
             </button>
             <button
               onClick={() => setActiveWorkspace("code")}
-              className={`flex items-center space-x-2 px-4 py-2 rounded-lg text-xs font-semibold transition-all ${
+              className={`flex items-center space-x-2 px-5 py-2.5 rounded-lg text-sm font-bold transition-all ${
                 activeWorkspace === "code"
-                  ? "bg-indigo-600 text-white shadow-md shadow-indigo-600/10"
-                  : "text-gray-600 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white"
+                  ? "bg-indigo-600 text-white shadow-lg shadow-indigo-600/20"
+                  : "text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800/50"
               }`}
             >
               <Code2 size={14} />
@@ -508,7 +508,7 @@ export default function ClassroomRoom() {
             )}
 
             {/* Main workspace container */}
-            <div className="flex-1 bg-gray-50 dark:bg-slate-900 rounded-2xl overflow-y-auto p-4 border border-gray-200 dark:border-slate-800 flex flex-col min-h-0">
+            <div className="flex-1 bg-gray-50/50 dark:bg-slate-900/40 rounded-[2rem] overflow-hidden p-6 border border-gray-200 dark:border-slate-800/60 shadow-inner flex flex-col min-h-0">
               {activeWorkspace === "video" && (
                 /* Grid Layout for Videos */
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -557,57 +557,60 @@ export default function ClassroomRoom() {
           </div>
 
           {/* Controls Bar */}
-          <div className="mt-4 bg-white/90 dark:bg-slate-800/80 backdrop-blur-md border border-gray-200 dark:border-slate-700/50 rounded-2xl p-4 flex items-center justify-center space-x-4">
+          <div className="mt-2 mx-auto bg-white/90 dark:bg-slate-900/80 backdrop-blur-xl border border-gray-200 dark:border-slate-800 shadow-[0_8px_30px_rgb(0,0,0,0.08)] dark:shadow-none rounded-full px-6 py-4 flex items-center justify-center space-x-4">
             <button
               onClick={toggleMute}
-              className={`p-4 rounded-xl transition-all ${isMuted ? "bg-red-500/20 text-red-400 hover:bg-red-500/30" : "bg-gray-200 hover:bg-gray-300 dark:bg-slate-700 dark:hover:bg-slate-600"}`}
+              className={`p-4 rounded-full transition-all hover:scale-105 ${isMuted ? "bg-red-500/20 text-red-500 hover:bg-red-500/30" : "bg-gray-100 text-slate-700 hover:bg-gray-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"}`}
             >
-              {isMuted ? <MicOff size={24} /> : <Mic size={24} />}
+              {isMuted ? <MicOff size={22} /> : <Mic size={22} />}
             </button>
             <button
               onClick={toggleVideo}
-              className={`p-4 rounded-xl transition-all ${isVideoOff ? "bg-red-500/20 text-red-400 hover:bg-red-500/30" : "bg-gray-200 hover:bg-gray-300 dark:bg-slate-700 dark:hover:bg-slate-600"}`}
+              className={`p-4 rounded-full transition-all hover:scale-105 ${isVideoOff ? "bg-red-500/20 text-red-500 hover:bg-red-500/30" : "bg-gray-100 text-slate-700 hover:bg-gray-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"}`}
             >
-              {isVideoOff ? <VideoOff size={24} /> : <Video size={24} />}
+              {isVideoOff ? <VideoOff size={22} /> : <Video size={22} />}
             </button>
             <button
               onClick={toggleHandRaise}
-              className={`p-4 rounded-xl transition-all ${isHandRaised ? "bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30" : "bg-gray-200 hover:bg-gray-300 dark:bg-slate-700 dark:hover:bg-slate-600"}`}
+              className={`p-4 rounded-full transition-all hover:scale-105 ${isHandRaised ? "bg-amber-500/20 text-amber-500 hover:bg-amber-500/30" : "bg-gray-100 text-slate-700 hover:bg-gray-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"}`}
             >
-              <Hand size={24} />
+              <Hand size={22} />
             </button>
             <button
               onClick={toggleScreenShare}
-              className={`p-4 rounded-xl transition-all ${isScreenSharing ? "bg-blue-500/20 text-blue-400 hover:bg-blue-500/30" : "bg-gray-200 hover:bg-gray-300 dark:bg-slate-700 dark:hover:bg-slate-600"}`}
+              className={`p-4 rounded-full transition-all hover:scale-105 ${isScreenSharing ? "bg-indigo-500/20 text-indigo-500 hover:bg-indigo-500/30" : "bg-gray-100 text-slate-700 hover:bg-gray-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"}`}
             >
-              <MonitorUp size={24} />
+              <MonitorUp size={22} />
             </button>
+            <div className="w-px h-8 bg-gray-200 dark:bg-slate-700 mx-2"></div>
             <button
               onClick={handleLeave}
-              className="p-4 rounded-xl bg-red-600 hover:bg-red-700 transition-all text-white px-8 font-semibold flex items-center space-x-2"
+              className="p-4 rounded-full bg-red-600 hover:bg-red-700 transition-all text-white px-8 font-bold flex items-center space-x-2 shadow-lg shadow-red-600/20 hover:-translate-y-0.5"
             >
               <PhoneOff size={20} />
-              <span>Leave</span>
+              <span>Leave Session</span>
             </button>
           </div>
         </div>
 
         {/* Sidebar */}
-        <div className="w-80 border-l border-gray-200 dark:border-slate-800 bg-gray-50 dark:bg-slate-900/50 flex flex-col">
-          <div className="flex border-b border-gray-200 dark:border-slate-800">
+        <div className="w-[340px] border-l border-gray-200 dark:border-slate-800 bg-white dark:bg-slate-900/80 flex flex-col z-10 shadow-[-10px_0_30px_rgba(0,0,0,0.02)]">
+          <div className="flex border-b border-gray-200 dark:border-slate-800 px-4 pt-4">
             <button
-              className={`flex-1 py-4 text-sm font-medium flex items-center justify-center space-x-2 transition-colors ${activeTab === "chat" ? "border-b-2 border-indigo-500 text-indigo-400" : "text-gray-600 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white"}`}
+              className={`flex-1 pb-4 text-sm font-bold flex items-center justify-center space-x-2 transition-colors relative ${activeTab === "chat" ? "text-indigo-600 dark:text-indigo-400" : "text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"}`}
               onClick={() => setActiveTab("chat")}
             >
               <MessageSquare size={16} />
-              <span>Chat</span>
+              <span>Chat Room</span>
+              {activeTab === "chat" && <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-indigo-600 dark:bg-indigo-400 rounded-t-full"></div>}
             </button>
             <button
-              className={`flex-1 py-4 text-sm font-medium flex items-center justify-center space-x-2 transition-colors ${activeTab === "participants" ? "border-b-2 border-indigo-500 text-indigo-400" : "text-gray-600 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white"}`}
+              className={`flex-1 pb-4 text-sm font-bold flex items-center justify-center space-x-2 transition-colors relative ${activeTab === "participants" ? "text-indigo-600 dark:text-indigo-400" : "text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"}`}
               onClick={() => setActiveTab("participants")}
             >
               <Users size={16} />
-              <span>Participants ({peers.length + 1})</span>
+              <span>Members ({peers.length + 1})</span>
+              {activeTab === "participants" && <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-indigo-600 dark:bg-indigo-400 rounded-t-full"></div>}
             </button>
           </div>
 
@@ -623,71 +626,71 @@ export default function ClassroomRoom() {
                   {chatMessages.map((msg, i) => (
                     <div
                       key={i}
-                      className="bg-white dark:bg-slate-800 rounded-lg p-3"
+                      className="bg-gray-50 dark:bg-slate-800/80 rounded-2xl p-4 border border-gray-100 dark:border-slate-700/50"
                     >
-                      <div className="flex items-center justify-between mb-1">
-                        <span className="font-semibold text-sm text-indigo-400">
+                      <div className="flex items-center justify-between mb-2">
+                        <span className="font-bold text-sm text-indigo-600 dark:text-indigo-400">
                           {msg.sender.name}
                         </span>
-                        <span className="text-xs text-gray-500 dark:text-slate-500">
+                        <span className="text-[10px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider">
                           {new Date(msg.timestamp).toLocaleTimeString([], {
                             hour: "2-digit",
                             minute: "2-digit",
                           })}
                         </span>
                       </div>
-                      <p className="text-gray-700 dark:text-slate-300 text-sm">
+                      <p className="text-slate-700 dark:text-slate-200 text-sm leading-relaxed">
                         {msg.message}
                       </p>
                     </div>
                   ))}
                 </div>
-                <form onSubmit={handleSendMessage} className="relative mt-auto">
+                <form onSubmit={handleSendMessage} className="relative mt-auto pt-4 border-t border-gray-100 dark:border-slate-800/80">
                   <input
                     type="text"
                     value={chatInput}
                     onChange={(e) => setChatInput(e.target.value)}
                     placeholder="Type a message..."
-                    className="w-full bg-white dark:bg-slate-800 border border-gray-300 dark:border-slate-700 rounded-xl pl-4 pr-12 py-3 text-sm focus:outline-none focus:border-indigo-500"
+                    className="w-full bg-gray-50 dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl pl-4 pr-14 py-3.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 transition-shadow text-slate-900 dark:text-white placeholder:text-slate-400"
                   />
                   <button
                     type="submit"
-                    className="absolute right-2 top-1/2 -translate-y-1/2 p-2 text-indigo-400 hover:text-indigo-300 transition-colors"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 mt-2 w-8 h-8 flex items-center justify-center rounded-lg bg-indigo-600 text-white hover:bg-indigo-500 transition-colors shadow-sm"
                   >
-                    <Send size={18} />
+                    <Send size={14} className="-ml-0.5" />
                   </button>
                 </form>
               </>
             ) : (
-              <div className="space-y-3">
-                <div className="flex items-center justify-between p-3 bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700">
+              <div className="space-y-3 pt-2">
+                <div className="flex items-center justify-between p-4 bg-gray-50 dark:bg-slate-800/80 rounded-2xl border border-gray-200 dark:border-slate-700">
                   <div className="flex items-center space-x-3">
-                    <div className="w-8 h-8 rounded-full bg-indigo-500 flex items-center justify-center font-semibold text-sm">
+                    <div className="w-10 h-10 rounded-full bg-indigo-100 dark:bg-indigo-500/20 flex items-center justify-center font-bold text-sm text-indigo-600 dark:text-indigo-400 border border-indigo-200 dark:border-indigo-500/30">
                       {user?.name?.charAt(0) || "U"}
                     </div>
-                    <span className="font-medium text-sm">
-                      {user?.name || user?.email} (You)
+                    <span className="font-bold text-sm text-slate-900 dark:text-white">
+                      {user?.name || user?.email} <span className="text-slate-400 font-medium">(You)</span>
                     </span>
                   </div>
                   {isHandRaised && (
-                    <Hand size={16} className="text-yellow-400" />
+                    <Hand size={18} className="text-amber-500" />
                   )}
                 </div>
                 {peers.map((peerObj, i) => (
                   <div
                     key={i}
-                    className="flex items-center justify-between p-3 bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700"
+                    className="flex items-center justify-between p-4 bg-white dark:bg-slate-900/60 rounded-2xl border border-gray-100 dark:border-slate-800"
                   >
                     <div className="flex items-center space-x-3">
-                      <div className="w-8 h-8 rounded-full bg-slate-600 flex items-center justify-center font-semibold text-sm">
+                      <div className="w-10 h-10 rounded-full bg-slate-100 dark:bg-slate-800 flex items-center justify-center font-bold text-sm text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-700">
                         {peerObj.user?.name?.charAt(0) || "U"}
                       </div>
-                      <span className="font-medium text-sm">
+                      <span className="font-bold text-sm text-slate-900 dark:text-white">
                         {peerObj.user?.name}
                       </span>
                     </div>
                     {peerObj.isHandRaised && (
-                      <Hand size={16} className="text-yellow-400" />
+                      <Hand size={18} className="text-amber-500" />
                     )}
                   </div>
                 ))}

--- a/client/src/modules/classrooms/pages/ClassroomRoom.jsx
+++ b/client/src/modules/classrooms/pages/ClassroomRoom.jsx
@@ -11,6 +11,8 @@ import {
   Users,
   Video,
   VideoOff,
+  ArrowLeft,
+  Copy,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
@@ -436,8 +438,39 @@ export default function ClassroomRoom() {
     navigate("/classrooms");
   };
 
+  const copyRoomId = () => {
+    navigator.clipboard.writeText(roomId);
+    toast.success("Room ID copied to clipboard!");
+  };
+
   return (
-    <div className="h-screen bg-white dark:bg-[#0B0F19] text-slate-900 dark:text-white flex flex-col pt-16 font-sans">
+    <div className="h-screen bg-white dark:bg-[#0B0F19] text-slate-900 dark:text-white flex flex-col font-sans">
+      {/* Top Header */}
+      <div className="h-16 flex items-center justify-between px-6 border-b border-gray-200 dark:border-slate-800 bg-white/50 dark:bg-slate-900/50 backdrop-blur-md z-20">
+        <div className="flex items-center space-x-4">
+          <button
+            onClick={() => navigate("/classrooms")}
+            className="flex items-center space-x-2 text-sm font-bold text-slate-500 hover:text-indigo-600 transition-colors"
+          >
+            <ArrowLeft size={16} />
+            <span>Back to Dashboard</span>
+          </button>
+        </div>
+        <div className="flex items-center space-x-3">
+          <div className="flex items-center bg-gray-100 dark:bg-slate-800 rounded-lg px-3 py-1.5 border border-gray-200 dark:border-slate-700">
+            <span className="text-xs font-semibold text-slate-500 uppercase mr-2">Room ID:</span>
+            <span className="text-sm font-bold text-slate-900 dark:text-white font-mono">{roomId}</span>
+          </div>
+          <button
+            onClick={copyRoomId}
+            className="p-2 bg-indigo-50 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 rounded-lg hover:bg-indigo-100 dark:hover:bg-indigo-500/20 transition-colors shadow-sm"
+            title="Copy Room ID"
+          >
+            <Copy size={16} />
+          </button>
+        </div>
+      </div>
+
       <div className="flex-1 flex overflow-hidden">
         {/* Main Video Area */}
         <div className="flex-1 p-6 flex flex-col min-h-0 gap-4">

--- a/client/src/modules/classrooms/pages/ClassroomRoom.jsx
+++ b/client/src/modules/classrooms/pages/ClassroomRoom.jsx
@@ -94,25 +94,27 @@ export default function ClassroomRoom() {
         s.on("room-participants", (participants) => {
           const peersArr = [];
           participants.forEach((p) => {
-            activeSocketIdsRef.current.add(p.socketId);
-            const peer = createPeer(p.socketId, s.id, stream, user);
-            peersRef.current.push({
-              peerId: p.socketId,
-              peer,
-              user: p.user,
-              isHandRaised: false,
-              isMuted: false,
-            });
-            peersArr.push({
-              peerId: p.socketId,
-              peer,
-              user: p.user,
-              stream: null, // Will be populated on peer 'stream' event
-              isHandRaised: false,
-              isMuted: false,
-              isVideoOff: false,
-              isScreenShare: false,
-            });
+            if (p.socketId !== s.id) {
+              activeSocketIdsRef.current.add(p.socketId);
+              const peer = createPeer(p.socketId, s.id, stream, user);
+              peersRef.current.push({
+                peerId: p.socketId,
+                peer,
+                user: p.user,
+                isHandRaised: false,
+                isMuted: false,
+              });
+              peersArr.push({
+                peerId: p.socketId,
+                peer,
+                user: p.user,
+                stream: null,
+                isHandRaised: false,
+                isMuted: false,
+                isVideoOff: false,
+                isScreenShare: false,
+              });
+            }
           });
           setPeers(peersArr);
         });
@@ -128,7 +130,20 @@ export default function ClassroomRoom() {
         s.on("user-joined", (payload) => {
           logger.debug("User joined", payload);
           activeSocketIdsRef.current.add(payload.socketId);
-          // We don't initiate here. We wait for their offer.
+          
+          // Immediately add them to members list so they show up, even before WebRTC connects
+          const newPeerObj = {
+            peerId: payload.socketId,
+            peer: null,
+            user: payload.user,
+            stream: null,
+            isHandRaised: false,
+            isMuted: false,
+            isVideoOff: false,
+            isScreenShare: false,
+          };
+          peersRef.current.push(newPeerObj);
+          setPeers((prev) => [...prev, newPeerObj]);
         });
 
         // Receiving an offer
@@ -148,19 +163,25 @@ export default function ClassroomRoom() {
             s,
           );
 
-          const newPeerObj = {
-            peerId: payload.callerSocketId,
-            peer,
-            user: payload.callerUser,
-            stream: null,
-            isHandRaised: false,
-            isMuted: false,
-            isVideoOff: false,
-            isScreenShare: false,
-          };
-
-          peersRef.current.push(newPeerObj);
-          setPeers((prev) => [...prev, newPeerObj]);
+          // Update existing placeholder or push new if missing
+          const existingIdx = peersRef.current.findIndex(p => p.peerId === payload.callerSocketId);
+          if (existingIdx >= 0) {
+            peersRef.current[existingIdx].peer = peer;
+            setPeers([...peersRef.current]);
+          } else {
+            const newPeerObj = {
+              peerId: payload.callerSocketId,
+              peer,
+              user: payload.callerUser,
+              stream: null,
+              isHandRaised: false,
+              isMuted: false,
+              isVideoOff: false,
+              isScreenShare: false,
+            };
+            peersRef.current.push(newPeerObj);
+            setPeers((prev) => [...prev, newPeerObj]);
+          }
         });
 
         // Receiving an answer

--- a/client/src/modules/classrooms/pages/ClassroomsDashboard.jsx
+++ b/client/src/modules/classrooms/pages/ClassroomsDashboard.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useSelector } from "react-redux";
-import { MonitorPlay, ShieldAlert, ArrowLeft } from "lucide-react";
+import { MonitorPlay, ShieldAlert, ArrowLeft, Users, Monitor } from "lucide-react";
 import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 
 // Hooks
@@ -27,31 +27,45 @@ export default function ClassroomsDashboard() {
   return (
     <div className="min-h-screen bg-white dark:bg-[#020617] text-gray-900 dark:text-white flex flex-col">
       <Navbar />
-      <div className="flex-1 max-w-6xl mx-auto w-full pt-24 pb-16 px-6">
+      <div className="flex-1 max-w-6xl mx-auto w-full pt-24 pb-16 px-6 relative">
         
+        {/* Floating Icons Background */}
+        <div className="absolute top-32 left-[0%] hidden lg:flex items-center justify-center w-16 h-16 bg-white dark:bg-surface rounded-full shadow-[0_8px_30px_rgb(0,0,0,0.08)] dark:shadow-white/5 opacity-80 pointer-events-none z-0 hover:opacity-100 transition-opacity">
+          <Users size={28} className="text-purple-500" />
+        </div>
+        <div className="absolute top-44 right-[0%] hidden lg:flex items-center justify-center w-16 h-16 bg-white dark:bg-surface rounded-full shadow-[0_8px_30px_rgb(0,0,0,0.08)] dark:shadow-white/5 opacity-80 pointer-events-none z-0 hover:opacity-100 transition-opacity">
+          <Monitor size={28} className="text-emerald-500" />
+        </div>
+
         {/* Header section */}
-        <div className="text-center mb-12">
+        <div className="w-full mx-auto relative z-10">
           <div className="mb-6">
             <Link 
               to="/dashboard" 
-              className="inline-flex items-center gap-2 text-sm text-blue-500 hover:text-blue-400 transition-colors"
+              className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
             >
               <ArrowLeft size={16} />
               Back to Dashboard
             </Link>
           </div>
-          <div className="inline-flex items-center justify-center p-3 bg-indigo-500/10 text-indigo-400 rounded-2xl mb-6 border border-indigo-500/20 shadow-[0_0_20px_rgba(99,102,241,0.15)] animate-[pulse_3s_infinite]">
-            <MonitorPlay size={32} />
+          
+          <div className="mb-12 text-center max-w-3xl mx-auto relative pt-4">
+            <div className="relative flex flex-col items-center">
+              <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-xs font-bold tracking-wider uppercase mb-6 border border-blue-100 dark:border-blue-800/50">
+                <MonitorPlay size={14} /> COLLABORATIVE LEARNING
+              </div>
+            </div>
+
+            <h1 className="text-5xl md:text-6xl font-black mb-6 tracking-tight leading-tight">
+              <span className="bg-clip-text text-transparent bg-gradient-to-r from-blue-600 via-indigo-500 to-emerald-400">Live</span> Classrooms
+            </h1>
+            <p className="text-lg text-gray-600 dark:text-slate-400 font-medium">
+              {isTutor 
+                ? "Host live interactive lessons, chat with peers, and share your screen in real-time."
+                : "Enter unique session IDs provided by your tutor to join active learning rooms."
+              }
+            </p>
           </div>
-          <h1 className="text-4xl md:text-5xl font-extrabold mb-4 bg-gradient-to-r from-indigo-400 via-purple-400 to-pink-400 bg-clip-text text-transparent">
-            Live Interactive Classrooms
-          </h1>
-          <p className="text-gray-600 dark:text-slate-400 text-lg max-w-2xl mx-auto">
-            {isTutor 
-              ? "Host live interactive lessons, chat with peers, and share your screen in real-time."
-              : "Enter unique session IDs provided by your tutor to join active learning rooms."
-            }
-          </p>
         </div>
 
         {dashboard.error && (

--- a/client/src/modules/classrooms/pages/ClassroomsDashboard.jsx
+++ b/client/src/modules/classrooms/pages/ClassroomsDashboard.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useSelector } from "react-redux";
-import { MonitorPlay, ShieldAlert, ArrowLeft, Users, Monitor } from "lucide-react";
+import { MonitorPlay, ShieldAlert, ArrowLeft, Users, Monitor, Sparkles } from "lucide-react";
 import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 
 // Hooks
@@ -29,13 +29,7 @@ export default function ClassroomsDashboard() {
       <Navbar />
       <div className="flex-1 max-w-6xl mx-auto w-full pt-24 pb-16 px-6 relative">
         
-        {/* Floating Icons Background */}
-        <div className="absolute top-32 left-[0%] hidden lg:flex items-center justify-center w-16 h-16 bg-white dark:bg-surface rounded-full shadow-[0_8px_30px_rgb(0,0,0,0.08)] dark:shadow-white/5 opacity-80 pointer-events-none z-0 hover:opacity-100 transition-opacity">
-          <Users size={28} className="text-purple-500" />
-        </div>
-        <div className="absolute top-44 right-[0%] hidden lg:flex items-center justify-center w-16 h-16 bg-white dark:bg-surface rounded-full shadow-[0_8px_30px_rgb(0,0,0,0.08)] dark:shadow-white/5 opacity-80 pointer-events-none z-0 hover:opacity-100 transition-opacity">
-          <Monitor size={28} className="text-emerald-500" />
-        </div>
+        {/* Floating Icons Background (managed in hero section now) */}
 
         {/* Header section */}
         <div className="w-full mx-auto relative z-10">
@@ -50,21 +44,27 @@ export default function ClassroomsDashboard() {
             </Link>
           </div>
           
-          <div className="mb-12 text-center max-w-3xl mx-auto relative pt-4">
-            <div className="relative flex flex-col items-center">
-              <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-xs font-bold tracking-wider uppercase mb-6 border border-blue-100 dark:border-blue-800/50">
-                <MonitorPlay size={14} /> COLLABORATIVE LEARNING
-              </div>
+          {/* Hero Section */}
+          <div className="text-center space-y-4 mb-10 relative">
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <Users className="w-6 h-6 text-purple-600" />
+            </div>
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <Monitor className="w-6 h-6 text-emerald-600" />
             </div>
 
-            <h1 className="text-5xl md:text-6xl font-black mb-6 tracking-tight leading-tight">
-              <span className="bg-clip-text text-transparent bg-gradient-to-r from-blue-600 via-indigo-500 to-emerald-400">Live</span> Classrooms
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-purple-500" /> COLLABORATIVE LEARNING
+            </div>
+            
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Live</span> Classrooms
             </h1>
-            <p className="text-lg text-gray-600 dark:text-slate-400 font-medium">
+            
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
               {isTutor 
                 ? "Host live interactive lessons, chat with peers, and share your screen in real-time."
-                : "Enter unique session IDs provided by your tutor to join active learning rooms."
-              }
+                : "Join live interactive lessons, chat with peers, and learn in real-time."}
             </p>
           </div>
         </div>

--- a/client/src/modules/classrooms/pages/ClassroomsDashboard.jsx
+++ b/client/src/modules/classrooms/pages/ClassroomsDashboard.jsx
@@ -39,10 +39,11 @@ export default function ClassroomsDashboard() {
 
         {/* Header section */}
         <div className="w-full mx-auto relative z-10">
-          <div className="mb-6">
+          {/* Back to Dashboard Link */}
+          <div className="py-6">
             <Link 
               to="/dashboard" 
-              className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
             >
               <ArrowLeft size={16} />
               Back to Dashboard

--- a/client/src/modules/classrooms/pages/ClassroomsDashboard.jsx
+++ b/client/src/modules/classrooms/pages/ClassroomsDashboard.jsx
@@ -75,7 +75,7 @@ export default function ClassroomsDashboard() {
           </div>
         )}
 
-        <div className="grid lg:grid-cols-5 gap-8 items-start">
+        <div className="grid lg:grid-cols-5 gap-8 items-stretch">
           
           {/* Form Side - Span 2 */}
           <div className="lg:col-span-2 space-y-6">

--- a/client/src/modules/dashboard/pages/ResumeAnalyzerHistoryPage.jsx
+++ b/client/src/modules/dashboard/pages/ResumeAnalyzerHistoryPage.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import Navbar from "../../../shared/components/Navbar";
 import Footer from "../../../shared/components/Footer";
 
-import { getCoverLetterHistory } from "../services/dashboardService";
+import { getCoverLetterHistory, getAnalysisHistory } from "../services/dashboardService";
 import { 
   FileText, 
   Clock, 
@@ -12,46 +12,92 @@ import {
   ArrowLeft,
   Loader2,
   Sparkles,
-  TrendingUp
+  TrendingUp,
+  Award,
+  FileCheck,
+  Search
 } from "lucide-react";
 import CoverLetterModal from "../../../shared/components/CoverLetterModal";
 import { generateCoverLetter } from "../../resume-analyzer/services/resumeService";
 import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 import { useToast } from "../../../shared/components/toast/ToastProvider";
-
+import { Pagination } from "../../../shared/components";
 
 import logger from "../../../utils/logger";
 
 const ResumeAnalyzerHistoryPage = () => {
   useDocumentTitle("Resume Analyzer History");
   const toast = useToast();
-  const [history, setHistory] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const navigate = useNavigate();
+
+  // Tabs
+  const [activeTab, setActiveTab] = useState("analyses"); // "analyses" | "coverLetters"
+
+  // Cover Letters State
+  const [clHistory, setClHistory] = useState([]);
+  const [clLoading, setClLoading] = useState(true);
+  const [clError, setClError] = useState(null);
+  const [clPage, setClPage] = useState(1);
+  const [clTotalPages, setClTotalPages] = useState(1);
+
+  // Resume Analyses State
+  const [raHistory, setRaHistory] = useState([]);
+  const [raLoading, setRaLoading] = useState(true);
+  const [raError, setRaError] = useState(null);
+  const [raPage, setRaPage] = useState(1);
+  const [raTotalPages, setRaTotalPages] = useState(1);
   
   // Modal state
   const [selectedCl, setSelectedCl] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const fetchHistory = async () => {
+  const fetchCoverLetters = async (page = 1) => {
+    setClLoading(true);
     try {
-      const response = await getCoverLetterHistory();
+      const response = await getCoverLetterHistory(null, page, 10);
       if (response.success) {
-        setHistory(response.data || []);
+        setClHistory(response.data || []);
+        if (response.pagination) {
+          setClTotalPages(response.pagination.totalPages || 1);
+        }
       } else {
-        setError("Failed to load cover letter history.");
+        setClError("Failed to load cover letter history.");
       }
     } catch (err) {
       logger.error(err);
-      setError("An error occurred while fetching history.");
+      setClError("An error occurred while fetching cover letters.");
     } finally {
-      setLoading(false);
+      setClLoading(false);
+    }
+  };
+
+  const fetchAnalyses = async (page = 1) => {
+    setRaLoading(true);
+    try {
+      const response = await getAnalysisHistory(null, page, 10);
+      if (response.success) {
+        setRaHistory(response.data || []);
+        if (response.pagination) {
+          setRaTotalPages(response.pagination.totalPages || 1);
+        }
+      } else {
+        setRaError("Failed to load resume analysis history.");
+      }
+    } catch (err) {
+      logger.error(err);
+      setRaError("An error occurred while fetching analyses.");
+    } finally {
+      setRaLoading(false);
     }
   };
 
   useEffect(() => {
-    fetchHistory();
-  }, []);
+    fetchAnalyses(raPage);
+  }, [raPage]);
+
+  useEffect(() => {
+    fetchCoverLetters(clPage);
+  }, [clPage]);
 
   const openModal = (cl) => {
     setSelectedCl(cl);
@@ -65,7 +111,7 @@ const ResumeAnalyzerHistoryPage = () => {
       const response = await generateCoverLetter(resumeId, selectedCl.jobDescription, tone, language);
       if (response && response.coverLetter && response.coverLetter.generatedText) {
         // Refresh history to show the newly generated version
-        fetchHistory();
+        fetchCoverLetters(clPage);
         return response.coverLetter.generatedText;
       }
       throw new Error("Invalid response format from server.");
@@ -79,6 +125,207 @@ const ResumeAnalyzerHistoryPage = () => {
     if (!jd) return "Targeted Cover Letter";
     const clean = jd.trim();
     return clean.length > 60 ? clean.substring(0, 60) + "..." : clean;
+  };
+
+  const renderAnalysesTab = () => {
+    if (raLoading) {
+      return (
+        <div className="flex flex-col items-center justify-center py-20">
+          <Loader2 className="w-8 h-8 text-blue-500 animate-spin mb-4" />
+          <p className="text-slate-400 animate-pulse">Loading resume analyses...</p>
+        </div>
+      );
+    }
+
+    if (raError) {
+      return (
+        <div className="bg-red-500/10 border border-red-500/20 text-red-400 p-6 rounded-2xl text-center">
+          {raError}
+        </div>
+      );
+    }
+
+    if (raHistory.length === 0) {
+      return (
+        <div className="flex flex-col items-center justify-center py-20 text-center bg-gray-50 dark:bg-slate-900/30 rounded-3xl border border-gray-200 dark:border-white/5 shadow-xl">
+          <div className="w-20 h-20 bg-blue-500/10 rounded-full flex items-center justify-center mb-6">
+            <FileCheck className="w-10 h-10 text-blue-400" />
+          </div>
+          <h3 className="text-2xl font-bold mb-2">No resume analyses yet</h3>
+          <p className="text-slate-500 max-w-md mx-auto mb-8">
+            Upload and analyze your resume to get insights on your skills and match scores.
+          </p>
+          <Link 
+            to="/resume-analyzer"
+            className="px-6 py-3 bg-blue-600 hover:bg-blue-500 text-white font-bold rounded-xl shadow-lg shadow-blue-500/20 transition-all flex items-center gap-2"
+          >
+            <TrendingUp size={18} />
+            Analyze Resume
+          </Link>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex flex-col gap-6">
+        <div className="grid gap-4 sm:gap-6 animate-in slide-in-from-bottom-8 duration-700">
+          {raHistory.map((analysis) => (
+            <div 
+              key={analysis._id} 
+              className="group p-6 bg-white dark:bg-slate-900/50 border border-gray-200 dark:border-white/10 hover:border-blue-500/30 rounded-2xl shadow-sm hover:shadow-xl transition-all flex flex-col sm:flex-row gap-6 sm:items-center justify-between"
+            >
+              <div className="flex items-start gap-4 flex-1">
+                <div className="p-3 bg-purple-500/10 text-purple-500 rounded-xl flex items-center justify-center flex-col">
+                  <span className="text-sm font-black">{Math.round(analysis.score)}</span>
+                  <span className="text-[10px] uppercase font-bold tracking-wider">Score</span>
+                </div>
+                <div>
+                  <h3 className="font-bold text-lg mb-1 text-gray-900 dark:text-white group-hover:text-blue-400 transition-colors flex items-center gap-2">
+                    {analysis.classification || "General Resume"}
+                    {analysis.score >= 80 && (
+                      <span className="bg-amber-100 text-amber-700 dark:bg-amber-500/10 dark:text-amber-400 px-2 py-0.5 rounded-full text-xs font-bold flex items-center gap-1">
+                        <Award size={12} /> Top Tier
+                      </span>
+                    )}
+                  </h3>
+                  <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 text-xs font-medium text-gray-500 dark:text-slate-400 mt-1">
+                    <span className="flex items-center gap-1.5">
+                      <Clock size={14} />
+                      {new Date(analysis.createdAt).toLocaleDateString(undefined, {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric'
+                      })}
+                    </span>
+                    <span className="hidden sm:inline-block w-1 h-1 rounded-full bg-gray-300 dark:bg-gray-600"></span>
+                    <span className="flex items-center gap-1.5">
+                      <FileCheck size={14} />
+                      {analysis.skills?.length || 0} Skills Detected
+                    </span>
+                  </div>
+                </div>
+              </div>
+              
+              <button
+                onClick={() => navigate(`/resume-analyzer/results/${analysis._id}`)}
+                className="w-full sm:w-auto px-6 py-2.5 bg-gray-100 dark:bg-white/5 hover:bg-blue-50 dark:hover:bg-blue-500/10 text-gray-700 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 font-bold rounded-xl border border-gray-200 dark:border-white/5 hover:border-blue-500/20 transition-all flex items-center justify-center gap-2 whitespace-nowrap"
+              >
+                View Report
+                <ChevronRight size={16} />
+              </button>
+            </div>
+          ))}
+        </div>
+        
+        {raTotalPages > 1 && (
+          <div className="mt-8">
+            <Pagination 
+              currentPage={raPage} 
+              totalPages={raTotalPages} 
+              onPageChange={(page) => {
+                setRaPage(page);
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+              }} 
+            />
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const renderCoverLettersTab = () => {
+    if (clLoading) {
+      return (
+        <div className="flex flex-col items-center justify-center py-20">
+          <Loader2 className="w-8 h-8 text-blue-500 animate-spin mb-4" />
+          <p className="text-slate-400 animate-pulse">Loading cover letters...</p>
+        </div>
+      );
+    }
+
+    if (clError) {
+      return (
+        <div className="bg-red-500/10 border border-red-500/20 text-red-400 p-6 rounded-2xl text-center">
+          {clError}
+        </div>
+      );
+    }
+
+    if (clHistory.length === 0) {
+      return (
+        <div className="flex flex-col items-center justify-center py-20 text-center bg-gray-50 dark:bg-slate-900/30 rounded-3xl border border-gray-200 dark:border-white/5 shadow-xl">
+          <div className="w-20 h-20 bg-blue-500/10 rounded-full flex items-center justify-center mb-6">
+            <FileText className="w-10 h-10 text-blue-400" />
+          </div>
+          <h3 className="text-2xl font-bold mb-2">No cover letters yet</h3>
+          <p className="text-slate-500 max-w-md mx-auto mb-8">
+            Analyze your resume and provide a target job description to generate your first AI-powered cover letter.
+          </p>
+          <Link 
+            to="/resume-analyzer"
+            className="px-6 py-3 bg-blue-600 hover:bg-blue-500 text-white font-bold rounded-xl shadow-lg shadow-blue-500/20 transition-all flex items-center gap-2"
+          >
+            <FileText size={18} />
+            Go to Resume Analyzer
+          </Link>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex flex-col gap-6">
+        <div className="grid gap-4 sm:gap-6 animate-in slide-in-from-bottom-8 duration-700">
+          {clHistory.map((cl) => (
+            <div 
+              key={cl._id} 
+              className="group p-6 bg-white dark:bg-slate-900/50 border border-gray-200 dark:border-white/10 hover:border-blue-500/30 rounded-2xl shadow-sm hover:shadow-xl transition-all flex flex-col sm:flex-row gap-6 sm:items-center justify-between"
+            >
+              <div className="flex items-start gap-4 flex-1">
+                <div className="p-3 bg-blue-500/10 text-blue-500 rounded-xl">
+                  <Briefcase size={24} />
+                </div>
+                <div>
+                  <h3 className="font-bold text-lg mb-1 text-gray-900 dark:text-white group-hover:text-blue-400 transition-colors">
+                    {getJobPreview(cl.jobDescription)}
+                  </h3>
+                  <div className="flex items-center gap-4 text-xs font-medium text-gray-500 dark:text-slate-400 mt-1">
+                    <span className="flex items-center gap-1.5">
+                      <Clock size={14} />
+                      {new Date(cl.createdAt).toLocaleDateString(undefined, {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric'
+                      })}
+                    </span>
+                  </div>
+                </div>
+              </div>
+              
+              <button
+                onClick={() => openModal(cl)}
+                className="w-full sm:w-auto px-6 py-2.5 bg-gray-100 dark:bg-white/5 hover:bg-blue-50 dark:hover:bg-blue-500/10 text-gray-700 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 font-bold rounded-xl border border-gray-200 dark:border-white/5 hover:border-blue-500/20 transition-all flex items-center justify-center gap-2 whitespace-nowrap"
+              >
+                View & Reuse
+                <ChevronRight size={16} />
+              </button>
+            </div>
+          ))}
+        </div>
+        
+        {clTotalPages > 1 && (
+          <div className="mt-8">
+            <Pagination 
+              currentPage={clPage} 
+              totalPages={clTotalPages} 
+              onPageChange={(page) => {
+                setClPage(page);
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+              }} 
+            />
+          </div>
+        )}
+      </div>
+    );
   };
 
   return (
@@ -105,9 +352,8 @@ const ResumeAnalyzerHistoryPage = () => {
             </Link>
           </div>
 
-          {/* Hero Section (Globally Visible) */}
+          {/* Hero Section */}
           <div className="text-center space-y-4 mb-10 relative">
-            {/* Floating Icons (Visible mainly on md+ screens) */}
             <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
                <FileText className="w-6 h-6 text-purple-600" />
             </div>
@@ -116,7 +362,7 @@ const ResumeAnalyzerHistoryPage = () => {
             </div>
 
             <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
-              <Sparkles size={12} className="text-purple-500" /> Advanced AI Intelligence Active
+              <Sparkles size={12} className="text-purple-500" /> ADVANCED AI INTELLIGENCE ACTIVE
             </div>
             
             <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
@@ -130,72 +376,38 @@ const ResumeAnalyzerHistoryPage = () => {
           </div>
         </div>
 
-        {/* Content */}
-        {loading ? (
-          <div className="flex flex-col items-center justify-center py-20">
-            <Loader2 className="w-8 h-8 text-blue-500 animate-spin mb-4" />
-            <p className="text-slate-400 animate-pulse">Loading history...</p>
-          </div>
-        ) : error ? (
-          <div className="bg-red-500/10 border border-red-500/20 text-red-400 p-6 rounded-2xl text-center">
-            {error}
-          </div>
-        ) : history.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-20 text-center bg-gray-50 dark:bg-slate-900/30 rounded-3xl border border-gray-200 dark:border-white/5 shadow-xl">
-            <div className="w-20 h-20 bg-blue-500/10 rounded-full flex items-center justify-center mb-6">
-              <FileText className="w-10 h-10 text-blue-400" />
-            </div>
-            <h3 className="text-2xl font-bold mb-2">No cover letters yet</h3>
-            <p className="text-slate-500 max-w-md mx-auto mb-8">
-              Analyze your resume and provide a target job description to generate your first AI-powered cover letter.
-            </p>
-            <Link 
-              to="/resume-analyzer"
-              className="px-6 py-3 bg-blue-600 hover:bg-blue-500 text-white font-bold rounded-xl shadow-lg shadow-blue-500/20 transition-all flex items-center gap-2"
+        {/* Tab Navigation */}
+        <div className="flex justify-center mb-10 relative z-10">
+          <div className="inline-flex items-center p-1 bg-white dark:bg-slate-900/60 border border-gray-200 dark:border-slate-800 rounded-xl backdrop-blur-sm shadow-sm">
+            <button
+              onClick={() => setActiveTab("analyses")}
+              className={`flex items-center gap-2 px-6 py-2.5 text-sm font-bold rounded-lg transition-all ${
+                activeTab === "analyses"
+                  ? "bg-blue-600 text-white shadow-md shadow-blue-500/20"
+                  : "text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-slate-800"
+              }`}
             >
-              <FileText size={18} />
-              Go to Resume Analyzer
-            </Link>
+              <TrendingUp size={16} />
+              Resume Analyses
+            </button>
+            <button
+              onClick={() => setActiveTab("coverLetters")}
+              className={`flex items-center gap-2 px-6 py-2.5 text-sm font-bold rounded-lg transition-all ${
+                activeTab === "coverLetters"
+                  ? "bg-blue-600 text-white shadow-md shadow-blue-500/20"
+                  : "text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-slate-800"
+              }`}
+            >
+              <FileText size={16} />
+              Cover Letters
+            </button>
           </div>
-        ) : (
-          <div className="grid gap-4 sm:gap-6 animate-in slide-in-from-bottom-8 duration-700">
-            {history.map((cl) => (
-              <div 
-                key={cl._id} 
-                className="group p-6 bg-white dark:bg-slate-900/50 border border-gray-200 dark:border-white/10 hover:border-blue-500/30 rounded-2xl shadow-sm hover:shadow-xl transition-all flex flex-col sm:flex-row gap-6 sm:items-center justify-between"
-              >
-                <div className="flex items-start gap-4 flex-1">
-                  <div className="p-3 bg-blue-500/10 text-blue-500 rounded-xl">
-                    <Briefcase size={24} />
-                  </div>
-                  <div>
-                    <h3 className="font-bold text-lg mb-1 text-gray-900 dark:text-white group-hover:text-blue-400 transition-colors">
-                      {getJobPreview(cl.jobDescription)}
-                    </h3>
-                    <div className="flex items-center gap-4 text-xs font-medium text-gray-500 dark:text-slate-400">
-                      <span className="flex items-center gap-1.5">
-                        <Clock size={14} />
-                        {new Date(cl.createdAt).toLocaleDateString(undefined, {
-                          year: 'numeric',
-                          month: 'long',
-                          day: 'numeric'
-                        })}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-                
-                <button
-                  onClick={() => openModal(cl)}
-                  className="w-full sm:w-auto px-6 py-2.5 bg-gray-100 dark:bg-white/5 hover:bg-blue-50 dark:hover:bg-blue-500/10 text-gray-700 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 font-bold rounded-xl border border-gray-200 dark:border-white/5 hover:border-blue-500/20 transition-all flex items-center justify-center gap-2 whitespace-nowrap"
-                >
-                  View & Reuse
-                  <ChevronRight size={16} />
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
+        </div>
+
+        {/* Content */}
+        <div className="w-full relative z-10">
+          {activeTab === "analyses" ? renderAnalysesTab() : renderCoverLettersTab()}
+        </div>
       </main>
 
       <CoverLetterModal 

--- a/client/src/modules/dashboard/pages/ResumeAnalyzerHistoryPage.jsx
+++ b/client/src/modules/dashboard/pages/ResumeAnalyzerHistoryPage.jsx
@@ -20,8 +20,8 @@ import { useToast } from "../../../shared/components/toast/ToastProvider";
 
 import logger from "../../../utils/logger";
 
-const CoverLetterHistoryPage = () => {
-  useDocumentTitle("Cover Letter History");
+const ResumeAnalyzerHistoryPage = () => {
+  useDocumentTitle("Resume Analyzer History");
   const toast = useToast();
   const [history, setHistory] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -80,24 +80,30 @@ const CoverLetterHistoryPage = () => {
   };
 
   return (
-    <div className="min-h-screen bg-white dark:bg-[#020817] text-gray-900 dark:text-slate-100 font-sans pt-24">
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col overflow-hidden relative">
       <Navbar />
 
-      <div className="max-w-5xl mx-auto pt-8 pb-12 px-4 sm:px-6 lg:px-8">
+      {/* Background glowing elements */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none z-0">
+        <div className="absolute -top-[20%] -left-[10%] w-[50%] h-[50%] rounded-full bg-blue-400/20 dark:bg-blue-900/20 blur-[120px] mix-blend-normal" />
+        <div className="absolute top-[20%] -right-[10%] w-[40%] h-[40%] rounded-full bg-purple-400/20 dark:bg-purple-900/20 blur-[120px] mix-blend-normal" />
+      </div>
+
+      <main className="container mx-auto px-4 max-w-5xl z-10 flex-grow py-8 relative">
         {/* Header */}
         <div className="mb-8 animate-in slide-in-from-bottom-4 duration-500">
           <Link 
             to="/dashboard" 
-            className="inline-flex items-center gap-2 text-sm text-blue-500 hover:text-blue-400 mb-4 transition-colors"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/50 dark:bg-white/5 border border-gray-200 dark:border-white/10 hover:bg-gray-50 dark:hover:bg-white/10 text-sm font-medium text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all backdrop-blur-md shadow-sm mb-8"
           >
             <ArrowLeft size={16} />
             Back to Dashboard
           </Link>
-          <h1 className="text-3xl sm:text-4xl font-extrabold bg-clip-text text-transparent bg-gradient-to-r from-gray-900 to-gray-500 dark:from-white dark:to-slate-400">
-            Cover Letter History
+          <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+            Resume Analyzer <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">History</span>
           </h1>
-          <p className="mt-2 text-gray-500 dark:text-slate-400">
-            View, manage, and reuse your previously generated AI cover letters.
+          <p className="mt-2 text-gray-600 dark:text-slate-400 text-lg">
+            View, manage, and reuse your previously generated AI cover letters and resume analyses.
           </p>
         </div>
 
@@ -167,7 +173,7 @@ const CoverLetterHistoryPage = () => {
             ))}
           </div>
         )}
-      </div>
+      </main>
 
       <CoverLetterModal 
         isOpen={isModalOpen}
@@ -175,9 +181,9 @@ const CoverLetterHistoryPage = () => {
         initialText={selectedCl ? selectedCl.generatedText : ""}
         onRegenerate={handleRegenerate}
       />
-          <Footer />
+      <Footer />
     </div>
   );
 };
 
-export default CoverLetterHistoryPage;
+export default ResumeAnalyzerHistoryPage;

--- a/client/src/modules/dashboard/pages/ResumeAnalyzerHistoryPage.jsx
+++ b/client/src/modules/dashboard/pages/ResumeAnalyzerHistoryPage.jsx
@@ -10,7 +10,9 @@ import {
   Briefcase, 
   ChevronRight, 
   ArrowLeft,
-  Loader2 
+  Loader2,
+  Sparkles,
+  TrendingUp
 } from "lucide-react";
 import CoverLetterModal from "../../../shared/components/CoverLetterModal";
 import { generateCoverLetter } from "../../resume-analyzer/services/resumeService";
@@ -90,21 +92,42 @@ const ResumeAnalyzerHistoryPage = () => {
       </div>
 
       <main className="container mx-auto px-4 max-w-5xl z-10 flex-grow py-8 relative">
-        {/* Header */}
-        <div className="mb-8 animate-in slide-in-from-bottom-4 duration-500">
-          <Link 
-            to="/dashboard" 
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/50 dark:bg-white/5 border border-gray-200 dark:border-white/10 hover:bg-gray-50 dark:hover:bg-white/10 text-sm font-medium text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all backdrop-blur-md shadow-sm mb-8"
-          >
-            <ArrowLeft size={16} />
-            Back to Dashboard
-          </Link>
-          <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
-            Resume Analyzer <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">History</span>
-          </h1>
-          <p className="mt-2 text-gray-600 dark:text-slate-400 text-lg">
-            View, manage, and reuse your previously generated AI cover letters and resume analyses.
-          </p>
+        <div className="w-full relative z-10">
+          
+          {/* Back to Dashboard Link */}
+          <div className="py-6">
+            <Link 
+              to="/dashboard" 
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
+            >
+              <ArrowLeft size={16} />
+              Back to Dashboard
+            </Link>
+          </div>
+
+          {/* Hero Section (Globally Visible) */}
+          <div className="text-center space-y-4 mb-10 relative">
+            {/* Floating Icons (Visible mainly on md+ screens) */}
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <FileText className="w-6 h-6 text-purple-600" />
+            </div>
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <TrendingUp className="w-6 h-6 text-emerald-600" />
+            </div>
+
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-purple-500" /> Advanced AI Intelligence Active
+            </div>
+            
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+              <span className="text-blue-600 dark:text-blue-500">Resume Analyzer</span> History
+            </h1>
+            
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
+              View, manage, and reuse your previously generated AI cover letters
+              <br className="hidden sm:block" /> and resume analyses.
+            </p>
+          </div>
         </div>
 
         {/* Content */}

--- a/client/src/modules/dashboard/pages/ResumeAnalyzerHistoryPage.jsx
+++ b/client/src/modules/dashboard/pages/ResumeAnalyzerHistoryPage.jsx
@@ -120,7 +120,7 @@ const ResumeAnalyzerHistoryPage = () => {
             </div>
             
             <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
-              <span className="text-blue-600 dark:text-blue-500">Resume Analyzer</span> History
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Resume Analyzer</span> History
             </h1>
             
             <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">

--- a/client/src/modules/dashboard/services/dashboardService.js
+++ b/client/src/modules/dashboard/services/dashboardService.js
@@ -183,6 +183,7 @@ export const transformAnalysisHistoryResponse = (response) => {
     data: response.data
       .filter(isPlainObject)
       .map(transformAnalysisHistoryItem),
+    pagination: response.pagination || null,
   };
 };
 
@@ -235,6 +236,7 @@ export const transformCoverLetterHistoryResponse = (response) => {
     success: true,
     data,
     count: toSafeNumber(response.count, data.length),
+    pagination: response.pagination || null,
   };
 };
 
@@ -523,10 +525,10 @@ const requestDashboardResource = async (
  * @returns {Promise<{success: boolean, data: Array, message?: string, isFallback?: boolean}>}
  * Safe analysis history response.
  */
-export const getAnalysisHistory = async (token) => {
+export const getAnalysisHistory = async (token, page = 1, limit = 10) => {
   const authToken = getAuthToken(token);
 
-  return requestDashboardResource("/api/dashboard/history", {
+  return requestDashboardResource(`/api/dashboard/history?page=${page}&limit=${limit}`, {
     token: authToken,
     payloadKey: "data",
     fallbackValue: [],
@@ -559,10 +561,10 @@ export const getSkillTrends = async (token) => {
  * @returns {Promise<{success: boolean, data: Array, count: number, message?: string, isFallback?: boolean}>}
  * Safe cover letter history response.
  */
-export const getCoverLetterHistory = async (token) => {
+export const getCoverLetterHistory = async (token, page = 1, limit = 10) => {
   const authToken = getAuthToken(token);
 
-  return requestDashboardResource("/api/cover-letters", {
+  return requestDashboardResource(`/api/cover-letters?page=${page}&limit=${limit}`, {
     token: authToken,
     payloadKey: "data",
     fallbackValue: [],

--- a/client/src/modules/job-matcher/pages/JobMatcherPage.jsx
+++ b/client/src/modules/job-matcher/pages/JobMatcherPage.jsx
@@ -118,41 +118,39 @@ export default function JobMatcherPage() {
 
 
       <div className="container mx-auto px-4 pb-12 flex-1 relative">
-        {/* Floating Icons Background (visible mostly on desktop) */}
-        <div className="absolute top-24 left-[10%] hidden lg:flex items-center justify-center w-16 h-16 bg-white dark:bg-slate-800 rounded-full shadow-[0_8px_30px_rgb(0,0,0,0.08)] dark:shadow-white/5 opacity-80 pointer-events-none z-0 hover:opacity-100 transition-opacity">
-          <Briefcase size={28} className="text-purple-500" />
-        </div>
-        <div className="absolute top-36 right-[10%] hidden lg:flex items-center justify-center w-16 h-16 bg-white dark:bg-slate-800 rounded-full shadow-[0_8px_30px_rgb(0,0,0,0.08)] dark:shadow-white/5 opacity-80 pointer-events-none z-0 hover:opacity-100 transition-opacity">
-          <Target size={28} className="text-green-500" />
-        </div>
-
         <div className="w-full max-w-[1200px] mx-auto relative z-10">
           {/* Back to Dashboard Link */}
           <div className="py-6">
             <Link 
               to="/dashboard" 
-              className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
             >
               <ArrowLeft size={16} />
               Back to Dashboard
             </Link>
           </div>
 
-          {/* Header */}
-          <div className="mb-16 text-center max-w-3xl mx-auto relative pt-4">
-            <div className="relative flex flex-col items-center">
-              <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-xs font-bold tracking-wider uppercase mb-6 border border-blue-100 dark:border-blue-800/50">
-                <Sparkles size={14} /> AI POWERED MATCHING
-              </div>
+          {/* Hero Section */}
+          <div className="text-center space-y-4 mb-10 relative">
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <Briefcase className="w-6 h-6 text-purple-600" />
+            </div>
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <Target className="w-6 h-6 text-emerald-600" />
             </div>
 
-          <h1 className="text-5xl md:text-6xl font-black mb-6 tracking-tight leading-tight">
-            <span className="bg-clip-text text-transparent bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400">Smart Job</span> Matching
-          </h1>
-          <p className="text-gray-500 dark:text-slate-400 text-lg leading-relaxed font-medium">
-            AI-powered job recommendations based on your resume skills 🚀
-          </p>
-        </div>
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-purple-500" /> AI POWERED MATCHING
+            </div>
+            
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Smart Job</span> Matching
+            </h1>
+            
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
+              AI-powered job recommendations based on your resume skills 🚀
+            </p>
+          </div>
 
         {/* Content */}
         {/* Always display the Upload Prompt so users can update their resume */}

--- a/client/src/modules/landing/components/Features.jsx
+++ b/client/src/modules/landing/components/Features.jsx
@@ -184,7 +184,7 @@ const Features = () => {
     {
       key: "classroom",
       icon: <Video className="text-[var(--primary)]" size={32} />,
-      title: "Live Interactive Classrooms",
+      title: "Live Classrooms",
       description:
         "Run real-time sessions with video, chat, and collaboration so learners can practice while tutors guide them.",
       metric: "Live",

--- a/client/src/modules/mock-interview/pages/InterviewHistory.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewHistory.jsx
@@ -11,6 +11,10 @@ import {
   Download,
   FileJson,
   ArrowLeft,
+  Trash2,
+  History,
+  Brain,
+  Sparkles,
 } from "lucide-react";
 import Navbar from "../../../shared/components/Navbar";
 import Footer from "../../../shared/components/Footer";
@@ -251,7 +255,7 @@ const InterviewHistory = () => {
         <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6">
           
           {/* Back to Dashboard Link */}
-          <div className="py-6 mt-[-1rem]">
+          <div className="py-6">
             <Link 
               to="/dashboard" 
               className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
@@ -261,15 +265,27 @@ const InterviewHistory = () => {
             </Link>
           </div>
 
-          {/* Header Section */}
-          <header className="mb-8 text-center max-w-3xl mx-auto relative pt-4 animate-[fadeIn_0.8s_ease-out]">
-            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-4 drop-shadow-sm">
+          {/* Hero Section */}
+          <div className="text-center space-y-4 mb-10 relative">
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <History className="w-6 h-6 text-purple-600" />
+            </div>
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <Brain className="w-6 h-6 text-emerald-600" />
+            </div>
+
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-purple-500" /> TRACK YOUR PROGRESS
+            </div>
+            
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
               <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Interview</span> History
             </h1>
-            <p className="text-gray-500 dark:text-slate-400 text-lg max-w-2xl mx-auto leading-relaxed">
+            
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
               Review your past mock interviews, export reports, and track your progression over time.
             </p>
-          </header>
+          </div>
 
         <div className="flex justify-center items-center gap-4 flex-wrap mb-4">
           <div className="flex items-center gap-3 flex-wrap">

--- a/client/src/modules/mock-interview/pages/InterviewHistory.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewHistory.jsx
@@ -237,30 +237,39 @@ const InterviewHistory = () => {
   }
 
   return (
-    <div className="min-h-screen bg-bg-main text-text-main flex flex-col font-sans pt-24">
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col overflow-hidden relative">
       <Navbar />
-      <main className="max-w-[1200px] w-full mx-auto px-4 sm:px-8 pb-12 flex flex-col gap-6 min-h-[calc(100vh-80px)]">
-        
-        {/* Back to Dashboard Link */}
-        <div className="-mt-4 mb-2 flex">
-          <Link 
-            to="/dashboard" 
-            className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
-          >
-            <ArrowLeft size={16} />
-            Back to Dashboard
-          </Link>
+
+      <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
+        {/* Background glow effects */}
+        <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+          <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+          <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+          <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
         </div>
 
-        {/* Header Section */}
-        <header className="mb-8 text-center max-w-3xl mx-auto relative pt-4 animate-[fadeIn_0.8s_ease-out]">
-          <h1 className="text-5xl md:text-6xl font-black tracking-tight bg-gradient-to-br from-indigo-600 via-purple-600 to-emerald-500 bg-clip-text text-transparent mb-4 drop-shadow-sm leading-tight">
-            Interview History
-          </h1>
-          <p className="text-text-muted max-w-2xl mx-auto text-lg leading-relaxed font-medium">
-            Review your past mock interviews, export reports, and track your progression over time.
-          </p>
-        </header>
+        <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6">
+          
+          {/* Back to Dashboard Link */}
+          <div className="py-6 mt-[-1rem]">
+            <Link 
+              to="/dashboard" 
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
+            >
+              <ArrowLeft size={16} />
+              Back to Dashboard
+            </Link>
+          </div>
+
+          {/* Header Section */}
+          <header className="mb-8 text-center max-w-3xl mx-auto relative pt-4 animate-[fadeIn_0.8s_ease-out]">
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-6 drop-shadow-sm leading-tight">
+              <span className="text-blue-600 dark:text-blue-500">Interview</span> History
+            </h1>
+            <p className="text-gray-500 dark:text-slate-400 text-lg max-w-2xl mx-auto leading-relaxed">
+              Review your past mock interviews, export reports, and track your progression over time.
+            </p>
+          </header>
 
         <div className="flex justify-center items-center gap-4 flex-wrap mb-4">
           <div className="flex items-center gap-3 flex-wrap">
@@ -363,6 +372,7 @@ const InterviewHistory = () => {
           )}
         </>
       )}
+        </div>
       </main>
       <Footer />
     </div>

--- a/client/src/modules/mock-interview/pages/InterviewHistory.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewHistory.jsx
@@ -263,8 +263,8 @@ const InterviewHistory = () => {
 
           {/* Header Section */}
           <header className="mb-8 text-center max-w-3xl mx-auto relative pt-4 animate-[fadeIn_0.8s_ease-out]">
-            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-6 drop-shadow-sm leading-tight">
-              <span className="text-blue-600 dark:text-blue-500">Interview</span> History
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-4 drop-shadow-sm">
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Interview</span> History
             </h1>
             <p className="text-gray-500 dark:text-slate-400 text-lg max-w-2xl mx-auto leading-relaxed">
               Review your past mock interviews, export reports, and track your progression over time.

--- a/client/src/modules/mock-interview/pages/InterviewLobby.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewLobby.jsx
@@ -75,15 +75,18 @@ const InterviewLobby = () => {
   }));
 
   return (
-    <div className="min-h-screen bg-bg-main text-text-main overflow-hidden relative pt-24">
-      {/* Premium Animated Backgrounds */}
-      <div className="pointer-events-none absolute -left-28 top-12 h-[500px] w-[500px] rounded-full bg-indigo-500/20 blur-[120px] dark:bg-indigo-600/15 animate-pulse" />
-      <div className="pointer-events-none absolute -right-24 top-1/4 h-[600px] w-[600px] rounded-full bg-violet-500/20 blur-[120px] dark:bg-violet-600/15 animate-pulse" style={{ animationDelay: "2s" }} />
-      <div className="pointer-events-none absolute bottom-0 left-1/3 h-[400px] w-[400px] rounded-full bg-emerald-500/20 blur-[120px] dark:bg-emerald-600/15" />
-
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col overflow-hidden relative">
       <Navbar />
 
-      <main className="relative z-10 pt-8 pb-12 max-w-[1200px] mx-auto px-4 sm:px-8 min-h-[calc(100vh-80px)] flex flex-col gap-10">
+      <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
+        {/* Background glow effects */}
+        <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+          <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+          <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+          <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
+        </div>
+
+        <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6">
         
         {/* Floating Icons Background */}
         <div className="absolute top-24 left-[2%] xl:-left-[5%] hidden lg:flex items-center justify-center w-16 h-16 bg-white dark:bg-surface rounded-full shadow-[0_8px_30px_rgb(0,0,0,0.08)] dark:shadow-white/5 opacity-80 pointer-events-none z-0 hover:opacity-100 transition-opacity animate-[float_6s_ease-in-out_infinite]">
@@ -93,24 +96,24 @@ const InterviewLobby = () => {
           <Brain size={28} className="text-indigo-500" />
         </div>
 
-        {/* Back to Dashboard Link */}
-        <div className="-mt-4 mb-2 flex">
-          <Link 
-            to="/dashboard" 
-            className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
-          >
-            <ArrowLeft size={16} />
-            Back to Dashboard
-          </Link>
-        </div>
+          {/* Back to Dashboard Link */}
+          <div className="py-6 mt-[-1rem]">
+            <Link 
+              to="/dashboard" 
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
+            >
+              <ArrowLeft size={16} />
+              Back to Dashboard
+            </Link>
+          </div>
 
         {/* Header Section */}
         <header className="mb-8 text-center max-w-3xl mx-auto relative pt-4 animate-[fadeIn_0.8s_ease-out] z-10">
           <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-indigo-50 dark:bg-indigo-500/10 border border-indigo-100 dark:border-indigo-500/20 text-indigo-600 dark:text-indigo-400 text-sm font-bold tracking-wide uppercase mb-4">
             <Sparkles size={16} /> Cognitive Evaluation Engine
           </div>
-          <h1 className="text-5xl md:text-6xl font-black tracking-tight bg-gradient-to-br from-indigo-600 via-purple-600 to-emerald-500 bg-clip-text text-transparent mb-6 drop-shadow-sm leading-tight">
-            Mock Interview
+          <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-6 drop-shadow-sm leading-tight">
+            <span className="text-blue-600 dark:text-blue-500">Mock</span> Interview
           </h1>
           <p className="text-text-muted max-w-2xl mx-auto text-lg leading-relaxed font-medium">
             Configure your simulator. The AI interviewer dynamically adapts its questions based on your real-time performance and chosen persona.
@@ -227,10 +230,10 @@ const InterviewLobby = () => {
               </div>
             </div>
           </div>
-
+        </div>
         </div>
       </main>
-          <Footer />
+      <Footer />
     </div>
   );
 };

--- a/client/src/modules/mock-interview/pages/InterviewLobby.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewLobby.jsx
@@ -88,13 +88,7 @@ const InterviewLobby = () => {
 
         <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6">
         
-        {/* Floating Icons Background */}
-        <div className="absolute top-24 left-[2%] xl:-left-[5%] hidden lg:flex items-center justify-center w-16 h-16 bg-white dark:bg-surface rounded-full shadow-[0_8px_30px_rgb(0,0,0,0.08)] dark:shadow-white/5 opacity-80 pointer-events-none z-0 hover:opacity-100 transition-opacity animate-[float_6s_ease-in-out_infinite]">
-          <Briefcase size={28} className="text-purple-500" />
-        </div>
-        <div className="absolute top-36 right-[2%] xl:-right-[5%] hidden lg:flex items-center justify-center w-16 h-16 bg-white dark:bg-surface rounded-full shadow-[0_8px_30px_rgb(0,0,0,0.08)] dark:shadow-white/5 opacity-80 pointer-events-none z-0 hover:opacity-100 transition-opacity animate-[float_7s_ease-in-out_infinite_reverse]">
-          <Brain size={28} className="text-indigo-500" />
-        </div>
+        {/* Floating Icons Background (managed in hero section now) */}
 
           {/* Back to Dashboard Link */}
           <div className="py-6">
@@ -107,18 +101,27 @@ const InterviewLobby = () => {
             </Link>
           </div>
 
-        {/* Header Section */}
-        <header className="mb-8 text-center max-w-3xl mx-auto relative pt-4 animate-[fadeIn_0.8s_ease-out] z-10">
-          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-indigo-50 dark:bg-indigo-500/10 border border-indigo-100 dark:border-indigo-500/20 text-indigo-600 dark:text-indigo-400 text-sm font-bold tracking-wide uppercase mb-4">
-            <Sparkles size={16} /> Cognitive Evaluation Engine
+          {/* Hero Section */}
+          <div className="text-center space-y-4 mb-10 relative">
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <Briefcase className="w-6 h-6 text-purple-600" />
+            </div>
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <Brain className="w-6 h-6 text-emerald-600" />
+            </div>
+
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-purple-500" /> COGNITIVE EVALUATION ENGINE
+            </div>
+            
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Mock</span> Interview
+            </h1>
+            
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
+              Configure your simulator. The AI interviewer dynamically adapts its questions based on your real-time performance and chosen persona.
+            </p>
           </div>
-          <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-6 drop-shadow-sm leading-tight">
-            <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Mock</span> Interview
-          </h1>
-          <p className="text-text-muted max-w-2xl mx-auto text-lg leading-relaxed font-medium">
-            Configure your simulator. The AI interviewer dynamically adapts its questions based on your real-time performance and chosen persona.
-          </p>
-        </header>
 
         {error && (
           <div className="max-w-2xl mx-auto w-full bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 text-red-600 dark:text-red-400 p-4 rounded-xl text-center backdrop-blur-md font-medium shadow-lg animate-[shake_0.5s_ease-in-out]">

--- a/client/src/modules/mock-interview/pages/InterviewLobby.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewLobby.jsx
@@ -97,7 +97,7 @@ const InterviewLobby = () => {
         </div>
 
           {/* Back to Dashboard Link */}
-          <div className="py-6 mt-[-1rem]">
+          <div className="py-6">
             <Link 
               to="/dashboard" 
               className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
@@ -113,7 +113,7 @@ const InterviewLobby = () => {
             <Sparkles size={16} /> Cognitive Evaluation Engine
           </div>
           <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-6 drop-shadow-sm leading-tight">
-            <span className="text-blue-600 dark:text-blue-500">Mock</span> Interview
+            <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Mock</span> Interview
           </h1>
           <p className="text-text-muted max-w-2xl mx-auto text-lg leading-relaxed font-medium">
             Configure your simulator. The AI interviewer dynamically adapts its questions based on your real-time performance and chosen persona.

--- a/client/src/modules/mock-interview/pages/InterviewResults.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewResults.jsx
@@ -69,20 +69,27 @@ const InterviewResults = () => {
 
   if (error || !results) {
     return (
-      <div className="min-h-screen bg-bg-main text-text-main pt-24">
+      <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col overflow-hidden relative">
         <Navbar />
-        <div className="max-w-[900px] mx-auto px-8 pb-8 flex flex-col gap-6">
-          <div className="flex-1 flex flex-col items-center justify-center gap-4 text-text-muted mt-24">
-            <AlertTriangle size={48} className="text-red-500" />
-            <p className="font-medium text-lg">{error || "No results found."}</p>
-            <button
-              className="bg-indigo-50 dark:bg-indigo-500/15 text-indigo-600 dark:text-indigo-300 border-none py-3 px-6 rounded-xl font-semibold cursor-pointer hover:bg-indigo-100 dark:hover:bg-indigo-500/30 transition-colors mt-4"
-              onClick={() => navigate("/mock-interview")}
-            >
-              Back to Lobby
-            </button>
+        <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
+          <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+            <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+            <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+            <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
           </div>
-        </div>
+          <div className="w-full max-w-[900px] relative z-10 flex flex-col gap-6">
+            <div className="flex-1 flex flex-col items-center justify-center gap-4 text-text-muted mt-24">
+              <AlertTriangle size={48} className="text-red-500" />
+              <p className="font-medium text-lg">{error || "No results found."}</p>
+              <button
+                className="bg-indigo-50 dark:bg-indigo-500/15 text-indigo-600 dark:text-indigo-300 border-none py-3 px-6 rounded-xl font-semibold cursor-pointer hover:bg-indigo-100 dark:hover:bg-indigo-500/30 transition-colors mt-4"
+                onClick={() => navigate("/mock-interview")}
+              >
+                Back to Lobby
+              </button>
+            </div>
+          </div>
+        </main>
       </div>
     );
   }
@@ -137,27 +144,35 @@ const InterviewResults = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-bg-main text-text-main flex flex-col font-sans pt-24">
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col overflow-hidden relative">
       <Navbar />
       
-      <main className="max-w-[900px] w-full mx-auto px-8 pb-12 flex flex-col gap-6">
-        
-        {/* Back to Dashboard Link */}
-        <div className="-mt-4 mb-2 flex">
-          <Link 
-            to="/dashboard" 
-            className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
-          >
-            <ArrowLeft size={16} />
-            Back to Dashboard
-          </Link>
+      <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
+        {/* Background glow effects */}
+        <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+          <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+          <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+          <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
         </div>
 
-        {/* Header */}
-        <div className="text-center animate-[fadeIn_0.8s_ease-out] relative pt-4">
-          <h1 className="text-5xl md:text-6xl font-black tracking-tight bg-gradient-to-br from-indigo-600 via-purple-600 to-emerald-500 bg-clip-text text-transparent mb-6 drop-shadow-sm leading-tight">
-            Interview Results
-          </h1>
+        <div className="w-full max-w-[900px] relative z-10 flex flex-col gap-6">
+          
+          {/* Back to Dashboard Link */}
+          <div className="py-6 mt-[-1rem]">
+            <Link 
+              to="/dashboard" 
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
+            >
+              <ArrowLeft size={16} />
+              Back to Dashboard
+            </Link>
+          </div>
+
+          {/* Header */}
+          <div className="text-center animate-[fadeIn_0.8s_ease-out] relative pt-4">
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-6 drop-shadow-sm leading-tight">
+              <span className="text-blue-600 dark:text-blue-500">Interview</span> Results
+            </h1>
         <div className="flex justify-center gap-4 mt-2 flex-wrap">
           <span className="py-1 px-3 rounded-full text-xs font-semibold bg-gradient-to-br from-indigo-500 to-purple-500 text-white">
             {results.topic?.toUpperCase()}
@@ -350,6 +365,7 @@ const InterviewResults = () => {
         >
           <ArrowLeft size={18} /> Back to Dashboard
         </button>
+      </div>
       </div>
       </main>
       <Footer />

--- a/client/src/modules/mock-interview/pages/InterviewResults.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewResults.jsx
@@ -16,6 +16,10 @@ import {
   Clock,
   Loader2,
   ArrowLeft,
+  Video,
+  Play,
+  FileJson,
+  Sparkles
 } from "lucide-react";
 import Navbar from "../../../shared/components/Navbar";
 import Footer from "../../../shared/components/Footer";
@@ -158,7 +162,7 @@ const InterviewResults = () => {
         <div className="w-full max-w-[900px] relative z-10 flex flex-col gap-6">
           
           {/* Back to Dashboard Link */}
-          <div className="py-6 mt-[-1rem]">
+          <div className="py-6">
             <Link 
               to="/dashboard" 
               className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
@@ -168,9 +172,20 @@ const InterviewResults = () => {
             </Link>
           </div>
 
-          {/* Header */}
-          <div className="text-center animate-[fadeIn_0.8s_ease-out] relative pt-4">
-            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-4 drop-shadow-sm">
+          {/* Hero Section */}
+          <div className="text-center space-y-4 mb-10 relative">
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <FileJson className="w-6 h-6 text-purple-600" />
+            </div>
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <Brain className="w-6 h-6 text-emerald-600" />
+            </div>
+
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-purple-500" /> COGNITIVE EVALUATION REPORT
+            </div>
+            
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
               <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Interview</span> Results
             </h1>
         <div className="flex justify-center gap-4 mt-2 flex-wrap">

--- a/client/src/modules/mock-interview/pages/InterviewResults.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewResults.jsx
@@ -170,8 +170,8 @@ const InterviewResults = () => {
 
           {/* Header */}
           <div className="text-center animate-[fadeIn_0.8s_ease-out] relative pt-4">
-            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-6 drop-shadow-sm leading-tight">
-              <span className="text-blue-600 dark:text-blue-500">Interview</span> Results
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-4 drop-shadow-sm">
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Interview</span> Results
             </h1>
         <div className="flex justify-center gap-4 mt-2 flex-wrap">
           <span className="py-1 px-3 rounded-full text-xs font-semibold bg-gradient-to-br from-indigo-500 to-purple-500 text-white">

--- a/client/src/modules/mock-interview/pages/InterviewSession.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewSession.jsx
@@ -157,10 +157,16 @@ const InterviewSession = () => {
     : 0;
 
   return (
-    <div className="min-h-screen bg-white dark:bg-[#0B0F19] text-slate-900 dark:text-white flex flex-col font-sans transition-colors duration-300 pt-24">
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col overflow-hidden relative">
       <Navbar />
 
-      <main className="flex-1 w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pb-12 mt-24 sm:mt-28 flex flex-col lg:flex-row gap-8 items-start">
+      {/* Background glowing elements */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none z-0">
+        <div className="absolute -top-[20%] -left-[10%] w-[50%] h-[50%] rounded-full bg-blue-400/20 dark:bg-blue-900/20 blur-[120px] mix-blend-normal" />
+        <div className="absolute top-[20%] -right-[10%] w-[40%] h-[40%] rounded-full bg-purple-400/20 dark:bg-purple-900/20 blur-[120px] mix-blend-normal" />
+      </div>
+
+      <main className="container mx-auto px-4 max-w-6xl z-10 flex-grow py-8 relative flex flex-col lg:flex-row gap-8 items-start">
         
         {/* LEFT COLUMN: Telemetry & Status */}
         <div className="w-full lg:w-1/3 flex flex-col gap-6">
@@ -171,7 +177,7 @@ const InterviewSession = () => {
                   navigate("/dashboard");
                 }
               }}
-              className="inline-flex items-center gap-2 text-sm font-medium text-red-500 hover:text-red-400 transition-colors"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/20 hover:bg-red-100 dark:hover:bg-red-500/20 text-sm font-medium text-red-600 dark:text-red-400 transition-all backdrop-blur-md shadow-sm"
             >
               <AlertCircle size={16} />
               Exit Session
@@ -179,8 +185,8 @@ const InterviewSession = () => {
           </div>
           
           {/* Status Card */}
-          <div className="bg-white dark:bg-slate-900/60 rounded-3xl p-6 shadow-[0_20px_40px_rgba(0,0,0,0.04)] dark:shadow-none border border-gray-200 dark:border-slate-800 flex flex-col gap-6">
-            <div className="flex items-center gap-4 border-b border-gray-200 dark:border-slate-800 pb-5">
+          <div className="bg-white dark:bg-slate-900/50 rounded-3xl p-6 shadow-sm border border-gray-200 dark:border-white/10 flex flex-col gap-6">
+            <div className="flex items-center gap-4 border-b border-gray-200 dark:border-white/10 pb-5">
               <div className="w-14 h-14 rounded-2xl bg-blue-50 dark:bg-blue-500/10 flex items-center justify-center border border-blue-100 dark:border-blue-500/20">
                 <Activity className="text-blue-600 dark:text-blue-400" size={28} />
               </div>
@@ -241,7 +247,7 @@ const InterviewSession = () => {
           </div>
 
           {/* Progress Card */}
-          <div className="bg-white dark:bg-slate-900/60 rounded-3xl p-6 shadow-[0_20px_40px_rgba(0,0,0,0.04)] dark:shadow-none border border-gray-200 dark:border-slate-800 flex flex-col gap-4">
+          <div className="bg-white dark:bg-slate-900/50 rounded-3xl p-6 shadow-sm border border-gray-200 dark:border-white/10 flex flex-col gap-4">
             <div className="flex justify-between items-end mb-2">
               <h3 className="text-sm font-bold text-slate-900 dark:text-white">Interview Progress</h3>
               <span className="text-sm font-bold text-blue-600 dark:text-blue-400 font-mono">

--- a/client/src/modules/mock-interview/pages/TutorInterviewConsole.jsx
+++ b/client/src/modules/mock-interview/pages/TutorInterviewConsole.jsx
@@ -125,13 +125,20 @@ const TutorInterviewConsole = () => {
   if (!session || !session.userId || !session.answers) return <div className="min-h-screen flex flex-col bg-slate-50 dark:bg-slate-900"><Navbar /><div className="flex-1 pt-24 text-center">Session data is incomplete or missing.</div><Footer /></div>;
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 flex flex-col">
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col overflow-hidden relative">
       <Navbar />
-      <div className="flex-1 px-6 pb-6 pt-24 max-w-5xl mx-auto w-full space-y-6">
+
+      {/* Background glowing elements */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none z-0">
+        <div className="absolute -top-[20%] -left-[10%] w-[50%] h-[50%] rounded-full bg-blue-400/20 dark:bg-blue-900/20 blur-[120px] mix-blend-normal" />
+        <div className="absolute top-[20%] -right-[10%] w-[40%] h-[40%] rounded-full bg-purple-400/20 dark:bg-purple-900/20 blur-[120px] mix-blend-normal" />
+      </div>
+
+      <main className="container mx-auto px-4 max-w-6xl z-10 flex-grow py-8 relative space-y-6">
         
         <div className="flex items-center justify-between">
           <div>
-            <Link to="/tutor/interviews" className="flex items-center gap-2 text-indigo-600 mb-2 hover:text-indigo-500 transition-colors">
+            <Link to="/tutor/interviews" className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/50 dark:bg-white/5 border border-gray-200 dark:border-white/10 hover:bg-gray-50 dark:hover:bg-white/10 text-sm font-medium text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-white transition-all backdrop-blur-md shadow-sm mb-4">
               <ArrowLeft size={16} /> Back to Interviews
             </Link>
             <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Interview Player Console</h1>
@@ -148,7 +155,7 @@ const TutorInterviewConsole = () => {
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <div className="md:col-span-1 space-y-6">
-            <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-slate-200 dark:border-slate-700 shadow-sm">
+            <div className="bg-white dark:bg-slate-900/50 p-6 rounded-3xl border border-gray-200 dark:border-white/10 shadow-sm">
               <h2 className="text-lg font-bold mb-4 border-b pb-2 dark:border-slate-700">Overall Grading</h2>
               
               <div className="mb-4">
@@ -189,7 +196,7 @@ const TutorInterviewConsole = () => {
             <h2 className="text-xl font-bold text-slate-800 dark:text-slate-200">Answer Transcripts & Scoring</h2>
             
             {session.answers.map((ans, idx) => (
-              <div key={idx} className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-slate-200 dark:border-slate-700 shadow-sm">
+              <div key={idx} className="bg-white dark:bg-slate-900/50 p-6 rounded-3xl border border-gray-200 dark:border-white/10 shadow-sm">
                 <div className="flex items-start justify-between mb-4">
                   <h3 className="font-bold text-lg">Q{idx + 1}: {ans.questionText}</h3>
                   {ans.audioPath && (
@@ -260,7 +267,7 @@ const TutorInterviewConsole = () => {
             ))}
           </div>
         </div>
-      </div>
+      </main>
           <Footer />
     </div>
   );

--- a/client/src/modules/mock-interview/pages/TutorInterviewsList.jsx
+++ b/client/src/modules/mock-interview/pages/TutorInterviewsList.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useSelector } from "react-redux";
-import { Clock, CheckCircle, Video, ArrowRight, User, ArrowLeft } from "lucide-react";
+import { Clock, CheckCircle, Video, ArrowRight, ArrowLeft, Users, Sparkles, User } from "lucide-react";
 import { apiRequest } from "../../../services/apiClient.js";
 import Navbar from "../../../shared/components/Navbar";
 import Footer from "../../../shared/components/Footer";
@@ -57,7 +57,7 @@ const TutorInterviewsList = () => {
         <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6">
           
           {/* Back to Dashboard Link */}
-          <div className="py-6 mt-[-1rem]">
+          <div className="py-6">
             <Link 
               to="/dashboard" 
               className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
@@ -67,15 +67,27 @@ const TutorInterviewsList = () => {
             </Link>
           </div>
 
-          {/* Header Section */}
-          <header className="mb-8 text-center max-w-3xl mx-auto relative pt-4 animate-[fadeIn_0.8s_ease-out]">
-            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-4 drop-shadow-sm">
+          {/* Hero Section */}
+          <div className="text-center space-y-4 mb-10 relative">
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <Video className="w-6 h-6 text-purple-600" />
+            </div>
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <Users className="w-6 h-6 text-emerald-600" />
+            </div>
+
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-purple-500" /> MANAGE INTERVIEWS
+            </div>
+            
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
               <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Student</span> Mock Interviews
             </h1>
-            <p className="text-gray-500 dark:text-slate-400 text-lg max-w-2xl mx-auto leading-relaxed">
+            
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
               Review completed AI mock interviews and provide manual feedback.
             </p>
-          </header>
+          </div>
 
         <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-sm border border-slate-200 dark:border-slate-700 overflow-hidden">
           {sessions.length === 0 ? (

--- a/client/src/modules/mock-interview/pages/TutorInterviewsList.jsx
+++ b/client/src/modules/mock-interview/pages/TutorInterviewsList.jsx
@@ -43,21 +43,39 @@ const TutorInterviewsList = () => {
   }
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 flex flex-col">
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col overflow-hidden relative">
       <Navbar />
-      <div className="flex-1 px-6 pb-6 pt-24 sm:px-10 sm:pb-10">
-        <div className="max-w-6xl mx-auto space-y-8">
-        <div>
-          <Link 
-            to="/dashboard" 
-            className="inline-flex items-center gap-2 text-sm text-indigo-600 hover:text-indigo-500 mb-4 transition-colors"
-          >
-            <ArrowLeft size={16} />
-            Back to Dashboard
-          </Link>
-          <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Student Mock Interviews</h1>
-          <p className="text-slate-500 dark:text-slate-400 mt-2">Review completed AI mock interviews and provide manual feedback.</p>
+
+      <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
+        {/* Background glow effects */}
+        <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+          <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+          <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+          <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
         </div>
+
+        <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6">
+          
+          {/* Back to Dashboard Link */}
+          <div className="py-6 mt-[-1rem]">
+            <Link 
+              to="/dashboard" 
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
+            >
+              <ArrowLeft size={16} />
+              Back to Dashboard
+            </Link>
+          </div>
+
+          {/* Header Section */}
+          <header className="mb-8 text-center max-w-3xl mx-auto relative pt-4 animate-[fadeIn_0.8s_ease-out]">
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-6 drop-shadow-sm leading-tight">
+              <span className="text-blue-600 dark:text-blue-500">Student</span> Mock Interviews
+            </h1>
+            <p className="text-gray-500 dark:text-slate-400 text-lg max-w-2xl mx-auto leading-relaxed">
+              Review completed AI mock interviews and provide manual feedback.
+            </p>
+          </header>
 
         <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-sm border border-slate-200 dark:border-slate-700 overflow-hidden">
           {sessions.length === 0 ? (
@@ -127,8 +145,8 @@ const TutorInterviewsList = () => {
             </div>
           )}
         </div>
-      </div>
-      </div>
+        </div>
+      </main>
       <Footer />
     </div>
   );

--- a/client/src/modules/mock-interview/pages/TutorInterviewsList.jsx
+++ b/client/src/modules/mock-interview/pages/TutorInterviewsList.jsx
@@ -69,8 +69,8 @@ const TutorInterviewsList = () => {
 
           {/* Header Section */}
           <header className="mb-8 text-center max-w-3xl mx-auto relative pt-4 animate-[fadeIn_0.8s_ease-out]">
-            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-6 drop-shadow-sm leading-tight">
-              <span className="text-blue-600 dark:text-blue-500">Student</span> Mock Interviews
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight mb-4 drop-shadow-sm">
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Student</span> Mock Interviews
             </h1>
             <p className="text-gray-500 dark:text-slate-400 text-lg max-w-2xl mx-auto leading-relaxed">
               Review completed AI mock interviews and provide manual feedback.

--- a/client/src/modules/recruiter-jobs/pages/RecruiterInsightsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterInsightsPage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
-import { ArrowLeft, Search, Filter, TrendingUp, Users, Award } from "lucide-react";
+import { ArrowLeft, Search, Filter, TrendingUp, Users, Award, Briefcase } from "lucide-react";
 import Navbar from "../../../shared/landing/Navbar";
 import Button from "../../../shared/components/Button";
 import Input from "../../../shared/components/Input";
@@ -96,7 +96,6 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
 
   useEffect(() => {
     fetchInsights(1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [jobId]);
 
   const handleApplyFilters = (event) => {

--- a/client/src/modules/resume-analyzer/pages/ResumeAnalyzerPage.jsx
+++ b/client/src/modules/resume-analyzer/pages/ResumeAnalyzerPage.jsx
@@ -263,7 +263,7 @@ const ResumeAnalyzerPage = () => {
             </div>
             
             <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
-              <span className="text-blue-600 dark:text-blue-500">Resume</span> Analyzer
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Resume</span> Analyzer
             </h1>
             
             <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">

--- a/client/src/modules/student-jobs/components/JobFilters.jsx
+++ b/client/src/modules/student-jobs/components/JobFilters.jsx
@@ -75,10 +75,10 @@ const JobFilters = ({ onFilterChange }) => {
   ];
 
   return (
-    <div className="bg-gray-100 dark:bg-slate-900/50 backdrop-blur-xl border border-gray-200 dark:border-white/10 rounded-2xl p-6 h-fit sticky top-28">
+    <div className="bg-white dark:bg-slate-900/50 backdrop-blur-xl border border-gray-200 dark:border-white/10 rounded-3xl p-6 h-fit sticky top-28 shadow-[0_4px_20px_rgb(0,0,0,0.03)] dark:shadow-none">
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
-          <Filter size={20} className="text-blue-400" />
+        <h2 className="text-lg font-bold text-gray-900 dark:text-white flex items-center gap-2">
+          <Filter size={20} className="text-blue-500" />
           Filters
         </h2>
         <button
@@ -108,7 +108,7 @@ const JobFilters = ({ onFilterChange }) => {
             onChange={handleChange}
             placeholder="e.g. Software Engineer"
             leftIcon={<Search size={18} />}
-            className="bg-slate-800/50 border-white/5 focus:border-blue-500/50"
+            className="bg-white dark:bg-slate-800/50 border-gray-200 dark:border-white/5 focus:border-blue-500/50 text-gray-900 dark:text-white"
           />
         </div>
 
@@ -125,7 +125,7 @@ const JobFilters = ({ onFilterChange }) => {
               value={filters.minSalary}
               onChange={handleChange}
               placeholder="Min"
-              className="bg-slate-800/50 border-white/5 focus:border-blue-500/50"
+              className="bg-white dark:bg-slate-800/50 border-gray-200 dark:border-white/5 focus:border-blue-500/50 text-gray-900 dark:text-white"
             />
             <Input
               id="filter-max-salary"
@@ -134,7 +134,7 @@ const JobFilters = ({ onFilterChange }) => {
               value={filters.maxSalary}
               onChange={handleChange}
               placeholder="Max"
-              className="bg-slate-800/50 border-white/5 focus:border-blue-500/50"
+              className="bg-white dark:bg-slate-800/50 border-gray-200 dark:border-white/5 focus:border-blue-500/50 text-gray-900 dark:text-white"
             />
           </div>
         </div>
@@ -157,7 +157,7 @@ const JobFilters = ({ onFilterChange }) => {
             onChange={handleChange}
             options={dateOptions}
             placeholder="Anytime"
-            className="bg-slate-800/50 border-white/5 focus:border-blue-500/50"
+            className="bg-white dark:bg-slate-800/50 border-gray-200 dark:border-white/5 focus:border-blue-500/50 text-gray-900 dark:text-white"
           />
         </div>
       </div>

--- a/client/src/modules/student-jobs/pages/JobBoardPage.jsx
+++ b/client/src/modules/student-jobs/pages/JobBoardPage.jsx
@@ -120,21 +120,22 @@ const JobBoardPage = () => {
 
           {/* Hero Section */}
           <div className="text-center space-y-4 mb-10 relative">
-            <div className="hidden md:flex absolute top-4 left-[10%] xl:left-[15%] w-16 h-16 bg-white dark:bg-surface border-none rounded-3xl items-center justify-center shadow-[0_8px_30px_rgb(0,0,0,0.06)] dark:shadow-white/5 transform -rotate-3 hover:rotate-0 transition-transform">
-               <Briefcase className="w-7 h-7 text-purple-600" />
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <Briefcase className="w-6 h-6 text-purple-600" />
             </div>
-            <div className="hidden md:flex absolute top-8 right-[10%] xl:right-[15%] w-16 h-16 bg-white dark:bg-surface border-none rounded-3xl items-center justify-center shadow-[0_8px_30px_rgb(0,0,0,0.06)] dark:shadow-white/5 transform rotate-3 hover:rotate-0 transition-transform">
-               <TrendingUp className="w-7 h-7 text-emerald-500" />
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <TrendingUp className="w-6 h-6 text-emerald-600" />
             </div>
 
             <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
               <Sparkles size={12} className="text-purple-500" /> Premium Opportunities
             </div>
             
-            <h1 className="text-5xl md:text-6xl font-black text-gray-900 dark:text-white tracking-tight">
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
               <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Job</span> Board
             </h1>
-            <p className="text-gray-600 dark:text-slate-400 text-lg max-w-2xl mx-auto leading-relaxed">
+            
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
               Browse through curated job listings from top companies looking for talent like you.
             </p>
           </div>

--- a/client/src/modules/student-jobs/pages/JobBoardPage.jsx
+++ b/client/src/modules/student-jobs/pages/JobBoardPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
-import { Briefcase, Info, ArrowLeft } from "lucide-react";
+import { Briefcase, Info, ArrowLeft, Sparkles, TrendingUp } from "lucide-react";
 import Navbar from "../../../shared/components/Navbar";
 import Footer from "../../../shared/components/Footer";
 
@@ -95,28 +95,49 @@ const JobBoardPage = () => {
   };
 
   return (
-    <main className="min-h-screen bg-white dark:bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] text-gray-900 dark:text-slate-100 flex flex-col pt-24">
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col">
       <Navbar />
-      
 
-      
-      <div className="container mx-auto px-4 pb-12 flex-1">
-        {/* Header Section */}
-        <div className="mb-16 text-center max-w-3xl mx-auto">
-          <Link 
-            to="/dashboard" 
-            className="inline-flex items-center gap-2 text-sm text-blue-500 hover:text-blue-400 mb-6 transition-colors"
-          >
-            <ArrowLeft size={16} />
-            Back to Dashboard
-          </Link>
-          <h1 className="text-5xl md:text-6xl font-black mb-6 tracking-tight leading-tight">
-            <span className="text-gradient">Opportunities</span> Await
-          </h1>
-          <p className="text-gray-500 dark:text-slate-400 text-xl leading-relaxed font-medium">
-            Browse through curated job listings from top companies looking for talent like you.
-          </p>
+      <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden">
+        {/* Background glow effects */}
+        <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+          <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+          <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+          <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
         </div>
+
+        <div className="w-full max-w-[1200px] relative z-10">
+          {/* Back to Dashboard Link */}
+          <div className="py-6">
+            <Link 
+              to="/dashboard" 
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
+            >
+              <ArrowLeft size={16} />
+              Back to Dashboard
+            </Link>
+          </div>
+
+          {/* Hero Section */}
+          <div className="text-center space-y-4 mb-10 relative">
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <Briefcase className="w-6 h-6 text-purple-600" />
+            </div>
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <TrendingUp className="w-6 h-6 text-emerald-600" />
+            </div>
+
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-purple-500" /> Premium Opportunities
+            </div>
+            
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+              <span className="text-blue-600 dark:text-blue-500">Job</span> Board
+            </h1>
+            <p className="text-gray-500 dark:text-slate-400 text-lg max-w-2xl mx-auto leading-relaxed">
+              Browse through curated job listings from top companies looking for talent like you.
+            </p>
+          </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
           {/* Filters Sidebar */}
@@ -191,7 +212,9 @@ const JobBoardPage = () => {
             )}
           </div>
         </div>
-      </div>
+        </div>
+      </main>
+
       {/* Apply Form Modal */}
       {applyModalJob && (
         <JobApplyForm
@@ -202,8 +225,8 @@ const JobBoardPage = () => {
           isSubmitting={!!applyingJobId}
         />
       )}
-          <Footer />
-    </main>
+      <Footer />
+    </div>
   );
 };
 

--- a/client/src/modules/student-jobs/pages/JobBoardPage.jsx
+++ b/client/src/modules/student-jobs/pages/JobBoardPage.jsx
@@ -198,11 +198,11 @@ const JobBoardPage = () => {
 
             {/* Quick Note */}
             {!loading && jobs.length > 0 && (
-              <div className="mt-10 p-5 rounded-2xl bg-slate-900/50 border border-white/5 flex gap-4 items-start">
-                <div className="p-2 bg-blue-500/10 text-blue-400 rounded-lg shrink-0">
+              <div className="mt-10 p-5 rounded-2xl bg-[#898F9C] dark:bg-slate-900/50 border-none dark:border-white/5 flex gap-4 items-center shadow-sm">
+                <div className="p-2 bg-white/20 dark:bg-blue-500/10 text-blue-100 dark:text-blue-400 rounded-lg shrink-0">
                   <Info size={20} />
                 </div>
-                <p className="text-sm text-slate-400 leading-relaxed">
+                <p className="text-sm text-gray-100 dark:text-slate-400 leading-relaxed font-medium">
                   Showing all active job listings. Jobs are updated daily based on company availability and recruiter postings. 
                   Ensure your profile is complete to improve your chances of getting noticed!
                 </p>

--- a/client/src/modules/student-jobs/pages/JobBoardPage.jsx
+++ b/client/src/modules/student-jobs/pages/JobBoardPage.jsx
@@ -132,7 +132,7 @@ const JobBoardPage = () => {
             </div>
             
             <h1 className="text-5xl md:text-6xl font-black text-gray-900 dark:text-white tracking-tight">
-              <span className="bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">Job</span> Board
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Job</span> Board
             </h1>
             <p className="text-gray-600 dark:text-slate-400 text-lg max-w-2xl mx-auto leading-relaxed">
               Browse through curated job listings from top companies looking for talent like you.

--- a/client/src/modules/student-jobs/pages/JobBoardPage.jsx
+++ b/client/src/modules/student-jobs/pages/JobBoardPage.jsx
@@ -95,7 +95,7 @@ const JobBoardPage = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col">
+    <div className="min-h-screen bg-slate-50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col">
       <Navbar />
 
       <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden">
@@ -120,21 +120,21 @@ const JobBoardPage = () => {
 
           {/* Hero Section */}
           <div className="text-center space-y-4 mb-10 relative">
-            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
-               <Briefcase className="w-6 h-6 text-purple-600" />
+            <div className="hidden md:flex absolute top-4 left-[10%] xl:left-[15%] w-16 h-16 bg-white dark:bg-surface border-none rounded-3xl items-center justify-center shadow-[0_8px_30px_rgb(0,0,0,0.06)] dark:shadow-white/5 transform -rotate-3 hover:rotate-0 transition-transform">
+               <Briefcase className="w-7 h-7 text-purple-600" />
             </div>
-            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
-               <TrendingUp className="w-6 h-6 text-emerald-600" />
+            <div className="hidden md:flex absolute top-8 right-[10%] xl:right-[15%] w-16 h-16 bg-white dark:bg-surface border-none rounded-3xl items-center justify-center shadow-[0_8px_30px_rgb(0,0,0,0.06)] dark:shadow-white/5 transform rotate-3 hover:rotate-0 transition-transform">
+               <TrendingUp className="w-7 h-7 text-emerald-500" />
             </div>
 
             <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
               <Sparkles size={12} className="text-purple-500" /> Premium Opportunities
             </div>
             
-            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
-              <span className="text-blue-600 dark:text-blue-500">Job</span> Board
+            <h1 className="text-5xl md:text-6xl font-black text-gray-900 dark:text-white tracking-tight">
+              <span className="bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">Job</span> Board
             </h1>
-            <p className="text-gray-500 dark:text-slate-400 text-lg max-w-2xl mx-auto leading-relaxed">
+            <p className="text-gray-600 dark:text-slate-400 text-lg max-w-2xl mx-auto leading-relaxed">
               Browse through curated job listings from top companies looking for talent like you.
             </p>
           </div>
@@ -147,13 +147,11 @@ const JobBoardPage = () => {
 
           {/* Job List Area */}
           <div className="lg:col-span-3">
-            <div className="mb-6 flex items-center justify-between">
-              <h2 className="text-xl font-semibold text-gray-800 dark:text-slate-200 flex items-center gap-2">
-                Available Jobs
-                <span className="text-sm font-normal text-slate-500 bg-slate-800/50 px-2 py-0.5 rounded-full border border-white/5">
-                  {loading ? "..." : jobs.length}
-                </span>
-              </h2>
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="text-lg font-bold text-gray-900 dark:text-white flex items-center gap-3">
+                Available Jobs 
+                <span className="bg-gray-200 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-xs px-2.5 py-0.5 rounded-full">{totalCount}</span>
+              </h3>
             </div>
 
 

--- a/client/src/modules/student-jobs/pages/MyApplicationsPage.jsx
+++ b/client/src/modules/student-jobs/pages/MyApplicationsPage.jsx
@@ -375,25 +375,31 @@ const MyApplicationsPage = () => {
           <div className="py-6">
             <Link 
               to="/dashboard" 
-              className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
             >
               <ArrowLeft size={16} />
               Back to Dashboard
             </Link>
           </div>
 
-          {/* Header */}
-          <div className="mb-12 text-center max-w-3xl mx-auto relative pt-4">
-            <div className="relative flex flex-col items-center">
-              <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 text-xs font-bold tracking-wider uppercase mb-6 border border-blue-100 dark:border-blue-800/50">
-                <Briefcase size={14} /> TRACK YOUR PROGRESS
-              </div>
+          {/* Hero Section */}
+          <div className="text-center space-y-4 mb-10 relative">
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <Briefcase className="w-6 h-6 text-purple-600" />
+            </div>
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <Target className="w-6 h-6 text-emerald-600" />
             </div>
 
-            <h1 className="text-5xl md:text-6xl font-black mb-6 tracking-tight leading-tight">
-              <span className="bg-clip-text text-transparent bg-gradient-to-r from-blue-600 via-indigo-500 to-emerald-400">My</span> Applications
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-purple-500" /> TRACK YOUR PROGRESS
+            </div>
+            
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">My</span> Applications
             </h1>
-            <p className="text-lg text-gray-600 dark:text-slate-400 font-medium">
+            
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
               Track and manage all the jobs you&apos;ve applied to
             </p>
           </div>

--- a/client/src/shared/components/CommandPalette.jsx
+++ b/client/src/shared/components/CommandPalette.jsx
@@ -23,7 +23,7 @@ const CommandPalette = () => {
       { id: 'resume', name: 'Resume Analyzer', path: '/resume-analyzer', icon: <FileSearch size={18} /> },
       { id: 'jobs', name: 'Job Board', path: '/jobs', icon: <Briefcase size={18} /> },
       { id: 'match', name: 'Smart Job Matching', path: '/job-matcher', icon: <Sparkles size={18} /> },
-      { id: 'cover', name: 'Cover Letters', path: '/cover-letters', icon: <FileText size={18} /> },
+      { id: 'cover', name: 'Analyzer History', path: '/resume-history', icon: <FileText size={18} /> },
       { id: 'roadmap', name: 'Career Roadmap', path: '/roadmap', icon: <Rocket size={18} /> }
     );
   } else if (user?.role === 'recruiter') {

--- a/client/src/shared/components/JobViewerCard.jsx
+++ b/client/src/shared/components/JobViewerCard.jsx
@@ -163,7 +163,7 @@ const JobViewerCard = ({
       className={`group w-full max-w-full transition-all duration-300 border backdrop-blur-md rounded-2xl overflow-hidden ${
         isExpanded
           ? "bg-white dark:bg-slate-900/80 border-blue-500/30 shadow-[0_0_30px_rgba(59,130,246,0.15)]"
-          : "bg-white/80 dark:bg-slate-900/40 border-gray-200 dark:border-white/5 hover:border-blue-300 dark:hover:border-white/10 hover:bg-white dark:hover:bg-slate-900/60 shadow-sm"
+          : "bg-white dark:bg-slate-900/40 border-gray-200 dark:border-white/5 hover:border-blue-300 dark:hover:border-white/10 shadow-sm"
       } ${className}`}
     >
       {/* ── Collapsed Header ── */}
@@ -182,7 +182,7 @@ const JobViewerCard = ({
       >
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-5">
           {/* Company Logo Placeholder */}
-          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-blue-100 dark:border-white/5 bg-gradient-to-br from-blue-50 to-purple-50 dark:from-blue-500/20 dark:to-purple-500/20 transition-transform duration-300 group-hover:scale-105 sm:h-14 sm:w-14 md:group-hover:scale-110">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-blue-100 dark:border-white/5 bg-blue-50 dark:bg-blue-500/20 transition-transform duration-300 group-hover:scale-105 sm:h-14 sm:w-14 md:group-hover:scale-110">
             <Briefcase size={28} className="text-blue-600 dark:text-blue-400 max-sm:h-6 max-sm:w-6" />
           </div>
 
@@ -230,8 +230,8 @@ const JobViewerCard = ({
                   )}
                 </p>
               </div>
-              <div className="mt-1 shrink-0 text-gray-400 dark:text-slate-500 transition-colors group-hover:text-blue-600 dark:group-hover:text-blue-400">
-                {isExpanded ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
+              <div className="mt-1 shrink-0 text-blue-500 transition-colors group-hover:text-blue-600 dark:group-hover:text-blue-400">
+                <ChevronDown size={20} className={`transform transition-transform ${isExpanded ? "rotate-180" : "-rotate-90"}`} />
               </div>
             </div>
 

--- a/client/src/shared/components/Navbar.jsx
+++ b/client/src/shared/components/Navbar.jsx
@@ -95,7 +95,7 @@ const Navbar = () => {
           { name: 'Job Board', path: '/jobs', icon: <Briefcase size={20} /> },
           { name: 'Job Match', path: '/job-matcher', icon: <Sparkles size={20} /> },
           { name: 'Resume Analyzer', path: '/resume-analyzer', icon: <FileText size={20} /> },
-          { name: 'Cover Letters', path: '/cover-letters', icon: <FileText size={20} /> },
+          { name: 'Analyzer History', path: '/resume-history', icon: <FileText size={20} /> },
           { name: 'Roadmap', path: '/roadmap', icon: <Rocket size={20} /> },
           { name: 'Live Classrooms', path: '/classrooms', icon: <Video size={20} /> }
         ]

--- a/client/src/shared/components/Pagination.jsx
+++ b/client/src/shared/components/Pagination.jsx
@@ -16,19 +16,19 @@ const Pagination = ({ currentPage, totalPages, onPageChange }) => {
       <button
         onClick={() => onPageChange(currentPage - 1)}
         disabled={currentPage <= 1}
-        className="flex items-center gap-1 px-4 py-2 text-sm font-medium text-slate-300 bg-slate-800/50 border border-white/10 rounded-xl hover:bg-slate-700/50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+        className="flex items-center gap-1 px-4 py-2 text-sm font-medium text-slate-500 dark:text-slate-300 bg-slate-100 dark:bg-slate-800/50 border border-slate-200 dark:border-white/10 rounded-xl hover:bg-slate-200 dark:hover:bg-slate-700/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <ChevronLeft size={16} />
         Previous
       </button>
-      <span className="text-sm font-medium text-slate-400">
-        Page <span className="text-white">{currentPage}</span> of{" "}
-        <span className="text-white">{totalPages}</span>
+      <span className="text-sm font-medium text-slate-500 dark:text-slate-400">
+        Page <span className="text-gray-900 dark:text-white">{currentPage}</span> of{" "}
+        <span className="text-gray-900 dark:text-white">{totalPages}</span>
       </span>
       <button
         onClick={() => onPageChange(currentPage + 1)}
         disabled={currentPage >= totalPages}
-        className="flex items-center gap-1 px-4 py-2 text-sm font-medium text-slate-300 bg-slate-800/50 border border-white/10 rounded-xl hover:bg-slate-700/50 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+        className="flex items-center gap-1 px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-blue-600 rounded-xl hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-blue-400 disabled:border-blue-400"
       >
         Next
         <ChevronRight size={16} />

--- a/server/runSeeder.js
+++ b/server/runSeeder.js
@@ -1,0 +1,19 @@
+import dotenv from "dotenv";
+dotenv.config();
+
+import { seedJobData } from "./src/modules/jobs/seed/seedJobData.js";
+import logger from "./src/utils/logger.js";
+import { default as connectDB } from "./src/database/db.js";
+
+const run = async () => {
+  try {
+    await connectDB();
+    logger.log("Connected to MongoDB for seeding.");
+    await seedJobData();
+    process.exit(0);
+  } catch (error) {
+    logger.error("Seeding failed", error);
+    process.exit(1);
+  }
+};
+run();

--- a/server/src/modules/classrooms/controller.js
+++ b/server/src/modules/classrooms/controller.js
@@ -1,4 +1,5 @@
 import asyncHandler from "../../utils/asyncHandler.js";
+import { getIO } from "../../utils/socketIO.js";
 import * as classroomService from "./service.js";
 
 /**
@@ -58,6 +59,12 @@ export const getClassroomSessionByRoomId = asyncHandler(async (req, res, next) =
 export const endClassroomSession = asyncHandler(async (req, res, next) => {
   const { roomId } = req.params;
   const session = await classroomService.endSession(roomId, req.user._id);
+
+  // Broadcast to all clients in the room that the session has ended
+  const io = getIO();
+  if (io) {
+    io.to(roomId).emit("session-ended", { roomId });
+  }
 
   res.status(200).json({
     success: true,

--- a/server/src/modules/classrooms/socket.js
+++ b/server/src/modules/classrooms/socket.js
@@ -9,6 +9,7 @@ import registerWhiteboardHandler from "./socketHandlers/whiteboardHandler.js";
 import registerCodeEditorHandler from "./socketHandlers/codeEditorHandler.js";
 
 const roomStates = new Map();
+const teardownTimeouts = new Map();
 
 export function getOrCreateRoomState(roomId) {
   if (!roomStates.has(roomId)) {
@@ -74,6 +75,13 @@ export function initClassroomSockets(io) {
             role: currentUser.role,
           },
         };
+
+        // Clear any pending teardown timeouts since someone joined
+        if (teardownTimeouts.has(roomId)) {
+          clearTimeout(teardownTimeouts.get(roomId));
+          teardownTimeouts.delete(roomId);
+          logger.log(`Teardown aborted for room ${roomId}, a user joined.`);
+        }
 
         logger.log(
           `User ${socket.data.user.name} (${socket.id}) joining room ${roomId}`,
@@ -167,12 +175,39 @@ export function initClassroomSockets(io) {
 
             // Automatically teardown/end the classroom session in database if empty
             if (session.participants.length === 0) {
-              logger.log(`Classroom ${roomId} empty. Automatically ending session.`);
-              session.status = "ended";
-              session.endedAt = new Date();
-
-              clearRoomState(roomId);
-              clearRoomLock(roomId);
+              logger.log(`Classroom ${roomId} empty. Initiating 30-second teardown countdown...`);
+              
+              if (!teardownTimeouts.has(roomId)) {
+                const timeoutId = setTimeout(async () => {
+                  try {
+                    const tearLock = getRoomLock(roomId);
+                    const tearRelease = await tearLock.acquire();
+                    
+                    try {
+                      const finalSessionCheck = await ClassroomSession.findOne({
+                        roomId,
+                        status: "active",
+                      });
+                      
+                      if (finalSessionCheck && finalSessionCheck.participants.length === 0) {
+                        logger.log(`Classroom ${roomId} teardown timer completed. Automatically ending session.`);
+                        finalSessionCheck.status = "ended";
+                        finalSessionCheck.endedAt = new Date();
+                        await finalSessionCheck.save();
+                        clearRoomState(roomId);
+                        clearRoomLock(roomId);
+                      }
+                    } finally {
+                      tearRelease();
+                      teardownTimeouts.delete(roomId);
+                    }
+                  } catch (err) {
+                    logger.error("Error during teardown execution:", err);
+                  }
+                }, 30000); // 30 second grace period
+                
+                teardownTimeouts.set(roomId, timeoutId);
+              }
             }
 
             await session.save();

--- a/server/src/modules/jobs/seed/seedJobData.js
+++ b/server/src/modules/jobs/seed/seedJobData.js
@@ -157,13 +157,24 @@ export const seedJobData = async () => {
       logger.log("[seed] Created mock recruiter for seeded jobs.");
     }
 
-    const jobsToInsert = jobPostingsData.map(job => ({
+    let jobsToInsert = jobPostingsData.map(job => ({
       ...job,
       recruiter: recruiter._id
     }));
 
-    await JobPosting.insertMany(jobsToInsert);
-    logger.log(`[seed] ✅ ${jobsToInsert.length} Job Postings seeded successfully!`);
+    // Duplicate the jobs to create a large dataset (500 jobs total)
+    const expandedJobs = [];
+    for (let i = 0; i < 50; i++) {
+      jobsToInsert.forEach((job, index) => {
+        expandedJobs.push({
+          ...job,
+          title: i === 0 ? job.title : `${job.title} - ${i + 1}`,
+        });
+      });
+    }
+
+    await JobPosting.insertMany(expandedJobs);
+    logger.log(`[seed] ✅ ${expandedJobs.length} Job Postings seeded successfully!`);
   } catch (error) {
     logger.error("[seed] Error seeding job data:", error);
   }


### PR DESCRIPTION
## Description
This PR significantly upgrades the `ResumeAnalyzerHistoryPage` to address missing data and navigation limitations, bringing it to a full production-ready standard. 
Previously, the page only fetched and displayed Cover Letters while completely ignoring Resume Analyses. Additionally, because the backend limits responses to 10 items to maintain performance, users with robust histories could not navigate past their 10 most recent items due to a lack of frontend pagination. 
This update resolves these issues by introducing a tabbed interface to manage both sets of data independently, fully supported by robust pagination logic.
**Key Changes:**
- **Tab Navigation Introduced:** Added an animated pill-style tab selector right below the hero section to easily toggle between "Resume Analyses" and "Cover Letters".
- **Resume Analyses Implementation:** Implemented UI cards to surface past Resume Analyses (which were previously hidden), including score displays, "Top Tier" badges for high scores, and direct "View Report" navigation.
- **Robust Pagination:** Added the `Pagination` component to both tabs and updated `dashboardService.js` to correctly pass `page` and `limit` URL parameters back to the server, ensuring users can access their unabridged history.
- **Maintained UI Standardization:** Ensured all new cards, empty states, and tabs strictly match the beautiful aesthetic layout (floating icons, badges, text gradients) we established for the rest of the dashboard.
## Resolved Issue
Resolves #1174
## UI Screen Recording

https://github.com/user-attachments/assets/f1382f73-399d-4ce0-970c-c5801debed70

