### PR TITLE
[BUG] errorMiddleware: production non-operational errors leak inconsi…

### DIFF
--- a/server/src/middleware/errorMiddleware.js
+++ b/server/src/middleware/errorMiddleware.js
@@ -185,12 +185,20 @@ const globalErrorHandler = (err, req, res, next) => {
       });
     } else {
       logger.error("ERROR 💥", error);
-      res.status(500).json({
+
+      // Standardize non-operational error payload shape for frontend reliability.
+      // Frontend may expect `errors` and `statusCode` consistently.
+      const statusCode = 500;
+
+      res.status(statusCode).json({
         success: false,
         status: "error",
+        statusCode,
         message: "Something went very wrong!",
+        errors: {},
       });
     }
+
   }
 };
 


### PR DESCRIPTION
Fixed inconsistent production error payload schema for non-operational errors in server/src/middleware/errorMiddleware.js.

Change: in the production, non-operational branch (error.isOperational === false), the handler now always returns a stable schema including:

errors: {} (was missing)
statusCode: 500 (added for frontend consistency)
New payload:
{
success: false,
status: "error",
statusCode: 500,
message: "Something went very wrong!",
errors: {}
}


closes #1194