### PR TITLE
test:  errorMiddleware: AI error mapping can incorrectly classify non-AI er…

### DIFF
--- a/server/src/__tests__/errorMiddleware.aiDetection.test.js
+++ b/server/src/__tests__/errorMiddleware.aiDetection.test.js
@@ -1,0 +1,74 @@
+const globalErrorHandler = require("../middleware/errorMiddleware.js");
+
+// NOTE: these tests validate AI classification gating logic.
+// They intentionally pass in a non-AI operational error whose message contains "google"
+// to ensure it is NOT re-mapped via handleAIError().
+
+describe("errorMiddleware AI detection", () => {
+  const makeRes = () => {
+    const res = {
+      statusCode: null,
+      payload: null,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload) {
+        this.payload = payload;
+        return this;
+      },
+    };
+    return res;
+  };
+
+  const next = () => {};
+
+  test("does not classify non-AI operational errors containing " +
+    "\"google\" as AI", async () => {
+    process.env.NODE_ENV = "production";
+
+    const err = new Error("Operational failure while calling google service");
+    err.isOperational = true;
+    err.statusCode = 502;
+    err.status = "error";
+    err.errors = undefined;
+    err.isAxiosError = false;
+    err.type = undefined;
+    err.name = "OperationalError";
+    err.provider = undefined;
+
+    const req = { method: "GET", originalUrl: "/api/test" };
+    const res = makeRes();
+
+    globalErrorHandler(err, req, res, next);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.payload.message).toBe("Operational failure while calling google service");
+
+    // If misclassified as AI, payload.message would be rewritten.
+    expect(res.payload.message).not.toMatch(/AI service is currently unavailable/i);
+  });
+
+  test("classifies GoogleGenerativeAI errors as AI", async () => {
+    process.env.NODE_ENV = "production";
+
+    const err = new Error("Bad request");
+    err.isOperational = true;
+    err.status = 400;
+    err.statusCode = 400;
+    err.code = undefined;
+    err.isAxiosError = false;
+    err.type = undefined;
+    err.name = "GoogleGenerativeAI";
+    err.provider = "google";
+
+    const req = { method: "GET", originalUrl: "/api/test" };
+    const res = makeRes();
+
+    globalErrorHandler(err, req, res, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.payload.message).toMatch(/AI request was invalid|AI Authentication failed|AI access forbidden/i);
+  });
+});
+

--- a/server/src/middleware/errorMiddleware.js
+++ b/server/src/middleware/errorMiddleware.js
@@ -134,13 +134,16 @@ const globalErrorHandler = (err, req, res, next) => {
   if (error.name === "ValidationError") error = handleValidationErrorDB(error);
   
   // Handle AI errors (Axios/OpenAI-like + Gemini/Google Generative AI)
+  // IMPORTANT: Do NOT classify AI errors solely by message text (e.g. "google"),
+  // otherwise non-AI operational errors containing these words get misclassified.
   if (
     error.isAxiosError ||
     error.type === "invalid_request_error" ||
     error?.name === "GoogleGenerativeAI" ||
     error?.provider === "google" ||
-    (typeof error?.status === 'number') ||
-    /gemini|generative ai|google/i.test(String(error?.message || ""))
+    (typeof error?.status === "number" &&
+      // Gate status-based heuristics behind known AI/provider identifiers.
+      (error?.name === "GoogleGenerativeAI" || error?.provider === "google"))
   ) {
     error = handleAIError(error);
   }


### PR DESCRIPTION
Implemented fix in server/src/middleware/errorMiddleware.js to prevent misclassification of non-AI errors as AI based only on message text.

Removed the regex trigger: /gemini|generative ai|google/i.test(error.message) from the AI-detection condition.
AI mapping now relies on structured identifiers first:
error.isAxiosError
error.type === "invalid_request_error"
error.name === "GoogleGenerativeAI"
error.provider === "google"
and gated status-based logic behind the same provider/name indicators.
Added a regression test:

server/src/__tests__/errorMiddleware.aiDetection.test.js
Asserts that an operational error containing the word “google” is NOT re-mapped to the AI service messages.
Asserts that a GoogleGenerativeAI error shape IS mapped as AI.


closes #1193