### PR TITLE
feat(notifications): implement full-stack category filtering and pagi…

### DIFF
--- a/client/src/modules/notifications/hooks/useNotifications.js
+++ b/client/src/modules/notifications/hooks/useNotifications.js
@@ -13,7 +13,7 @@ import {
  * Custom hook for managing notifications
  * Provides access to notifications state and dispatch functions
  */
-export const useNotifications = ({ page = 1, limit = 10, filter = "all" } = {}) => {
+export const useNotifications = ({ page = 1, limit = 10, filter = "all", type } = {}) => {
   const dispatch = useDispatch();
   const { items, unreadCount, loading, error, pagination, socketStatus } = useSelector(
     (state) => state.notifications,
@@ -26,9 +26,9 @@ export const useNotifications = ({ page = 1, limit = 10, filter = "all" } = {}) 
 
   // Fetch notifications on component mount
   useEffect(() => {
-    dispatch(getNotifications({ page, limit, isRead }));
+    dispatch(getNotifications({ page, limit, isRead, type }));
     dispatch(getUnreadCount());
-  }, [dispatch, page, limit, isRead]);
+  }, [dispatch, page, limit, isRead, type]);
 
   // Mark single notification as read
   const handleMarkAsRead = useCallback(
@@ -60,9 +60,9 @@ export const useNotifications = ({ page = 1, limit = 10, filter = "all" } = {}) 
   const handleLoadMore = useCallback(() => {
     const nextPage = pagination.page + 1;
     if (nextPage <= pagination.pages) {
-      dispatch(getNotifications({ page: nextPage, limit, isRead }));
+      dispatch(getNotifications({ page: nextPage, limit, isRead, type }));
     }
-  }, [dispatch, pagination, limit, isRead]);
+  }, [dispatch, pagination, limit, isRead, type]);
 
   return {
     notifications: items,

--- a/client/src/modules/notifications/pages/NotificationsPage.jsx
+++ b/client/src/modules/notifications/pages/NotificationsPage.jsx
@@ -82,6 +82,7 @@ const NotificationsPage = () => {
   const navigate = useNavigate();
   const { user } = useSelector((state) => state.auth);
   const [filterRead, setFilterRead] = useState("all");
+  const [filterType, setFilterType] = useState("all");
   const [expandedFilters, setExpandedFilters] = useState(false);
   const [selectedNotifications, setSelectedNotifications] = useState(new Set());
 
@@ -99,6 +100,7 @@ const NotificationsPage = () => {
     socketStatus,
   } = useNotifications({
     filter: filterRead,
+    type: filterType === "all" ? undefined : filterType,
     limit: NOTIFICATIONS_PAGE_SIZE,
   });
 
@@ -108,15 +110,36 @@ const NotificationsPage = () => {
     }
   }, [user, navigate]);
 
+  const matchesCategory = (notificationType, categoryFilter) => {
+    if (categoryFilter === "all") return true;
+    if (categoryFilter === "jobs") {
+      return ["job-update", "application", "new_application"].includes(notificationType);
+    }
+    if (categoryFilter === "interviews") {
+      return ["interview"].includes(notificationType);
+    }
+    if (categoryFilter === "system") {
+      return ["info", "warning", "success", "error", "skill_gap_alert"].includes(notificationType);
+    }
+    return false;
+  };
+
   const filteredNotifications = notifications.filter((notification) => {
-    if (filterRead === "read") return notification.isRead;
-    if (filterRead === "unread") return !notification.isRead;
+    if (filterRead === "read" && !notification.isRead) return false;
+    if (filterRead === "unread" && notification.isRead) return false;
+    if (!matchesCategory(notification.type, filterType)) return false;
     return true;
   });
 
   const handleFilterChange = (option) => {
     if (option === filterRead) return;
     setFilterRead(option);
+    setSelectedNotifications(new Set());
+  };
+
+  const handleTypeChange = (type) => {
+    if (type === filterType) return;
+    setFilterType(type);
     setSelectedNotifications(new Set());
   };
 
@@ -249,20 +272,48 @@ const NotificationsPage = () => {
           </div>
 
           {expandedFilters && (
-            <div className="flex gap-2 p-3 bg-slate-50 dark:bg-slate-800/50 rounded-lg border border-slate-200 dark:border-slate-700">
-              {["all", "unread", "read"].map((option) => (
-                <button
-                  key={option}
-                  onClick={() => handleFilterChange(option)}
-                  className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                    filterRead === option
-                      ? "bg-blue-500 text-white"
-                      : "bg-white dark:bg-slate-700 text-slate-900 dark:text-white border border-slate-300 dark:border-slate-600 hover:bg-slate-100 dark:hover:bg-slate-600"
-                  }`}
-                >
-                  {option.charAt(0).toUpperCase() + option.slice(1)}
-                </button>
-              ))}
+            <div className="p-4 bg-slate-50 dark:bg-slate-800/50 rounded-lg border border-slate-200 dark:border-slate-700 space-y-4">
+              <div>
+                <span className="block text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">Read Status</span>
+                <div className="flex flex-wrap gap-2">
+                  {["all", "unread", "read"].map((option) => (
+                    <button
+                      key={option}
+                      onClick={() => handleFilterChange(option)}
+                      className={`px-4 py-2 rounded-lg font-medium text-sm transition-colors ${
+                        filterRead === option
+                          ? "bg-blue-500 text-white"
+                          : "bg-white dark:bg-slate-700 text-slate-900 dark:text-white border border-slate-300 dark:border-slate-600 hover:bg-slate-100 dark:hover:bg-slate-600"
+                      }`}
+                    >
+                      {option.charAt(0).toUpperCase() + option.slice(1)}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <span className="block text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">Category</span>
+                <div className="flex flex-wrap gap-2">
+                  {[
+                    { id: "all", label: "All Categories" },
+                    { id: "jobs", label: "Jobs" },
+                    { id: "interviews", label: "Interviews" },
+                    { id: "system", label: "System Alerts" }
+                  ].map((category) => (
+                    <button
+                      key={category.id}
+                      onClick={() => handleTypeChange(category.id)}
+                      className={`px-4 py-2 rounded-lg font-medium text-sm transition-colors ${
+                        filterType === category.id
+                          ? "bg-blue-500 text-white"
+                          : "bg-white dark:bg-slate-700 text-slate-900 dark:text-white border border-slate-300 dark:border-slate-600 hover:bg-slate-100 dark:hover:bg-slate-600"
+                      }`}
+                    >
+                      {category.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
             </div>
           )}
         </div>

--- a/client/src/services/notificationService.js
+++ b/client/src/services/notificationService.js
@@ -10,11 +10,15 @@ import { apiRequest } from "./apiClient";
  * @returns {Promise<Object>} The API response containing notifications and pagination
  */
 export const fetchNotifications = async (token, params = {}) => {
-  const { page = 1, limit = 10, isRead } = params;
+  const { page = 1, limit = 10, isRead, type } = params;
   let queryString = `?page=${page}&limit=${limit}`;
   
   if (isRead !== undefined) {
     queryString += `&isRead=${isRead}`;
+  }
+
+  if (type) {
+    queryString += `&type=${type}`;
   }
 
   return apiRequest(`/api/notifications${queryString}`, {

--- a/server/src/modules/notifications/__tests__/controller.test.js
+++ b/server/src/modules/notifications/__tests__/controller.test.js
@@ -89,6 +89,41 @@ describe("Notification Controller", () => {
       assert.equal(data[0].metadata.relatedModel, "JobPosting");
       assert.equal(data[1].metadata.actionUrl, "/dashboard");
     });
+
+    it("should throw AppError(400) when type filter is invalid", async () => {
+      req.query = { type: "invalid-category" };
+      getNotifications(req, res, next);
+      await flush();
+
+      assert.equal(next.mock.calls.length, 1);
+      assert.ok(next.mock.calls[0].arguments[0] instanceof AppError);
+      assert.equal(next.mock.calls[0].arguments[0].statusCode, 400);
+    });
+
+    it("should throw AppError(400) when type filter is too long", async () => {
+      req.query = { type: "a".repeat(51) };
+      getNotifications(req, res, next);
+      await flush();
+
+      assert.equal(next.mock.calls.length, 1);
+      assert.ok(next.mock.calls[0].arguments[0] instanceof AppError);
+      assert.equal(next.mock.calls[0].arguments[0].statusCode, 400);
+    });
+
+    it("should respond with 200 when a valid type filter is provided", async () => {
+      const mockNotifications = [{ _id: "n1", title: "Test", type: "job-update" }];
+      mock.method(Notification, "find", () => ({
+        sort: () => ({ skip: () => ({ limit: () => ({ populate: () => mockNotifications }) }) }),
+      }));
+      mock.method(Notification, "countDocuments", () => 1);
+
+      req.query = { type: "jobs" };
+      getNotifications(req, res, next);
+      await flush();
+
+      assert.equal(res.status.mock.calls[0].arguments[0], 200);
+      assert.equal(res.json.mock.calls[0].arguments[0].success, true);
+    });
   });
 
   describe("getUnreadCount", () => {

--- a/server/src/modules/notifications/controller.js
+++ b/server/src/modules/notifications/controller.js
@@ -96,10 +96,33 @@ const serializeNotification = (notification) => {
  * @access  Private
  */
 export const getNotifications = asyncHandler(async (req, res) => {
-  const { page, limit, isRead } = req.query;
+  const { page, limit, isRead, type } = req.query;
   const userId = req.user._id;
 
-  const result = await getUserNotifications(userId, { page, limit, isRead });
+  if (type) {
+    if (typeof type !== "string" || type.length > 50) {
+      throw new AppError("Invalid type filter", 400);
+    }
+    const validTypes = [
+      "jobs",
+      "interviews",
+      "system",
+      "info",
+      "warning",
+      "success",
+      "error",
+      "job-update",
+      "interview",
+      "application",
+      "new_application",
+      "skill_gap_alert",
+    ];
+    if (!validTypes.includes(type)) {
+      throw new AppError(`Type filter must be one of: ${validTypes.join(", ")}`, 400);
+    }
+  }
+
+  const result = await getUserNotifications(userId, { page, limit, isRead, type });
 
   res.status(200).json({
     success: true,

--- a/server/src/modules/notifications/service.js
+++ b/server/src/modules/notifications/service.js
@@ -35,12 +35,24 @@ export const createNotification = async (notificationData) => {
  * @returns {Promise<Object>} - Notifications and metadata
  */
 export const getUserNotifications = async (userId, queryParams = {}) => {
-  const { page = 1, limit = 20, isRead } = queryParams;
+  const { page = 1, limit = 20, isRead, type } = queryParams;
 
   const filters = { userId };
 
   if (isRead !== undefined) {
     filters.isRead = isRead === "true" || isRead === true;
+  }
+
+  if (type) {
+    if (type === "jobs") {
+      filters.type = { $in: ["job-update", "application", "new_application"] };
+    } else if (type === "interviews") {
+      filters.type = { $in: ["interview"] };
+    } else if (type === "system") {
+      filters.type = { $in: ["info", "warning", "success", "error", "skill_gap_alert"] };
+    } else {
+      filters.type = type;
+    }
   }
 
   const skip = (page - 1) * limit;


### PR DESCRIPTION
## Summary

This change implements full-stack category-based filtering and pagination for the notifications system. Users can now filter their notifications by category (Jobs, Interviews, and System Alerts) from the UI, with the queries handled efficiently on the backend, while supporting seamless infinite-scroll pagination.

## Type of Change

- [x] Feature


## Related Issue

Closes #1226 

## Changes Made

- **Backend Service (`getUserNotifications`):** Extended query parameter handling to map incoming UI categories (`jobs`, `interviews`, `system`) to corresponding array groups of MongoDB schema types.
- **Backend Controller (`getNotifications`):** Added string validation and length limits (<= 50 chars) for the `type` filter, and updated controller tests with 3 new unit test cases.
- **Frontend Service (`fetchNotifications`):** Updated the apiRequest query string builder to append the new `type` parameter when requesting notifications.
- **Frontend Hook (`useNotifications`):** Extended hook parameters to accept `type`, added it to the `useEffect` trigger dependencies for automatic reload, and forwarded it through pagination requests.
- **Frontend UI (`NotificationsPage.jsx`):** Added a tab-based category filter panel (All Categories, Jobs, Interviews, System Alerts) within the expanded filter drawer and bound it to React state.

## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated


## Screenshots
<img width="1044" height="674" alt="image" src="https://github.com/user-attachments/assets/cad9e3a1-7b7f-4096-b744-1644b30029f1" />
