### PR TITLE
feat(jobs): support sorting and limiting in job recommendations API

### DIFF
--- a/server/src/modules/jobs/__tests__/service.test.js
+++ b/server/src/modules/jobs/__tests__/service.test.js
@@ -160,7 +160,9 @@ describe("Job Service", () => {
       ];
 
       const mockLimitFn = mock.fn(async () => mockJobs);
+      const mockSortFn = mock.fn(() => ({ limit: mockLimitFn }));
       mock.method(JobPosting, "find", () => ({
+        sort: mockSortFn,
         limit: mockLimitFn
       }));
 
@@ -188,6 +190,187 @@ describe("Job Service", () => {
       assert.equal(result.jobs.length, 1);
       assert.equal(result.jobs[0].matchScore, 85);
       assert.equal(result.jobs[0].relevanceInsights, "Great match");
+    });
+
+    it("should sort recommendations by matchScore (default/score) descending and limit results", async () => {
+      const mockUser = { _id: new mongoose.Types.ObjectId() };
+      const mockResume = {
+        _id: "resume123",
+        skills: ["React"],
+        keywords: ["Developer"]
+      };
+
+      const mockQuery = {
+        select: mock.fn(() => mockQuery),
+        lean: mock.fn(async () => mockResume)
+      };
+      mock.method(Resume, "findOne", () => mockQuery);
+
+      const mockJobs = [
+        { _id: "job1", title: "Job 1", salary: { max: 100 }, createdAt: new Date("2026-06-01"), _doc: { _id: "job1", title: "Job 1", salary: { max: 100 }, createdAt: new Date("2026-06-01") } },
+        { _id: "job2", title: "Job 2", salary: { max: 200 }, createdAt: new Date("2026-06-03"), _doc: { _id: "job2", title: "Job 2", salary: { max: 200 }, createdAt: new Date("2026-06-03") } },
+        { _id: "job3", title: "Job 3", salary: { max: 150 }, createdAt: new Date("2026-06-02"), _doc: { _id: "job3", title: "Job 3", salary: { max: 150 }, createdAt: new Date("2026-06-02") } }
+      ];
+
+      const mockLimitFn = mock.fn(async () => mockJobs);
+      const mockSortFn = mock.fn(() => ({ limit: mockLimitFn }));
+      mock.method(JobPosting, "find", () => ({
+        sort: mockSortFn,
+        limit: mockLimitFn
+      }));
+
+      const mockMatchResult = {
+        recommendations: [
+          { job: "job1", score: 70 },
+          { job: "job2", score: 95 },
+          { job: "job3", score: 85 }
+        ]
+      };
+      mock.method(matchingService, "evaluateMatches", async () => mockMatchResult);
+      mock.method(matchingService, "getLatestRecommendations", async () => null);
+
+      // Verify default sorting by score and limiting to 2
+      const result = await jobService.getJobRecommendations(mockUser, { sortBy: "score", limit: 2 });
+      assert.equal(result.success, true);
+      assert.equal(result.jobs.length, 2);
+      assert.equal(result.jobs[0].title, "Job 2"); // score 95
+      assert.equal(result.jobs[1].title, "Job 3"); // score 85
+    });
+
+    it("should sort recommendations by highest salary descending when sortBy: 'salary' is passed", async () => {
+      const mockUser = { _id: new mongoose.Types.ObjectId() };
+      const mockResume = {
+        _id: "resume123",
+        skills: ["React"],
+        keywords: ["Developer"]
+      };
+
+      const mockQuery = {
+        select: mock.fn(() => mockQuery),
+        lean: mock.fn(async () => mockResume)
+      };
+      mock.method(Resume, "findOne", () => mockQuery);
+
+      const mockJobs = [
+        { _id: "job1", title: "Job 1", salary: { max: 100 }, createdAt: new Date("2026-06-01"), _doc: { _id: "job1", title: "Job 1", salary: { max: 100 }, createdAt: new Date("2026-06-01") } },
+        { _id: "job2", title: "Job 2", salary: { max: 200 }, createdAt: new Date("2026-06-03"), _doc: { _id: "job2", title: "Job 2", salary: { max: 200 }, createdAt: new Date("2026-06-03") } },
+        { _id: "job3", title: "Job 3", salary: { max: 150 }, createdAt: new Date("2026-06-02"), _doc: { _id: "job3", title: "Job 3", salary: { max: 150 }, createdAt: new Date("2026-06-02") } }
+      ];
+
+      const mockLimitFn = mock.fn(async () => mockJobs);
+      const mockSortFn = mock.fn(() => ({ limit: mockLimitFn }));
+      mock.method(JobPosting, "find", () => ({
+        sort: mockSortFn,
+        limit: mockLimitFn
+      }));
+
+      const mockMatchResult = {
+        recommendations: [
+          { job: "job1", score: 70 },
+          { job: "job2", score: 95 },
+          { job: "job3", score: 85 }
+        ]
+      };
+      mock.method(matchingService, "evaluateMatches", async () => mockMatchResult);
+      mock.method(matchingService, "getLatestRecommendations", async () => null);
+
+      const result = await jobService.getJobRecommendations(mockUser, { sortBy: "salary" });
+      assert.equal(result.success, true);
+      assert.equal(result.jobs.length, 3);
+      assert.equal(result.jobs[0].title, "Job 2"); // salary max 200
+      assert.equal(result.jobs[1].title, "Job 3"); // salary max 150
+      assert.equal(result.jobs[2].title, "Job 1"); // salary max 100
+      // Check MongoDB sort was called with {"salary.max": -1}
+      assert.equal(mockSortFn.mock.calls.length, 1);
+      assert.deepEqual(mockSortFn.mock.calls[0].arguments[0], { "salary.max": -1 });
+    });
+
+    it("should sort recommendations by posting date descending when sortBy: 'date' is passed", async () => {
+      const mockUser = { _id: new mongoose.Types.ObjectId() };
+      const mockResume = {
+        _id: "resume123",
+        skills: ["React"],
+        keywords: ["Developer"]
+      };
+
+      const mockQuery = {
+        select: mock.fn(() => mockQuery),
+        lean: mock.fn(async () => mockResume)
+      };
+      mock.method(Resume, "findOne", () => mockQuery);
+
+      const mockJobs = [
+        { _id: "job1", title: "Job 1", salary: { max: 100 }, createdAt: new Date("2026-06-01"), _doc: { _id: "job1", title: "Job 1", salary: { max: 100 }, createdAt: new Date("2026-06-01") } },
+        { _id: "job2", title: "Job 2", salary: { max: 200 }, createdAt: new Date("2026-06-03"), _doc: { _id: "job2", title: "Job 2", salary: { max: 200 }, createdAt: new Date("2026-06-03") } },
+        { _id: "job3", title: "Job 3", salary: { max: 150 }, createdAt: new Date("2026-06-02"), _doc: { _id: "job3", title: "Job 3", salary: { max: 150 }, createdAt: new Date("2026-06-02") } }
+      ];
+
+      const mockLimitFn = mock.fn(async () => mockJobs);
+      const mockSortFn = mock.fn(() => ({ limit: mockLimitFn }));
+      mock.method(JobPosting, "find", () => ({
+        sort: mockSortFn,
+        limit: mockLimitFn
+      }));
+
+      const mockMatchResult = {
+        recommendations: [
+          { job: "job1", score: 70 },
+          { job: "job2", score: 95 },
+          { job: "job3", score: 85 }
+        ]
+      };
+      mock.method(matchingService, "evaluateMatches", async () => mockMatchResult);
+      mock.method(matchingService, "getLatestRecommendations", async () => null);
+
+      const result = await jobService.getJobRecommendations(mockUser, { sortBy: "date" });
+      assert.equal(result.success, true);
+      assert.equal(result.jobs.length, 3);
+      assert.equal(result.jobs[0].title, "Job 2"); // createdAt 2026-06-03
+      assert.equal(result.jobs[1].title, "Job 3"); // createdAt 2026-06-02
+      assert.equal(result.jobs[2].title, "Job 1"); // createdAt 2026-06-01
+      // Check MongoDB sort was called with {createdAt: -1}
+      assert.equal(mockSortFn.mock.calls.length, 1);
+      assert.deepEqual(mockSortFn.mock.calls[0].arguments[0], { createdAt: -1 });
+    });
+
+    it("should cap the recommendation limit at 50 if a larger limit is requested", async () => {
+      const mockUser = { _id: new mongoose.Types.ObjectId() };
+      const mockResume = {
+        _id: "resume123",
+        skills: ["React"],
+        keywords: ["Developer"]
+      };
+
+      const mockQuery = {
+        select: mock.fn(() => mockQuery),
+        lean: mock.fn(async () => mockResume)
+      };
+      mock.method(Resume, "findOne", () => mockQuery);
+
+      const mockJobs = Array.from({ length: 60 }, (_, i) => ({
+        _id: `job${i}`,
+        title: `Job ${i}`,
+        salary: { max: 100 },
+        createdAt: new Date("2026-06-01"),
+        _doc: { _id: `job${i}`, title: `Job ${i}`, salary: { max: 100 }, createdAt: new Date("2026-06-01") }
+      }));
+
+      const mockLimitFn = mock.fn(async () => mockJobs);
+      const mockSortFn = mock.fn(() => ({ limit: mockLimitFn }));
+      mock.method(JobPosting, "find", () => ({
+        sort: mockSortFn,
+        limit: mockLimitFn
+      }));
+
+      const mockMatchResult = {
+        recommendations: mockJobs.map((j, i) => ({ job: j._id, score: 50 + (i % 50) }))
+      };
+      mock.method(matchingService, "evaluateMatches", async () => mockMatchResult);
+      mock.method(matchingService, "getLatestRecommendations", async () => null);
+
+      const result = await jobService.getJobRecommendations(mockUser, { limit: 100 });
+      assert.equal(result.success, true);
+      assert.equal(result.jobs.length, 50); // capped at 50
     });
   });
 

--- a/server/src/modules/jobs/controller.js
+++ b/server/src/modules/jobs/controller.js
@@ -247,7 +247,8 @@ export const getJobs = asyncHandler(async (req, res) => {
  * @access  Private (Students only)
  */
 export const getRecommendations = asyncHandler(async (req, res) => {
-  const recommendations = await getJobRecommendations(req.user);
+  const { sortBy, limit } = req.query;
+  const recommendations = await getJobRecommendations(req.user, { sortBy, limit });
   res.status(200).json(recommendations);
 });
 

--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -221,12 +221,48 @@ export const deleteJob = async (id, recruiterId) => {
 };
 
 /**
+ * Helper to sort and limit recommendations in memory.
+ * @param {Array} jobs - List of recommendations with job details and matchScore
+ * @param {string} sortBy - Sort strategy ("score", "salary", "date")
+ * @param {number} limit - Number of items to return
+ * @returns {Array} Sorted and limited recommendations
+ */
+const sortAndLimitRecommendations = (jobs, sortBy, limit) => {
+  const sortedJobs = [...jobs];
+  if (sortBy === "salary") {
+    sortedJobs.sort((a, b) => {
+      const salaryA = a.salary?.max ?? 0;
+      const salaryB = b.salary?.max ?? 0;
+      return salaryB - salaryA;
+    });
+  } else if (sortBy === "date") {
+    sortedJobs.sort((a, b) => {
+      const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return dateB - dateA;
+    });
+  } else {
+    // Default/score: Sort by matchScore descending (highest first)
+    sortedJobs.sort((a, b) => {
+      const scoreA = a.matchScore ?? 0;
+      const scoreB = b.matchScore ?? 0;
+      return scoreB - scoreA;
+    });
+  }
+  return sortedJobs.slice(0, limit);
+};
+
+/**
  * Get personalized job recommendations for a student based on their resume.
  * 
  * @param {Object} user - The authenticated user object
+ * @param {Object} options - Query options (sortBy, limit)
  * @returns {Promise<Object>} Recommendations and status message
  */
-export const getJobRecommendations = async (user) => {
+export const getJobRecommendations = async (user, options = {}) => {
+  const { sortBy = "score", limit = 20 } = options;
+  const parsedLimit = Math.min(50, Math.max(1, parseInt(limit) || 20));
+
   // 1. Get the latest parsed resume for the user
   const resume = await resumeService.getLatestResume(user._id, true);
 
@@ -257,10 +293,12 @@ export const getJobRecommendations = async (user) => {
         };
       }).filter(Boolean);
       
+      const sortedAndLimitedJobs = sortAndLimitRecommendations(jobsWithDetails, sortBy, parsedLimit);
+      
       return {
         success: true,
         message: "Personalized matches found by SkillSphere AI",
-        jobs: jobsWithDetails,
+        jobs: sortedAndLimitedJobs,
         hasResume: true
       };
     }
@@ -295,14 +333,22 @@ export const getJobRecommendations = async (user) => {
     ];
   }
 
+  // Configure MongoDB sorting
+  let dbSort = {};
+  if (sortBy === "salary") {
+    dbSort = { "salary.max": -1 };
+  } else if (sortBy === "date") {
+    dbSort = { createdAt: -1 };
+  }
+
   // Fetch only the relevant subset of jobs (limit to 100 at DB level)
-  let openJobs = await JobPosting.find(query).limit(100);
+  let openJobs = await JobPosting.find(query).sort(dbSort).limit(100);
 
   // Fallback: If no jobs strictly match the skills/keywords, just fetch the latest 10 open jobs
   // This ensures the AI always has something to evaluate and recommend
   if (openJobs.length === 0) {
     openJobs = await JobPosting.find({ status: "open" })
-      .sort({ createdAt: -1 })
+      .sort(sortBy === "salary" ? { "salary.max": -1 } : { createdAt: -1 })
       .limit(10);
   }
 
@@ -333,10 +379,12 @@ export const getJobRecommendations = async (user) => {
     };
   });
 
+  const sortedAndLimitedJobs = sortAndLimitRecommendations(jobsWithDetails, sortBy, parsedLimit);
+
   return {
     success: true,
     message: "Personalized matches found by SkillSphere AI",
-    jobs: jobsWithDetails,
+    jobs: sortedAndLimitedJobs,
     hasResume: true
   };
 };


### PR DESCRIPTION


#### **Description:**
This PR enhances the `getJobRecommendations` API to accept `sortBy` and `limit` query parameters.
* **Sorting Strategies:** Supports sorting by matching score (`score`), maximum salary (`salary`), and posting date (`date`).
* **Database Optimization:** Performs database-level sorting for `salary` and `date` strategies before fetching the pre-filtered set of jobs.
* **In-Memory Logic:** Sorts and limits the final evaluated recommendations using a safe helper function.
* **Performance Protection:** Enforces a maximum limit cap of `50` recommendations per request.

closes issue #1225 

#### **Verification:**
* Added five comprehensive unit tests in [service.test.js](file:///c:/Users/hp/SkillsSphere-AI/server/src/modules/jobs/__tests__/service.test.js) checking sorting strategies, limit capping, default options, and mock chains.
* Run backend tests: `npm test` inside the `server` directory (all new tests passed).

