### PR TITLE
feat(jobs): add sorting and limiting dropdown controls to student job…

### DIFF
--- a/client/src/modules/job-matcher/pages/JobMatcherPage.jsx
+++ b/client/src/modules/job-matcher/pages/JobMatcherPage.jsx
@@ -32,15 +32,17 @@ export default function JobMatcherPage() {
   const [isUploading, setIsUploading] = useState(false);
   const fileInputRef = useRef(null);
   const ITEMS_PER_PAGE = 6;
+  const [sortBy, setSortBy] = useState("score");
+  const [limit, setLimit] = useState(20);
 
   useEffect(() => {
-    if (refreshTrigger === 0) return;
+    if (!token) return;
 
     const fetchRecommendations = async () => {
       setLoading(true);
       setError(null);
       try {
-        const data = await getRecommendations(token);
+        const data = await getRecommendations(token, { sortBy, limit });
         setJobs(data.jobs || []);
         setHasResume(data.hasResume !== false);
         setMessage(data.message || "");
@@ -60,7 +62,7 @@ export default function JobMatcherPage() {
     };
 
     fetchRecommendations();
-  }, [token, refreshTrigger]);
+  }, [token, refreshTrigger, sortBy, limit]);
 
   const handleFileUpload = async (e) => {
     const file = e.target.files?.[0];
@@ -226,7 +228,7 @@ export default function JobMatcherPage() {
         </div>
 
         {/* Results Section */}
-        {refreshTrigger === 0 && !loading && !error ? null : loading ? (
+        {!hasResume && !loading && !error ? null : loading ? (
           <div className="min-h-[400px] flex items-center justify-center bg-gray-100 dark:bg-slate-900/30 rounded-2xl border border-gray-200 dark:border-white/5 backdrop-blur-sm">
             <LoadingState message="Analyzing your profile for the best matches..." />
           </div>
@@ -261,16 +263,58 @@ export default function JobMatcherPage() {
         ) : (
           /* Recommendations found */
           <div>
-            <div className="mb-6 flex items-center gap-3">
-              <div className="p-2 bg-blue-500/10 rounded-lg">
-                <Sparkles size={20} className="text-blue-400" />
+            <div className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-blue-500/10 rounded-lg">
+                  <Sparkles size={20} className="text-blue-400" />
+                </div>
+                <h2 className="text-xl font-semibold text-gray-800 dark:text-slate-200">
+                  Recommended for You
+                  <span className="ml-2 text-sm font-normal text-slate-600 dark:text-slate-400 bg-slate-200 dark:bg-slate-800/50 px-2 py-0.5 rounded-full border border-gray-300 dark:border-white/5">
+                    {jobs.length}
+                  </span>
+                </h2>
               </div>
-              <h2 className="text-xl font-semibold text-gray-800 dark:text-slate-200">
-                Recommended for You
-                <span className="ml-2 text-sm font-normal text-slate-600 dark:text-slate-400 bg-slate-200 dark:bg-slate-800/50 px-2 py-0.5 rounded-full border border-gray-300 dark:border-white/5">
-                  {jobs.length}
-                </span>
-              </h2>
+
+              {/* Sorting and Limiting Controls */}
+              <div className="flex flex-wrap items-center gap-4">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                    Sort By:
+                  </span>
+                  <select
+                    value={sortBy}
+                    onChange={(e) => {
+                      setSortBy(e.target.value);
+                      setCurrentPage(1);
+                    }}
+                    className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-800 rounded-xl px-3 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 text-gray-700 dark:text-slate-200"
+                  >
+                    <option value="score">Best Match</option>
+                    <option value="salary">Highest Salary</option>
+                    <option value="date">Most Recent</option>
+                  </select>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                    Limit:
+                  </span>
+                  <select
+                    value={limit}
+                    onChange={(e) => {
+                      setLimit(Number(e.target.value));
+                      setCurrentPage(1);
+                    }}
+                    className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-800 rounded-xl px-3 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 text-gray-700 dark:text-slate-200"
+                  >
+                    <option value="5">5 Matches</option>
+                    <option value="10">10 Matches</option>
+                    <option value="20">20 Matches</option>
+                    <option value="50">50 Matches</option>
+                  </select>
+                </div>
+              </div>
             </div>
 
             <div className="grid grid-cols-1 gap-5">

--- a/client/src/modules/job-matcher/services/matcherService.js
+++ b/client/src/modules/job-matcher/services/matcherService.js
@@ -3,8 +3,10 @@ import { apiRequest } from "../../../services/apiClient";
 /**
  * Get AI-powered job recommendations based on the student's latest resume
  * @param {string} token - Auth token
+ * @param {Object} options - Query options (sortBy, limit)
  * @returns {Promise<Object>} - { success, message, jobs, hasResume }
  */
-export const getRecommendations = async (token) => {
-  return apiRequest("/api/jobs/recommendations", { token });
+export const getRecommendations = async (token, options = {}) => {
+  const { sortBy = "score", limit = 20 } = options;
+  return apiRequest(`/api/jobs/recommendations?sortBy=${sortBy}&limit=${limit}`, { token });
 };


### PR DESCRIPTION


## Summary
Enhances the Student Job Matching UI by adding dropdown controls next to the recommendations header. This allows students to sort their job recommendations by matching score, highest salary, or posting date, and limit the returned results to 5, 10, 20, or 50 matches. Recommendations are also now automatically loaded on page mount if the student has a resume on file.

## Type of Change
- [x] Feature


## Related Issue
Closes #1225 

## Changes Made
* **Added Selector State hooks:** Integrated `sortBy` (defaulting to `"score"`) and `limit` (defaulting to `20`) state hooks in `JobMatcherPage.jsx`.
* **Created Dropdown Selectors:** Implemented responsive select inputs in the recommended jobs section header to control the sorting strategy and results limit.
* **Auto-Load on Mount:** Replaced the initial `refreshTrigger === 0` return check in the mount `useEffect` to fetch recommendations immediately on page load when the user is logged in.
* **Reactive refetching:** Configured the `useEffect` hook to automatically refetch data from the recommendations API endpoint whenever `sortBy` or `limit` is updated by the student.
* **Service parameter support:** Updated the `getRecommendations` API helper function in `matcherService.js` to accept sorting/limiting configurations and append them as query parameters.

## Validation
- [x] Build passes locally


## Screenshots
<img width="1309" height="295" alt="image" src="https://github.com/user-attachments/assets/952ff703-4bbe-4c6f-9394-c86b5769837b" />

