### PR TITLE
fix: notify applicants when job posting is deleted

### DIFF
--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -228,9 +228,23 @@ export const deleteJob = async (id, recruiterId) => {
       }
 
       // Delete all associated applications
-      await JobApplication.deleteMany({ job: id }).session(dbSession);
-      
-      await JobPosting.findByIdAndDelete(id).session(dbSession);
+      const applications = await JobApplication.find({ job: id }).select("applicant");
+await JobApplication.deleteMany({ job: id });
+await JobPosting.findByIdAndDelete(id);
+
+const io = getIO();
+for (const app of applications) {
+  await Notification.create({
+    userId: app.applicant,
+    type: "application",
+    title: "Job Posting Removed",
+    message: `A job you applied to has been removed by the recruiter.`,
+    metadata: { jobId: id }
+  });
+  if (io) {
+    io.to(`user_${app.applicant}`).emit("new-notification", {});
+  }
+}
 
       await dbSession.commitTransaction();
     } catch (error) {

--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -256,24 +256,30 @@ for (const app of applications) {
     }
   } else {
     const job = await JobPosting.findById(id);
-
     if (!job) {
       throw new AppError("Job not found", 404);
     }
-
-    // Check if the recruiter owns this job
     if (job.recruiter.toString() !== recruiterId.toString()) {
       throw new AppError("You do not have permission to delete this job", 403);
     }
-
-    // Delete all associated applications
+    const applications = await JobApplication.find({ job: id }).select("applicant");
     await JobApplication.deleteMany({ job: id });
-    
     await JobPosting.findByIdAndDelete(id);
+
+    const io = getIO();
+    for (const app of applications) {
+      await Notification.create({
+        userId: app.applicant,
+        type: "application",
+        title: "Job Posting Removed",
+        message: `A job you applied to has been removed by the recruiter.`,
+        metadata: { jobId: id }
+      });
+      if (io) {
+        io.to(`user_${app.applicant}`).emit("new-notification", {});
+      }
+    }
   }
-};
-
-
 /**
  * Helper to sort and limit recommendations in memory.
  * @param {Array} jobs - List of recommendations with job details and matchScore


### PR DESCRIPTION
Fixes #1180

## Problem
In `server/src/modules/jobs/service.js`, the `deleteJob` function 
was silently deleting all job applications without notifying 
the affected applicants:

await JobApplication.deleteMany({ job: id });
await JobPosting.findByIdAndDelete(id);

Students who applied had no idea their application was removed.

## Fix
Added notification logic before deletion:
- Fetch all applicants before deleting applications
- Create a notification for each applicant
- Emit real-time socket notification to each applicant

## Changes
- `server/src/modules/jobs/service.js` — notify applicants on job deletion