### PR TITLE
fix: add limit to getTutorSessions and getActiveSessions to prevent memory issues

### DIFF
--- a/server/src/modules/classrooms/service.js
+++ b/server/src/modules/classrooms/service.js
@@ -35,6 +35,7 @@ export const createSession = async (hostId, { title, subject, maxParticipants })
 export const getTutorSessions = async (hostId) => {
   return await ClassroomSession.find({ host: hostId })
     .sort({ createdAt: -1 })
+    .limit(50)
     .lean();
 };
 
@@ -102,6 +103,7 @@ export const getActiveSessions = async () => {
   return await ClassroomSession.find({ status: "active" })
     .populate("host", "name profilePic role")
     .sort({ createdAt: -1 })
+    .limit(20)
     .lean();
 };
 


### PR DESCRIPTION
Fixes #1238

## Problem
In `server/src/modules/classrooms/service.js`, both 
`getTutorSessions` and `getActiveSessions` were fetching ALL 
records with no limit, loading everything into memory at once.

## Fix
Added reasonable limits:
- `getTutorSessions` — limited to 50 sessions
- `getActiveSessions` — limited to 20 active sessions

## Changes
- `server/src/modules/classrooms/service.js` — 2 lines added