### PR TITLE
fix: prevent user enumeration in forgot password and resend OTP flows

### DIFF
--- a/server/src/modules/auth/service.js
+++ b/server/src/modules/auth/service.js
@@ -131,7 +131,7 @@ export const forgotPasswordRequest = async (email) => {
   const user = await User.findOne({ email });
 
   if (!user) {
-    throw new AppError("No account found with this email address", 404);
+    return { success: true, message: "If an account exists with this email, a reset code has been sent." };
   }
 
   const otp = generateOTP();
@@ -149,7 +149,7 @@ export const forgotPasswordRequest = async (email) => {
     throw new AppError("Failed to send reset code. Please try again.", 500);
   }
 
-  return { success: true, message: "A reset code has been sent to your email." };
+  return { success: true, message: "If an account exists with this email, a reset code has been sent." };
 };
 
 // 🔄 Reset password
@@ -189,7 +189,7 @@ export const resendUserOTP = async (email) => {
   const user = await User.findOne({ email });
 
   if (!user) {
-    throw new AppError("No account found with this email address", 404);
+    return { success: true, message: "If an account exists with this email, a verification code has been sent." };
   }
 
   if (user.isVerified) {
@@ -211,7 +211,7 @@ export const resendUserOTP = async (email) => {
     throw new AppError("Failed to resend verification code. Please try again.", 500);
   }
 
-  return { success: true, message: "A new verification code has been sent to your email." };
+  return { success: true, message: "If an account exists with this email, a verification code has been sent." };
 };
 
 export const loginUser = async (email, password) => {


### PR DESCRIPTION
Closes #1245

This PR fixes a security issue where the forgot password and resend OTP endpoints previously returned different responses depending on whether an email address was registered on the platform. Attackers could use these response differences to enumerate valid user accounts without authentication.

The vulnerable behavior has now been removed and both endpoints return the same generic success response regardless of whether the provided email exists in the database. This prevents attackers from determining which email addresses are associated with valid accounts while preserving the existing OTP generation and email delivery logic for legitimate users.

I verified that requests made with both registered and unregistered email addresses now receive identical HTTP 200 responses and the same generic message. Password reset functionality and OTP delivery continue to work normally for valid accounts after the changes.

This improves overall application security by preventing user enumeration through authentication-related endpoints while preserving existing functionality.

I have also attached screenshots after fix,

Forgot password requests using registered email :
<img width="699" height="248" alt="Screenshot 2026-06-04 202638" src="https://github.com/user-attachments/assets/569c0299-351b-4fdb-93b7-bcc72e0b7ec7" />
Forgot password requests using unregistered email :
<img width="704" height="269" alt="Screenshot 2026-06-04 202915" src="https://github.com/user-attachments/assets/ca6060c6-d2f1-4a80-ac21-db4cce290174" />

 
