### PR TITLE
Fix: Major Backend Security, Authorization, and Performance Issues

### DIFF
--- a/server/src/database/models/User.js
+++ b/server/src/database/models/User.js
@@ -65,6 +65,7 @@ const userSchema = new mongoose.Schema(
     verificationTokenExpires: { type: Date, default: null },
     resetPasswordToken: { type: String, default: null },
     resetPasswordExpires: { type: Date, default: null },
+    passwordChangedAt: { type: Date, default: null },
 
     otpAttempts: {
       type: Number,

--- a/server/src/middleware/authMiddleware.js
+++ b/server/src/middleware/authMiddleware.js
@@ -42,7 +42,17 @@ export const protect = asyncHandler(async (req, res, next) => {
       );
     }
 
-    // 4) GRANT ACCESS TO PROTECTED ROUTE
+    // 5) Check if user changed password after the token was issued
+    if (currentUser.passwordChangedAt && decoded.iat) {
+      const changedTimestamp = parseInt(currentUser.passwordChangedAt.getTime() / 1000, 10);
+      if (decoded.iat < changedTimestamp) {
+        return next(
+          new AppError("User recently changed password! Please log in again.", 401)
+        );
+      }
+    }
+
+    // 6) GRANT ACCESS TO PROTECTED ROUTE
     req.user = currentUser;
     next();
   } catch (error) {
@@ -96,6 +106,13 @@ export const verifySocketToken = async (token) => {
   const user = await User.findById(decoded.userId).select("-password");
   if (!user) {
     throw new Error("User not found");
+  }
+
+  if (user.passwordChangedAt && decoded.iat) {
+    const changedTimestamp = parseInt(user.passwordChangedAt.getTime() / 1000, 10);
+    if (decoded.iat < changedTimestamp) {
+      throw new Error("User recently changed password");
+    }
   }
 
   return user;

--- a/server/src/modules/auth/service.js
+++ b/server/src/modules/auth/service.js
@@ -145,6 +145,10 @@ export const forgotPasswordRequest = async (email) => {
     return { success: true, message: "If an account exists with this email, a reset code has been sent." };
   }
 
+  if (user.resetPasswordExpires && user.resetPasswordExpires.getTime() > Date.now() + (OTP_EXPIRY_MINUTES - 1) * 60 * 1000) {
+    throw new AppError("Please wait a minute before requesting another reset code", 429);
+  }
+
   const otp = generateOTP();
   const otpExpiry = new Date(Date.now() + OTP_EXPIRY_MINUTES * 60 * 1000);
   const hashedOtp = await bcrypt.hash(otp, SALT_ROUNDS);
@@ -196,9 +200,10 @@ export const resetUserPassword = async (email, otp, newPassword) => {
   const hashedPassword = await bcrypt.hash(newPassword, SALT_ROUNDS);
 
   user.password = hashedPassword;
-  user.resetPasswordToken = null;
-  user.resetPasswordExpires = null;
+  user.resetPasswordToken = undefined;
+  user.resetPasswordExpires = undefined;
   user.otpAttempts = 0;
+  user.passwordChangedAt = new Date();
   await user.save();
 
   return { success: true, message: "Password reset successfully" };
@@ -214,6 +219,10 @@ export const resendUserOTP = async (email) => {
 
   if (user.isVerified) {
     throw new AppError("User is already verified", 400);
+  }
+
+  if (user.verificationTokenExpires && user.verificationTokenExpires.getTime() > Date.now() + (OTP_EXPIRY_MINUTES - 1) * 60 * 1000) {
+    throw new AppError("Please wait a minute before requesting another verification code", 429);
   }
 
   const otp = generateOTP();

--- a/server/src/modules/files/controller.js
+++ b/server/src/modules/files/controller.js
@@ -62,14 +62,17 @@ const checkResumeAccess = async (userId, filename) => {
   }).select("_id");
 
   if (resumeDoc) {
-    const jobApp = await JobApplication.findOne({ resume: resumeDoc._id })
+    const jobApps = await JobApplication.find({ resume: resumeDoc._id })
       .populate({
         path: "job",
-        match: { recruiter: userId },
-        select: "_id recruiter",
+        select: "recruiter",
       });
 
-    if (jobApp && jobApp.job) {
+    const hasAccess = jobApps.some(
+      (app) => app.job && app.job.recruiter && app.job.recruiter.toString() === userId.toString()
+    );
+
+    if (hasAccess) {
       return true;
     }
   }

--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -280,6 +280,7 @@ for (const app of applications) {
       }
     }
   }
+};
 /**
  * Helper to sort and limit recommendations in memory.
  * @param {Array} jobs - List of recommendations with job details and matchScore
@@ -373,23 +374,21 @@ export const getJobRecommendations = async (user, options = {}) => {
     ...(resume.keywords || []),
   ].map((term) => term.trim().toLowerCase()).filter(Boolean);
 
-  const uniqueTerms = [...new Set(candidateTerms)];
+  const uniqueTerms = [...new Set(candidateTerms)].slice(0, 30);
 
   if (uniqueTerms.length > 0) {
     // Pre-filter: Only fetch jobs where at least one skill or title matches a candidate term.
-    // This drastically reduces the number of jobs sent to the AI evaluator.
     const escapeRegex = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     
-    // We avoid \b for terms with special characters (like C++, Node.js) as it causes matching issues
-    const regexTerms = uniqueTerms.map((term) => {
-      const escaped = escapeRegex(term);
-      return new RegExp(`^${escaped}$|\\b${escaped}\\b`, "i");
-    });
+    // For exact match in arrays (highly optimized by MongoDB indexes)
+    const exactRegexTerms = uniqueTerms.map((term) => new RegExp(`^${escapeRegex(term)}$`, "i"));
+    // For substring match in title (prevents ReDoS from backtracking \b)
+    const substringRegexTerms = uniqueTerms.map((term) => new RegExp(escapeRegex(term), "i"));
     
     query.$or = [
-      { skills: { $in: regexTerms } },
-      { keywords: { $in: regexTerms } },
-      { title: { $in: regexTerms } }
+      { skills: { $in: exactRegexTerms } },
+      { keywords: { $in: exactRegexTerms } },
+      { title: { $in: substringRegexTerms } }
     ];
   }
 


### PR DESCRIPTION
##  Description
This PR resolves three major backend issues relating to resume authorization, ReDoS vulnerabilities in job recommendations, and insecure password resets.
###  Changes Included
#### 1. Fixed Resume Authorization (403 Errors)
- **Files Modified:** `server/src/modules/files/controller.js`
- **Fix:** Refactored `checkResumeAccess` to use `JobApplication.find()` instead of `findOne()`. The logic now successfully checks if *any* of the job applications associated with a resume belong to the requesting recruiter, ensuring they are never incorrectly denied access.
#### 2. Patched ReDoS & Optimized Job Recommendations
- **Files Modified:** `server/src/modules/jobs/service.js`
- **Fix:** Replaced the highly inefficient and backtracking-prone `\b` boundary regexes with highly optimized exact array matches (`^term$`) and simple substring searches for titles. Capped unique candidate terms at 30. This restores MongoDB index utilization, preventing massive CPU spikes and ReDoS vulnerabilities.
#### 3. Secured Password Reset & Session Invalidation
- **Files Modified:** 
  - `server/src/modules/auth/service.js`
  - `server/src/database/models/User.js`
  - `server/src/middleware/authMiddleware.js`
- **Fix:** 
  - Added a strict 1-minute cooldown directly in `forgotPasswordRequest` and `resendUserOTP` to prevent OTP Denial of Service (DoS) spam.
  - Added a `passwordChangedAt` field to the `User` schema.
  - Updated `authMiddleware.js` (`protect` and `verifySocketToken`) to ensure any JWT issued *before* the latest `passwordChangedAt` timestamp is immediately rejected (401 Unauthorized), closing the token persistence loophole.
##  Testing Performed
- Verified recruiter can view candidate resume even if the candidate applies to multiple jobs.
- Verified recommendation queries execute smoothly without syntax/regex errors.
- Verified requesting OTP twice within 1 minute correctly returns a `429 Too Many Requests` error.
- Verified logging in with an old token after a password reset returns a `401 Unauthorized` error.
##  Related Issues
Resolves #1279 