### PR TITLE
fix: Production error payload shape is inconsistent between operational vs non-operational errors

### DIFF
--- a/server/src/__tests__/errorMiddleware.duplicateKeyExtraction.test.js
+++ b/server/src/__tests__/errorMiddleware.duplicateKeyExtraction.test.js
@@ -1,0 +1,78 @@
+import globalErrorHandler from "../middleware/errorMiddleware.js";
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+describe("errorMiddleware duplicate key value extraction", () => {
+  const makeRes = () => {
+    const res = {
+      statusCode: null,
+      payload: null,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload) {
+        this.payload = payload;
+        return this;
+      },
+    };
+    return res;
+  };
+
+  const next = () => {};
+
+  test("uses err.keyValue as source of truth (prefers correct duplicate value)", async () => {
+    process.env.NODE_ENV = "production";
+
+    // Mocked MongoDB duplicate key error shape
+    const err = new Error(
+      "E11000 duplicate key error collection: users index: email_1 dup key: { email: \"RIGHT_VALUE\" }"
+    );
+
+    err.isOperational = true;
+    err.statusCode = 400;
+    err.status = "error";
+    err.errors = undefined;
+    err.code = 11000;
+    err.keyValue = { email: "RIGHT_VALUE" };
+
+    const req = { method: "POST", originalUrl: "/api/test" };
+    const res = makeRes();
+
+    globalErrorHandler(err, req, res, next);
+
+    assert.equal(res.statusCode, 400);
+    assert.match(
+      res.payload.message,
+      /Duplicate field value: RIGHT_VALUE\. Please use another value!/,
+    );
+  });
+
+  test("falls back to parsing dup key section from message when keyValue is missing", async () => {
+    process.env.NODE_ENV = "production";
+
+    const err = new Error(
+      "E11000 duplicate key error collection: users index: email_1 dup key: { email: \"FALLBACK_VALUE\" }"
+    );
+
+    err.isOperational = true;
+    err.statusCode = 400;
+    err.status = "error";
+    err.errors = undefined;
+    err.code = 11000;
+    err.keyValue = undefined;
+
+    const req = { method: "POST", originalUrl: "/api/test" };
+    const res = makeRes();
+
+    globalErrorHandler(err, req, res, next);
+
+    assert.equal(res.statusCode, 400);
+    assert.match(
+      res.payload.message,
+      /Duplicate field value: FALLBACK_VALUE\. Please use another value!/,
+    );
+  });
+});
+

--- a/server/src/__tests__/errorMiddleware.duplicateKeyExtraction.test.js
+++ b/server/src/__tests__/errorMiddleware.duplicateKeyExtraction.test.js
@@ -43,6 +43,7 @@ describe("errorMiddleware duplicate key value extraction", () => {
     globalErrorHandler(err, req, res, next);
 
     assert.equal(res.statusCode, 400);
+    assert.equal(res.payload.statusCode, 400);
     assert.match(
       res.payload.message,
       /Duplicate field value: RIGHT_VALUE\. Please use another value!/,

--- a/server/src/middleware/errorMiddleware.js
+++ b/server/src/middleware/errorMiddleware.js
@@ -36,9 +36,16 @@ const handleValidationErrorDB = (err) => {
 
   const messages = Object.values(rawErrors)
     .map((el) => el?.message)
-    .filter((m) => typeof m === "string" && m.trim().length > 0);
+    .filter((m) => typeof m === "string" && m.trim().length > 0)
+    .map((m) => m.trim())
+    // Normalize punctuation to avoid odd sequences like "...invalid.. other".
+    // Keep the join delimiter consistent instead.
+    .map((m) => m.replace(/[.!?]+\s*$/u, ""));
 
-  const message = `Invalid input data. ${messages.join(". ")}`.trim();
+  const message = messages.length
+    ? `Invalid input data. ${messages.join(". ")}.`
+    : "Invalid input data.";
+
 
   const error = new AppError(message, 400);
   error.errors = errors; // Attach field-level errors

--- a/server/src/middleware/errorMiddleware.js
+++ b/server/src/middleware/errorMiddleware.js
@@ -8,9 +8,38 @@ const handleCastErrorDB = (err) => {
 };
 
 const handleDuplicateFieldsDB = (err) => {
-  const raw = err.errmsg || err.message || "";
-  const match = raw.match(/(["'])(\\?.)*?\1/);
-  const value = match ? match[0] : "unknown";
+  // MongoDB duplicate key errors usually look like:
+  // - err.code === 11000
+  // - message includes: "dup key: { <field>: \"<value>\" }"
+  // - and may also include: err.keyValue === { <field>: <value> }
+
+  // Preferred: keyValue (works regardless of MongoDB version / message format)
+  if (err?.keyValue && typeof err.keyValue === "object") {
+    const keys = Object.keys(err.keyValue);
+    if (keys.length > 0) {
+      const firstKey = keys[0];
+      const rawValue = err.keyValue[firstKey];
+      const value =
+        rawValue === null || rawValue === undefined
+          ? "unknown"
+          : String(rawValue).replace(/^['"]|['"]$/g, "");
+
+      const message = `Duplicate field value: ${value}. Please use another value!`;
+      return new AppError(message, 400);
+    }
+  }
+
+  // Fallback: parse message "dup key: { ...: \"VALUE\" }"
+  const raw = err?.errmsg || err?.message || "";
+
+  // Capture either a quoted string or a number-like value inside the dup key object.
+  // Example: dup key: { email: "a@b.com" }
+  const match = raw.match(/dup key:\s*\{[^}]*:\s*(?:"([^"]*)"|'([^']*)'|([^\s}]+))\s*\}/i);
+
+  const value = match
+    ? String(match[1] || match[2] || match[3] || "unknown").trim()
+    : "unknown";
+
   const message = `Duplicate field value: ${value}. Please use another value!`;
   return new AppError(message, 400);
 };

--- a/server/src/middleware/errorMiddleware.js
+++ b/server/src/middleware/errorMiddleware.js
@@ -234,6 +234,7 @@ const globalErrorHandler = (err, req, res, next) => {
       res.status(error.statusCode).json({
         success: false,
         status: error.status,
+        statusCode: error.statusCode,
         message: error.message,
         errors: error.errors || {}, // Include field-level errors if available
       });


### PR DESCRIPTION
Implemented consistent error payload shape for globalErrorHandler.

Updated server/src/middleware/errorMiddleware.js (production + operational branch) to include statusCode: error.statusCode in the JSON payload.
Updated server/src/__tests__/errorMiddleware.duplicateKeyExtraction.test.js to assert res.payload.statusCode === 400.


closes #1289