### PR TITLE
fix: invalidate jobs cache on update and delete

### DIFF
--- a/server/src/modules/jobs/controller.js
+++ b/server/src/modules/jobs/controller.js
@@ -191,6 +191,7 @@ export const getJobPostingById = asyncHandler(async (req, res) => {
  */
 export const updateJobPosting = asyncHandler(async (req, res) => {
   const updatedJob = await updateJobService(req.params.id, req.body, req.user._id);
+  await invalidateCacheByPrefix("jobs");
   await invalidateAnalyticsCache(req.user._id.toString());
   res.status(200).json({
     success: true,
@@ -205,6 +206,7 @@ export const updateJobPosting = asyncHandler(async (req, res) => {
  */
 export const deleteJobPosting = asyncHandler(async (req, res) => {
   await deleteJobService(req.params.id, req.user._id);
+  await invalidateCacheByPrefix("jobs");
   await invalidateAnalyticsCache(req.user._id.toString());
   res.status(200).json({
     success: true,


### PR DESCRIPTION
## Summary

`updateJobPosting` and `deleteJobPosting` were only invalidating the analytics cache after a mutation, leaving the `GET /api/jobs` Redis cache (TTL 300 s) stale. Students would see outdated or deleted job listings for up to 5 minutes. This fix adds `invalidateCacheByPrefix("jobs")` to both handlers, matching the pattern already used in `createJobPosting`.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #1310

## Changes Made

- Added `await invalidateCacheByPrefix("jobs")` to `updateJobPosting` in `server/src/modules/jobs/controller.js`
- Added `await invalidateCacheByPrefix("jobs")` to `deleteJobPosting` in `server/src/modules/jobs/controller.js`

## Validation

- [x] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)

N/A — backend-only change.