### PR TITLE
fix: make cacheMiddleware write to Redis without blocking response

### DIFF
--- a/server/src/middleware/cacheMiddleware.js
+++ b/server/src/middleware/cacheMiddleware.js
@@ -21,13 +21,11 @@ const cacheMiddleware = (prefix, ttlSeconds) => {
       }
 
       const originalJson = res.json.bind(res);
-      res.json = async (body) => {
+      res.json = (body) => {
         if (res.statusCode >= 200 && res.statusCode < 300) {
-          try {
-            await redisClient.setEx(key, ttlSeconds, JSON.stringify(body));
-          } catch (err) {
-            logger.error("Redis set error:", err);
-          }
+          redisClient
+            .setEx(key, ttlSeconds, JSON.stringify(body))
+            .catch((err) => logger.error("Redis set error:", err));
         }
         return originalJson(body);
       };


### PR DESCRIPTION
## Summary

`cacheMiddleware` was overriding `res.json` with an `async` function that `await`ed the Redis `setEx` call before sending the HTTP response. This blocked every cacheable GET response on Redis write latency (1–10 ms normally, worse during Redis hiccups). The cache write is a side-effect and should never delay the client. This fix switches to a synchronous override that fires the write as a non-blocking promise, preserving the same error-logging behaviour.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #1311

## Changes Made

- Changed `res.json` override from `async` to synchronous in `server/src/middleware/cacheMiddleware.js`
- Replaced `await redisClient.setEx(...)` inside `try/catch` with a fire-and-forget `.catch()` chain
- HTTP response is now sent immediately; Redis write completes in the background

## Validation

- [x] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)

N/A — backend-only change.