### PR TITLE
fix: add autoComplete attributes to auth form fields

### DIFF
--- a/client/src/modules/auth/Login.jsx
+++ b/client/src/modules/auth/Login.jsx
@@ -115,6 +115,7 @@ const Login = () => {
               onChange={handleChange}
               error={errors.email}
               disabled={loading}
+              autoComplete="email"
             />
 
             <Input
@@ -126,6 +127,7 @@ const Login = () => {
               onChange={handleChange}
               error={errors.password}
               disabled={loading}
+              autoComplete="current-password"
             />
           </div>
 

--- a/client/src/modules/auth/Register.jsx
+++ b/client/src/modules/auth/Register.jsx
@@ -186,6 +186,7 @@ const Register = () => {
               onChange={handleChange}
               error={errors.name}
               disabled={loading}
+              autoComplete="name"
             />
 
             <Input
@@ -197,6 +198,7 @@ const Register = () => {
               onChange={handleChange}
               error={errors.email}
               disabled={loading}
+              autoComplete="email"
             />
 
             <div className="flex flex-col gap-1">
@@ -209,6 +211,7 @@ const Register = () => {
                 onChange={handleChange}
                 error={errors.password}
                 disabled={loading}
+                autoComplete="new-password"
               />
               
               {/* Password Strength Indicator */}
@@ -254,6 +257,7 @@ const Register = () => {
               onChange={handleChange}
               error={errors.confirmPassword}
               disabled={loading}
+              autoComplete="new-password"
             />
             {passwordsMatch && (
               <p className="text-emerald-500 text-xs sm:text-sm -mt-1 font-medium flex items-center gap-1">

--- a/client/src/modules/auth/ResetPassword.jsx
+++ b/client/src/modules/auth/ResetPassword.jsx
@@ -215,6 +215,7 @@ const ResetPassword = () => {
                 error={errors.newPassword}
                 helperText="Must be at least 8 characters"
                 disabled={loading}
+                autoComplete="new-password"
               />
 
               <Input
@@ -226,6 +227,7 @@ const ResetPassword = () => {
                 onChange={handleChange}
                 error={errors.confirmPassword}
                 disabled={loading}
+                autoComplete="new-password"
               />
             </div>
 


### PR DESCRIPTION
## Summary

Login, Register, and ResetPassword forms were missing `autocomplete` hints on all email and password inputs. Password managers could not distinguish a login field from a new-password field, causing incorrect auto-fill behaviour. The forms also violated WCAG 2.1 Success Criterion 1.3.5 (Identify Input Purpose). Added the correct `autoComplete` token to each field — no component changes needed since the shared `Input` already spreads `...rest` onto the underlying `<input>`.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #1312

## Changes Made

- `Login.jsx` — added `autoComplete="email"` to the email field and `autoComplete="current-password"` to the password field
- `Register.jsx` — added `autoComplete="name"`, `autoComplete="email"`, and `autoComplete="new-password"` (×2) to all four fields
- `ResetPassword.jsx` — added `autoComplete="new-password"` to both password fields

## Validation

- [x] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)

No visual change — `autocomplete` is a browser/password-manager hint only.