### PR TITLE
feat(resume-analyzer): add loading skeleton UI during analysis.

### DIFF
--- a/client/src/modules/resume-analyzer/components/AnalysisResultSkeleton.jsx
+++ b/client/src/modules/resume-analyzer/components/AnalysisResultSkeleton.jsx
@@ -1,0 +1,87 @@
+const AnalysisResultSkeleton = () => {
+  return (
+    <div className="w-full space-y-4 animate-pulse">
+
+      {/* ATS Score + Match Score row */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+
+        {/* ATS Score skeleton */}
+        <div className="bg-white rounded-2xl border border-gray-100 p-5">
+          <p className="text-xs uppercase tracking-widest text-gray-400 mb-4 font-medium">
+            ATS Score
+          </p>
+          <div className="flex items-center gap-4">
+            {/* Circle ring placeholder */}
+            <div className="w-18 h-18 rounded-full bg-gray-200 flex-shrink-0" style={{ width: 72, height: 72 }} />
+            <div className="flex-1 space-y-2">
+              <div className="h-3.5 bg-gray-200 rounded w-3/5" />
+              <div className="h-2.5 bg-gray-200 rounded w-2/5" />
+            </div>
+          </div>
+        </div>
+
+        {/* Match Score skeleton */}
+        <div className="bg-white rounded-2xl border border-gray-100 p-5">
+          <p className="text-xs uppercase tracking-widest text-gray-400 mb-4 font-medium">
+            Match Score
+          </p>
+          <div className="flex items-center gap-4">
+            <div className="rounded-full bg-gray-200 flex-shrink-0" style={{ width: 72, height: 72 }} />
+            <div className="flex-1 space-y-2">
+              <div className="h-3.5 bg-gray-200 rounded w-3/5" />
+              <div className="h-2.5 bg-gray-200 rounded w-2/5" />
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      {/* Skills skeleton — horizontal bars */}
+      <div className="bg-white rounded-2xl border border-gray-100 p-5">
+        <p className="text-xs uppercase tracking-widest text-gray-400 mb-4 font-medium">
+          Skills
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {[72, 96, 60, 88, 64, 80].map((w, i) => (
+            <div
+              key={i}
+              className="h-7 bg-gray-200 rounded-full"
+              style={{ width: w }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Keywords skeleton — tag-shaped blobs */}
+      <div className="bg-white rounded-2xl border border-gray-100 p-5">
+        <p className="text-xs uppercase tracking-widest text-gray-400 mb-4 font-medium">
+          Keywords
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {[80, 64, 104, 72, 56, 90].map((w, i) => (
+            <div
+              key={i}
+              className="h-6 bg-gray-200 rounded-full"
+              style={{ width: w }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Experience skeleton — bar */}
+      <div className="bg-white rounded-2xl border border-gray-100 p-5">
+        <p className="text-xs uppercase tracking-widest text-gray-400 mb-4 font-medium">
+          Experience
+        </p>
+        <div className="space-y-2.5">
+          <div className="h-3.5 bg-gray-200 rounded w-11/12" />
+          <div className="h-3.5 bg-gray-200 rounded w-3/4" />
+          <div className="h-3.5 bg-gray-200 rounded w-4/5" />
+        </div>
+      </div>
+
+    </div>
+  );
+};
+
+export default AnalysisResultSkeleton;

--- a/client/src/modules/resume-analyzer/pages/ResumeAnalyzerPage.jsx
+++ b/client/src/modules/resume-analyzer/pages/ResumeAnalyzerPage.jsx
@@ -3,6 +3,8 @@ import { Link } from "react-router-dom";
 import { useToast, ErrorState } from "../../../shared/components";
 import Navbar from "../../../shared/components/Navbar";
 import Footer from "../../../shared/components/Footer";
+import AnalysisResultSkeleton from "../components/AnalysisResultSkeleton";
+
 
 import AnalysisResult from "../components/AnalysisResult";
 import DragDropUpload from "../components/DragDropUpload";
@@ -274,6 +276,8 @@ const ResumeAnalyzerPage = () => {
 
           {isLoadingLatest ? (
             <ResumeSkeleton />
+          ) : loading && !result && !error ? (
+            <AnalysisResultSkeleton />
           ) : error && !result ? (
             <div className="w-full max-w-4xl mx-auto space-y-6 mt-12 bg-white dark:bg-[#121214] p-8 md:p-12 rounded-3xl shadow-sm border border-gray-100 dark:border-white/5">
               <div className="flex items-center gap-3 text-red-600 mb-8">


### PR DESCRIPTION
## Summary

Added a loading skeleton UI for the Resume Analyzer to provide visual feedback while resume analysis is in progress. This prevents users from seeing a blank state and improves the overall user experience during API processing.

## Type of Change

* [x] Feature
* [ ] Bug fix
* [ ] Refactor
* [ ] Documentation
* [ ] Chore

## Related Issue

Closes #1254

## Changes Made

* Created a new `AnalysisResultSkeleton` component with animated placeholder sections.
* Added conditional rendering to display the skeleton loader while resume analysis is loading.
* Replaced the blank waiting state with ATS Score, Match Score, Skills, Keywords, and Experience placeholders.
* Ensured the skeleton is automatically replaced with the actual analysis results once processing completes.

## Validation

* [ ] Build passes locally
* [ ] Relevant tests added/updated
* [ ] Documentation updated (if needed)

