### PR TITLE
fix: allow recruiters to access skill gap heatmap endpoint

### DIFF
--- a/server/src/modules/analytics/routes.js
+++ b/server/src/modules/analytics/routes.js
@@ -4,7 +4,7 @@ import { protect, authorizeRoles } from "../../middleware/authMiddleware.js";
 
 const router = express.Router();
 
-router.get("/skill-gaps", protect, authorizeRoles("tutor"), getSkillGapHeatmap);
+router.get("/skill-gaps", protect, authorizeRoles("tutor", "recruiter"), getSkillGapHeatmap);
 router.get("/dashboard", protect, getDashboardAnalytics);
 
 export default router;


### PR DESCRIPTION
Fixes #1243

## Problem
The skill gap heatmap endpoint was restricted to tutors only,
blocking recruiters from accessing valuable candidate skill data.

## Fix
Added "recruiter" to authorizeRoles:
authorizeRoles("tutor", "recruiter")

## Changes
- `server/src/modules/analytics/routes.js` — 1 line updated