### PR TITLE
fix: filter students at DB level in getStudentsRoadmaps using populate match

### DIFF
--- a/server/src/modules/roadmap/controller.js
+++ b/server/src/modules/roadmap/controller.js
@@ -193,12 +193,10 @@ export const updateTopicStatus = asyncHandler(async (req, res) => {
  * Get all active student roadmaps (Tutors only)
  */
 export const getStudentsRoadmaps = asyncHandler(async (req, res) => {
-  const roadmaps = await LearningProgress.find({ tutorsTracking: req.user._id })
-    .populate("user", "name email role")
-    .lean();
-
-  // Filter only those whose user role is "student"
-  const studentRoadmaps = roadmaps.filter(r => r.user && r.user.role === "student");
+    const roadmaps = await LearningProgress.find({ tutorsTracking: req.user._id })
+  .populate({ path: "user", match: { role: "student" }, select: "name email role" })
+  .lean();
+const studentRoadmaps = roadmaps.filter(r => r.user !== null);
 
   res.status(200).json({
     success: true,


### PR DESCRIPTION
Fixes #1242

## Problem
In `server/src/modules/roadmap/controller.js`, `getStudentsRoadmaps` 
was loading ALL roadmaps into memory then filtering for students 
in JavaScript — inefficient at scale.

## Fix
Used Mongoose populate `match` option to filter at DB level:

.populate({ path: "user", match: { role: "student" }, select: "name email role" })
.lean();
const studentRoadmaps = roadmaps.filter(r => r.user !== null);

## Changes
- `server/src/modules/roadmap/controller.js` — DB-level filtering