### PR TITLE
fix: geminiModel is used but never defined in server/index.js

### DIFF
--- a/client/src/modules/ai-assistant/components/ChatBox.jsx
+++ b/client/src/modules/ai-assistant/components/ChatBox.jsx
@@ -31,6 +31,7 @@ const ChatBox = ({ onClose }) => {
 
   const sendMessageToBackend = async (history) => {
     try {
+      const message = history[history.length - 1]?.text;
       const data = await apiRequest("/api/chat", {
         method: "POST",
         body: { message },

--- a/server/index.js
+++ b/server/index.js
@@ -51,6 +51,7 @@ import roadmapRoutes from "./src/modules/roadmap/routes.js";
 import { initRoadmapSockets } from "./src/modules/roadmap/socket.js";
 import userRoutes from "./src/modules/users/routes.js";
 import aiAssistantRoutes from "./src/modules/ai-assistant/routes.js";
+import { geminiModel } from "./src/modules/ai-assistant/controller.js";
 import { setIO } from "./src/utils/socketIO.js";
 
 import attachSocketRateLimiter from "./src/middleware/socketRateLimiter.js";
@@ -189,7 +190,7 @@ app.get("/health", (req, res) => {
 
 // app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
-app.post("/api/chat", protect, async (req, res) => {
+app.post("/api/chat", protect, async (req, res, next) => {
   try {
     const { message } = req.body;
     if (!message) {

--- a/server/src/modules/ai-assistant/controller.js
+++ b/server/src/modules/ai-assistant/controller.js
@@ -3,7 +3,7 @@ import asyncHandler from "../../middleware/asyncHandler.js";
 import logger from "../../utils/logger.js";
 import AppError from "../../utils/AppError.js";
 
-let geminiModel = null;
+export let geminiModel = null;
 if (process.env.GEMINI_API_KEY) {
   const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
   geminiModel = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });


### PR DESCRIPTION
I have resolved the ReferenceError: geminiModel is not defined bug in server/index.js as well as a related client-side bug in ChatBox.jsx.

Here is a summary of the fixes:

Exported geminiModel: Exported geminiModel from 

controller.js
 where it gets initialized.
Imported geminiModel in server/index.js: Added the import of geminiModel from ./src/modules/ai-assistant/controller.js to 

index.js
.
Fixed Route Handler Parameters: Added the missing next parameter in app.post("/api/chat", protect, async (req, res, next) => { ... }) in 

index.js
 to avoid a potential ReferenceError in the catch block when next(error) is called.
Resolved Client-Side Reference Error: Defined message inside the client-side sendMessageToBackend helper in 

ChatBox.jsx
 by extracting it from the conversation history, which avoids another runtime ReferenceError on the client.


closes #1287