### PR TITLE
fix(ai-ml): resolve existing test suite failures

### DIFF
--- a/ai-ml/evaluators/__tests__/experienceEvaluator.test.js
+++ b/ai-ml/evaluators/__tests__/experienceEvaluator.test.js
@@ -30,7 +30,7 @@ test("partial match returns ratio-based score", () => {
     jobDescription: "Need 3 years of experience",
   });
 
-  assert.equal(result.score, 33.33);
+  assert.equal(result.score, 43.87);
   assert.equal(result.details.experienceGap, 2);
   assert.ok(
     result.details.feedback.some(f => f.includes("Candidate has significantly less experience than required"))
@@ -56,7 +56,7 @@ test("combined year and month expression is parsed correctly", () => {
 
   assert.equal(result.details.candidateExperience, 1.5);
   assert.equal(result.details.requiredExperience, 2);
-  assert.equal(result.score, 75);
+  assert.equal(result.score, 80.59);
   assert.equal(result.details.experienceGap, 0.5);
 });
 

--- a/ai-ml/evaluators/__tests__/semanticEvaluator.test.js
+++ b/ai-ml/evaluators/__tests__/semanticEvaluator.test.js
@@ -1,7 +1,48 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
 
+// Ensure process.env.HF_API_TOKEN is set so offline tests can run
+if (!process.env.HF_API_TOKEN) {
+  process.env.HF_API_TOKEN = "mock_token_for_offline_testing";
+}
+
 const { semanticEvaluator } = await import("../semanticEvaluator.js");
+
+
+// Mock global fetch to prevent actual network calls to HuggingFace
+const originalFetch = globalThis.fetch;
+before(() => {
+  globalThis.fetch = async (url, options) => {
+    if (url && url.includes("sentence-similarity")) {
+      const body = JSON.parse(options.body);
+      const source = body.inputs.source_sentence.toLowerCase();
+      const compare = body.inputs.sentences[0].toLowerCase();
+
+      let score = 0.5; // default moderate score
+
+      if (source === compare) {
+        score = 0.99;
+      } else if (source.includes("pastry chef") && compare.includes("devops")) {
+        score = 0.1;
+      } else if (source.includes("chef") && compare.includes("machine learning")) {
+        score = 0.15;
+      } else if (source.includes("react") && compare.includes("react")) {
+        score = 0.85;
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [score],
+      };
+    }
+    return originalFetch(url, options);
+  };
+});
+
+after(() => {
+  globalThis.fetch = originalFetch;
+});
 
 // --- Helpers ---
 function assertValidShape(result) {

--- a/ai-ml/evaluators/__tests__/skillNormalizer.test.js
+++ b/ai-ml/evaluators/__tests__/skillNormalizer.test.js
@@ -43,8 +43,8 @@ await describe("synonym normalization", async () => {
     assertNormalized("c#", "csharp");
     assertNormalized(".NET", "dotnet");
     assertNormalized(".net", "dotnet");
-    assertNormalized("C++", "cpp");
-    assertNormalized("c++", "cpp");
+    assertNormalized("C++", "c++");
+    assertNormalized("c++", "c++");
   });
 
   await it("normalizes database aliases", () => {
@@ -59,8 +59,8 @@ await describe("synonym normalization", async () => {
   await it("normalizes cloud/devops aliases", () => {
     assertNormalized("Amazon Web Services", "aws");
     assertNormalized("AWS", "aws");
-    assertNormalized("GCP", "googlecloud");
-    assertNormalized("Google Cloud", "googlecloud");
+    assertNormalized("GCP", "gcp");
+    assertNormalized("Google Cloud", "gcp");
     assertNormalized("K8s", "kubernetes");
     assertNormalized("Kubernetes", "kubernetes");
   });

--- a/ai-ml/pipeline/__tests__/evaluatorContract.test.js
+++ b/ai-ml/pipeline/__tests__/evaluatorContract.test.js
@@ -22,7 +22,11 @@ const validResult = (overrides = {}) => ({
 test("accepts a valid evaluator result object", () => {
   const result = validateEvaluatorResult(validResult());
 
-  assert.deepEqual(result, validResult());
+  const expected = validResult();
+  expected.details.feedback = [];
+  expected.details.suggestions = [];
+
+  assert.deepEqual(result, expected);
 });
 
 test("applies defaults for optional summary, details, and meta fields", () => {
@@ -35,7 +39,7 @@ test("applies defaults for optional summary, details, and meta fields", () => {
   });
 
   assert.equal(result.summary, "");
-  assert.deepEqual(result.details, {});
+  assert.deepEqual(result.details, { feedback: [], suggestions: [] });
   assert.deepEqual(result.meta, {});
 });
 


### PR DESCRIPTION


#### **Description**
Fixes outdated assertions and setup issues across the existing test suite in the `ai-ml` package, restoring a 100% green test suite status (80/80 tests passing).

closes issue #1334 

#### **Changes Made**
* **`semanticEvaluator.test.js`**: Mocks the global `fetch` call for the HuggingFace model API offline. This prevents `401: Unauthorized` test failures when running the test runner in an environment without a valid key.
* **`experienceEvaluator.test.js`**: Updates score assertions to match the tiered concave scoring curve formula (`100 * Math.pow(ratio, 0.75)`) rather than the older linear assumption.
* **`skillNormalizer.test.js`**: Aligns assertions to expect the actual canonical keys (`c++` and `gcp`) instead of the inverse synonyms.
* **`evaluatorContract.test.js`**: Fixes assertions to match the default empty arrays (`feedback: []` and `suggestions: []`) introduced in the details schema from a recent merge.