### PR TITLE
`feat(ai-ml): implement evaluator and global pipeline timeouts`

### DIFF
--- a/ai-ml/pipeline/__tests__/timeout.test.js
+++ b/ai-ml/pipeline/__tests__/timeout.test.js
@@ -1,0 +1,117 @@
+import test, { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { withTimeout, TimeoutError } from "../withTimeout.js";
+import { runPipeline } from "../runPipeline.js";
+
+// Ensure process.env.HF_API_TOKEN is set so semanticMatch evaluator executes
+if (!process.env.HF_API_TOKEN) {
+  process.env.HF_API_TOKEN = "mock_token_for_timeout_tests";
+}
+
+describe("withTimeout utility", () => {
+  it("resolves when the promise resolves before timeout", async () => {
+    const p = new Promise((resolve) => setTimeout(() => resolve("success"), 5));
+    const result = await withTimeout(p, 50, "test");
+    assert.equal(result, "success");
+  });
+
+  it("rejects when the promise rejects before timeout", async () => {
+    const p = new Promise((_, reject) => setTimeout(() => reject(new Error("oops")), 5));
+    await assert.rejects(withTimeout(p, 50, "test"), /oops/);
+  });
+
+  it("rejects with TimeoutError when the timeout occurs first", async () => {
+    const p = new Promise((resolve) => setTimeout(() => resolve("too slow"), 100));
+    await assert.rejects(withTimeout(p, 10, "slow_evaluator"), (err) => {
+      assert.ok(err instanceof TimeoutError);
+      assert.equal(err.evaluatorName, "slow_evaluator");
+      assert.equal(err.timeoutMs, 10);
+      return true;
+    });
+  });
+});
+
+describe("runPipeline with timeouts", () => {
+  let originalFetch;
+
+  test.before(() => {
+    originalFetch = globalThis.fetch;
+    // Mock global fetch to delay responses by 100ms, simulating a slow external API
+    globalThis.fetch = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [0.85],
+      };
+    };
+  });
+
+  test.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("enters degraded mode when evaluator exceeds deadline", async () => {
+    const originalEnv = process.env.EVALUATOR_TIMEOUT_MS;
+    // Set evaluator deadline to 20ms, which is less than the 100ms fetch delay
+    process.env.EVALUATOR_TIMEOUT_MS = "20";
+
+    console.log("[TEST DEBUG] process.env.EVALUATOR_TIMEOUT_MS set to:", process.env.EVALUATOR_TIMEOUT_MS);
+
+    try {
+      const result = await runPipeline({
+        resumeData: {
+          resumeText: "Experienced developer",
+          skills: ["JavaScript"],
+          experience: [],
+          classification: { field: "frontend developer" },
+        },
+        jobSkills: ["JavaScript"],
+        jobDescription: "React developer",
+      });
+
+      console.log("[TEST DEBUG] result.degraded:", result.degraded);
+      console.log("[TEST DEBUG] result.timedOutEvaluators:", result.timedOutEvaluators);
+      console.log("[TEST DEBUG] result.failedEvaluators:", result.failedEvaluators);
+
+      assert.equal(result.degraded, true);
+      assert.ok(result.timedOutEvaluators.includes("semanticMatch"));
+      assert.ok(result.failedEvaluators.includes("semanticMatch"));
+      assert.equal(typeof result.score, "number");
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.EVALUATOR_TIMEOUT_MS;
+      } else {
+        process.env.EVALUATOR_TIMEOUT_MS = originalEnv;
+      }
+    }
+  });
+
+  it("aborts and throws when global pipeline timeout is exceeded", async () => {
+    const originalEnv = process.env.PIPELINE_TIMEOUT_MS;
+    // Set global deadline to 20ms, which is less than the 100ms fetch delay
+    process.env.PIPELINE_TIMEOUT_MS = "20";
+
+    try {
+      await assert.rejects(
+        runPipeline({
+          resumeData: {
+            resumeText: "Experienced developer",
+            skills: ["JavaScript"],
+            experience: [],
+            classification: { field: "frontend developer" },
+          },
+          jobSkills: ["JavaScript"],
+          jobDescription: "React developer",
+        }),
+        /Resume analysis timed out/
+      );
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.PIPELINE_TIMEOUT_MS;
+      } else {
+        process.env.PIPELINE_TIMEOUT_MS = originalEnv;
+      }
+    }
+  });
+});

--- a/ai-ml/pipeline/runPipeline.js
+++ b/ai-ml/pipeline/runPipeline.js
@@ -16,14 +16,80 @@ import logger from "../utils/logger.js";
 import { extractSkillsFromText } from "../utils/skillNormalizer.js";
 import techKeywords from "../config/keywords.js";
 import { getBenchmarkForRole } from "../config/benchmarks.js";
+import {
+  withTimeout,
+  TimeoutError,
+  getEvaluatorTimeoutMs,
+  getPipelineTimeoutMs,
+} from "./withTimeout.js";
 
+/**
+ * @file runPipeline.js
+ * @description Core resume evaluation pipeline.
+ *
+ * Runs all evaluators in parallel with individual per-evaluator deadlines
+ * and a global pipeline deadline. Any evaluator that exceeds its deadline
+ * is replaced with a safe fallback result — the pipeline continues in
+ * degraded mode rather than hanging indefinitely.
+ *
+ * Timeout configuration (via environment variables):
+ *   EVALUATOR_TIMEOUT_MS  — per-evaluator deadline (default: 10 000 ms)
+ *   PIPELINE_TIMEOUT_MS   — global pipeline deadline (default: 30 000 ms)
+ *
+ * The semantic evaluator (HuggingFace HTTP call) is the most likely to be
+ * slow and gets the same deadline as all other evaluators. If it times out,
+ * the pipeline continues without semantic scoring.
+ */
 
 export async function runPipeline({
   resumeData,
   jobSkills = [],
   jobDescription = "",
 }) {
-  const _safeEval = (name, fn, fallback) => safeEval(name, fn, validateEvaluatorResult, fallback);
+  const pipelineStart = Date.now();
+  const evaluatorTimeoutMs = getEvaluatorTimeoutMs();
+  const pipelineTimeoutMs = getPipelineTimeoutMs();
+
+  // Wrap safeEval + withTimeout so every evaluator has both:
+  //   1. A contract validator (safeEval catches runtime errors & shape violations)
+  //   2. A hard per-evaluator deadline (withTimeout rejects if it takes too long)
+  //
+  // The order matters: withTimeout wraps the safeEval promise so that even if
+  // safeEval itself hangs (e.g., awaiting a never-resolving promise), the outer
+  // timeout still fires and the pipeline can continue.
+  const _safeEval = (name, fn) =>
+    withTimeout(
+      safeEval(name, fn, validateEvaluatorResult),
+      evaluatorTimeoutMs,
+      name,
+    ).catch((err) => {
+      // withTimeout rejects with TimeoutError if the entire safeEval hangs.
+      // safeEval itself already handles internal errors — this catch is only
+      // reached if withTimeout fires before safeEval even returns a fallback.
+      if (err instanceof TimeoutError) {
+        logger.warn(
+          `[runPipeline] Evaluator "${name}" timed out at pipeline level ` +
+          `after ${evaluatorTimeoutMs}ms — substituting degraded fallback.`
+        );
+      } else {
+        logger.error(`[runPipeline] Unexpected error from evaluator "${name}":`, err?.message);
+      }
+      return {
+        score: 0,
+        key: name,
+        label: name,
+        name,
+        weight: 0,
+        weightedScore: 0,
+        error: true,
+        timedOut: err instanceof TimeoutError,
+        summary: err instanceof TimeoutError
+          ? `Evaluator timed out after ${evaluatorTimeoutMs}ms.`
+          : "Evaluator failed to run.",
+        details: {},
+        meta: {},
+      };
+    });
 
   function parseExperience(experience = []) {
     return experience
@@ -40,8 +106,7 @@ export async function runPipeline({
   }
 
   const isJDProvided = !!(jobDescription && jobDescription.trim().length > 0);
-  
-  
+
   let finalJobSkills = jobSkills;
   let finalJobDescription = jobDescription;
   let mode = isJDProvided ? "match" : "benchmark";
@@ -50,28 +115,24 @@ export async function runPipeline({
     const allKeywords = Object.values(techKeywords).flat();
     finalJobSkills = extractSkillsFromText(jobDescription, allKeywords);
   } else if (!isJDProvided) {
-    
     const detectedField = resumeData.classification?.field || "full stack developer";
     finalJobSkills = getBenchmarkForRole(detectedField);
     finalJobDescription = `A standard role for ${detectedField} requiring skills like ${finalJobSkills.join(", ")}.`;
   }
-  const evaluations = [];
 
+  const evaluations = [];
   const resumeText = resumeData.resumeText || "";
 
-  // 🔥 RUN EVALUATORS IN PARALLEL
-  const [
-    skillMatch,
-    keywordMatch,
-    experienceMatch,
-    semanticMatchResult,
-    consistencyMatch,
-    readabilityMatch,
-    impactMatch,
-    atsOptimization,
-    techStandard
-  ] = await Promise.all([
-    // 🟢 Skill Match
+  logger.debug(
+    `[runPipeline] Starting pipeline — mode=${mode}, ` +
+    `evaluatorTimeout=${evaluatorTimeoutMs}ms, pipelineTimeout=${pipelineTimeoutMs}ms`
+  );
+
+  // ─── Build the parallel evaluator work ────────────────────────────────────
+  // All 9 evaluators run concurrently. Each is individually guarded by
+  // withTimeout so a single slow evaluator cannot block the others.
+  const evaluatorWork = Promise.all([
+    // ── Skill Match ─────────────────────────────────────────────────────────
     _safeEval("skillMatch", () =>
       skillEvaluator({
         resumeSkills: resumeData.skills || [],
@@ -79,7 +140,7 @@ export async function runPipeline({
       }),
     ),
 
-    // 🟡 Keyword Match
+    // ── Keyword Match ────────────────────────────────────────────────────────
     _safeEval("keywordMatch", () =>
       keywordEvaluator({
         resumeText,
@@ -89,7 +150,7 @@ export async function runPipeline({
       }),
     ),
 
-    // 🔵 Experience Match
+    // ── Experience Match ─────────────────────────────────────────────────────
     _safeEval("experienceMatch", () =>
       experienceEvaluator({
         candidateExperienceText: parseExperience(resumeData.experience),
@@ -97,16 +158,23 @@ export async function runPipeline({
       }),
     ),
 
-    // 🌀 Semantic Match
+    // ── Semantic Match ───────────────────────────────────────────────────────
+    // This evaluator makes an external HTTP call to HuggingFace and is the
+    // most likely to be slow or rate-limited. It is skipped entirely when
+    // no job description is provided or no API key is configured —
+    // withTimeout still applies when it does run.
     (async () => {
       const hasHFKey = !!process.env.HF_API_TOKEN;
+
       if (!isJDProvided) {
         return {
           score: null,
           name: "semanticMatch",
-          message: "No job description provided",
+          message: "No job description provided — semantic match skipped",
         };
-      } else if (!hasHFKey) {
+      }
+
+      if (!hasHFKey) {
         return {
           score: null,
           name: "semanticMatch",
@@ -114,55 +182,95 @@ export async function runPipeline({
           label: "Semantic Match",
           weight: 0,
           weightedScore: 0,
-          summary: "Semantic evaluation skipped — no API key",
+          summary: "Semantic evaluation skipped — HF_API_TOKEN not configured",
           details: {},
           meta: {},
         };
-      } else {
-        return await _safeEval("semanticMatch", () =>
-          semanticEvaluator({
-            resumeText,
-            jobDescription,
-          }),
-        );
       }
+
+      // HuggingFace call — most likely to be slow. withTimeout is applied
+      // inside _safeEval so it gets the same deadline as every other evaluator.
+      return _safeEval("semanticMatch", () =>
+        semanticEvaluator({
+          resumeText,
+          jobDescription,
+        }),
+      );
     })(),
 
-    // 🟣 Consistency Match
+    // ── Consistency Match ────────────────────────────────────────────────────
     _safeEval("consistencyMatch", () =>
-      consistencyEvaluator({
-        resumeText,
-      }),
+      consistencyEvaluator({ resumeText }),
     ),
 
-    // 🟠 Readability Match
+    // ── Readability Match ────────────────────────────────────────────────────
     _safeEval("readabilityMatch", () =>
-      readabilityEvaluator({
-        resumeText,
-      }),
+      readabilityEvaluator({ resumeText }),
     ),
 
-    // 💥 Impact Match
+    // ── Impact Match ─────────────────────────────────────────────────────────
     _safeEval("impactMatch", () =>
-      impactEvaluator({
-        resumeText,
-      }),
+      impactEvaluator({ resumeText }),
     ),
 
-    // 🏗️ ATS Optimization
+    // ── ATS Optimization ─────────────────────────────────────────────────────
     _safeEval("atsOptimization", () =>
-      atsOptimizationEvaluator({
-        resumeData,
-      }),
+      atsOptimizationEvaluator({ resumeData }),
     ),
 
-    // 🏛️ Tech Standard
+    // ── Tech Standard ────────────────────────────────────────────────────────
     _safeEval("techStandard", () =>
-      techStandardEvaluator({
-        resumeText,
-      }),
+      techStandardEvaluator({ resumeText }),
     ),
   ]);
+
+  // ─── Global pipeline deadline ─────────────────────────────────────────────
+  // Even if individual evaluators have their own timeouts, a global deadline
+  // guards against edge cases (e.g., withTimeout itself hanging, or a
+  // combination of slow evaluators chaining together).
+  let globalTimeoutId;
+  const globalTimeout = new Promise((_resolve, reject) => {
+    globalTimeoutId = setTimeout(() => {
+      reject(
+        new TimeoutError("global_pipeline", pipelineTimeoutMs)
+      );
+    }, pipelineTimeoutMs);
+  });
+
+  let results;
+  try {
+    results = await Promise.race([evaluatorWork, globalTimeout]);
+  } catch (err) {
+    const elapsed = Date.now() - pipelineStart;
+    if (err instanceof TimeoutError && err.evaluatorName === "global_pipeline") {
+      logger.error(
+        `[runPipeline] GLOBAL TIMEOUT: Pipeline did not complete within ` +
+        `${pipelineTimeoutMs}ms (elapsed: ${elapsed}ms). ` +
+        `Increase PIPELINE_TIMEOUT_MS or investigate slow evaluators.`
+      );
+      // Re-throw so the calling controller can return a 503 / degraded response
+      // rather than silently returning an empty/zero score to the user.
+      throw new Error(
+        `Resume analysis timed out. The evaluation service is currently slow. ` +
+        `Please try again in a few moments.`
+      );
+    }
+    throw err;
+  } finally {
+    clearTimeout(globalTimeoutId);
+  }
+
+  const [
+    skillMatch,
+    keywordMatch,
+    experienceMatch,
+    semanticMatchResult,
+    consistencyMatch,
+    readabilityMatch,
+    impactMatch,
+    atsOptimization,
+    techStandard,
+  ] = results;
 
   const semanticMatch = semanticMatchResult;
 
@@ -175,19 +283,40 @@ export async function runPipeline({
     { ...readabilityMatch, name: "readabilityMatch" },
     impactMatch,
     atsOptimization,
-    techStandard
+    techStandard,
   );
 
-  // 🧠 Aggregate
+  // ── Aggregate ──────────────────────────────────────────────────────────────
   const result = aggregateResults(evaluations, isJDProvided);
   if (!result) throw new Error("[runPipeline] aggregateResults returned empty");
   const { score, breakdown } = result;
 
   const failedEvaluators = evaluations
-    .filter((e) => e.error)
+    .filter((e) => e?.error)
     .map((e) => e.name);
 
-  // 🎯 Gap Analysis
+  const timedOutEvaluators = evaluations
+    .filter((e) => e?.timedOut)
+    .map((e) => e.name);
+
+  const elapsed = Date.now() - pipelineStart;
+
+  // Log a summary so operators can track pipeline performance over time.
+  if (timedOutEvaluators.length > 0) {
+    logger.warn(
+      `[runPipeline] Completed in ${elapsed}ms with ${timedOutEvaluators.length} timed-out ` +
+      `evaluator(s): [${timedOutEvaluators.join(", ")}]`
+    );
+  } else if (failedEvaluators.length > 0) {
+    logger.warn(
+      `[runPipeline] Completed in ${elapsed}ms with ${failedEvaluators.length} failed ` +
+      `evaluator(s): [${failedEvaluators.join(", ")}]`
+    );
+  } else {
+    logger.debug(`[runPipeline] Completed successfully in ${elapsed}ms`);
+  }
+
+  // ── Gap Analysis ───────────────────────────────────────────────────────────
   const gapAnalysis = gapAnalyzer({
     skillMatch,
     keywordMatch,
@@ -201,7 +330,7 @@ export async function runPipeline({
     isJDProvided,
   });
 
-  // 🔥 Classification
+  // ── Classification ─────────────────────────────────────────────────────────
   const classification = classifyResume({
     score,
     skillMatch,
@@ -213,6 +342,7 @@ export async function runPipeline({
     breakdown,
     degraded: failedEvaluators.length > 0,
     failedEvaluators,
+    timedOutEvaluators,
     skillMatch,
     keywordMatch,
     experienceMatch,
@@ -226,6 +356,7 @@ export async function runPipeline({
     classification,
     isJDProvided,
     mode,
+    pipelineDurationMs: elapsed,
     semanticRateLimited: semanticMatch?.meta?.rateLimited ?? false,
     semanticRetryAfter:  semanticMatch?.meta?.retryAfter  ?? null,
   };

--- a/ai-ml/pipeline/safeEval.js
+++ b/ai-ml/pipeline/safeEval.js
@@ -1,17 +1,71 @@
 import logger from "../utils/logger.js";
+import { TimeoutError } from "./withTimeout.js";
 
-export async function safeEval(name, fn, validateFn, fallback = { score: 0, error: true, details: {}, meta: {} }) {
+/**
+ * @file safeEval.js
+ * @description Fault-tolerant evaluator runner.
+ *
+ * Wraps a single evaluator call so that any error — including contract
+ * violations, runtime exceptions, and timeout errors — is caught and
+ * converted into a safe fallback result instead of crashing the pipeline.
+ *
+ * Timeout errors are logged at WARN level (expected degraded-mode events)
+ * while all other failures are logged at ERROR level (unexpected failures).
+ */
+
+/**
+ * Executes an evaluator function safely, catching all errors and returning
+ * a structured fallback result on failure.
+ *
+ * @param {string}   name       - Evaluator name (used in logs and returned result)
+ * @param {Function} fn         - Async factory that returns the evaluator promise
+ * @param {Function} validateFn - Contract validator for the evaluator result shape
+ * @param {Object}   [fallback] - Default result returned on any failure
+ * @param {Object}   [options]  - Additional options
+ * @param {number}   [options.startTime] - Pipeline-level start time for duration logging
+ * @returns {Promise<Object>} Validated evaluator result or safe fallback
+ */
+export async function safeEval(
+  name,
+  fn,
+  validateFn,
+  fallback = { score: 0, error: true, details: {}, meta: {} },
+  options = {},
+) {
+  const evalStart = Date.now();
+
   try {
     const result = await fn();
+    const duration = Date.now() - evalStart;
+
     const { name: _name, ...dataToValidate } = { ...result };
     const validated = validateFn({
       key: dataToValidate.key || name,
       label: dataToValidate.label || name,
       ...dataToValidate,
     });
-    return { ...validated, name };
+
+    logger.debug(`[safeEval] "${name}" completed in ${duration}ms`);
+    return { ...validated, name, _durationMs: duration };
+
   } catch (err) {
-    logger.error(`[safeEval] Evaluator "${name}" contract violation or failure:`, err?.message || err);
+    const duration = Date.now() - evalStart;
+
+    if (err instanceof TimeoutError) {
+      // Timeout is an expected degraded-mode event — log at WARN, not ERROR.
+      // This keeps production error logs clean during transient API slowdowns.
+      logger.warn(
+        `[safeEval] Evaluator "${name}" timed out after ${err.timeoutMs}ms ` +
+        `(actual elapsed: ${duration}ms) — using fallback result.`
+      );
+    } else {
+      // All other failures (contract violations, runtime errors) are unexpected.
+      logger.error(
+        `[safeEval] Evaluator "${name}" failed after ${duration}ms:`,
+        err?.message || err
+      );
+    }
+
     return {
       ...fallback,
       key: name,
@@ -19,7 +73,14 @@ export async function safeEval(name, fn, validateFn, fallback = { score: 0, erro
       name,
       weight: 0,
       weightedScore: 0,
-      summary: "Evaluator failed to run.",
+      // Differentiate timeout from other failures in the pipeline return value
+      // so callers can surface "service slow" vs "service broken" to the user.
+      summary: err instanceof TimeoutError
+        ? `Evaluator timed out after ${err.timeoutMs}ms.`
+        : "Evaluator failed to run.",
+      error: true,
+      timedOut: err instanceof TimeoutError,
+      _durationMs: duration,
     };
   }
 }

--- a/ai-ml/pipeline/withTimeout.js
+++ b/ai-ml/pipeline/withTimeout.js
@@ -1,0 +1,101 @@
+/**
+ * @file withTimeout.js
+ * @description Wraps a promise with a hard deadline.
+ *
+ * If the wrapped promise does not settle within `ms` milliseconds, the returned
+ * promise is rejected with a `TimeoutError`. The rejection carries the evaluator
+ * name so that `safeEval` / `runPipeline` can log exactly which evaluator stalled
+ * rather than showing a generic timeout message.
+ *
+ * Usage:
+ *   const result = await withTimeout(someEvaluator(), 10_000, "semanticMatch");
+ */
+
+/**
+ * A structured error thrown when an evaluator exceeds its time budget.
+ * Extends the native Error so that `instanceof TimeoutError` works reliably.
+ */
+export class TimeoutError extends Error {
+  /**
+   * @param {string} evaluatorName - Name of the evaluator that timed out
+   * @param {number} ms            - The deadline in milliseconds that was exceeded
+   */
+  constructor(evaluatorName, ms) {
+    super(`[Timeout] Evaluator "${evaluatorName}" did not complete within ${ms}ms`);
+    this.name = "TimeoutError";
+    this.evaluatorName = evaluatorName;
+    this.timeoutMs = ms;
+  }
+}
+
+/**
+ * Reads the per-evaluator timeout from the environment.
+ *
+ * Priority:
+ *   1. `process.env.EVALUATOR_TIMEOUT_MS`  — per-evaluator deadline (default: 10 000 ms)
+ *
+ * Values that are not positive safe integers fall back to the default.
+ *
+ * @returns {number} Per-evaluator deadline in milliseconds
+ */
+export const getEvaluatorTimeoutMs = () => {
+  const configured = Number(process.env.EVALUATOR_TIMEOUT_MS);
+  return Number.isSafeInteger(configured) && configured > 0
+    ? configured
+    : 10_000;
+};
+
+/**
+ * Reads the global pipeline timeout from the environment.
+ *
+ * Priority:
+ *   1. `process.env.PIPELINE_TIMEOUT_MS`  — global deadline (default: 30 000 ms)
+ *
+ * @returns {number} Global pipeline deadline in milliseconds
+ */
+export const getPipelineTimeoutMs = () => {
+  const configured = Number(process.env.PIPELINE_TIMEOUT_MS);
+  return Number.isSafeInteger(configured) && configured > 0
+    ? configured
+    : 30_000;
+};
+
+/**
+ * Wraps `promise` with a hard deadline of `ms` milliseconds.
+ *
+ * - If `promise` resolves before the deadline  → resolves with the same value.
+ * - If `promise` rejects before the deadline   → rejects with the same reason.
+ * - If the deadline fires first                → rejects with a `TimeoutError`.
+ *
+ * The internal timer is always cleared after settlement so that dangling
+ * `setTimeout` handles never prevent the Node.js event loop from exiting.
+ *
+ * @template T
+ * @param {Promise<T>} promise       - The promise to race against the clock
+ * @param {number}     ms            - Deadline in milliseconds (must be > 0)
+ * @param {string}     evaluatorName - Human-readable name used in error messages
+ * @returns {Promise<T>}
+ */
+export function withTimeout(promise, ms, evaluatorName) {
+  if (typeof ms !== "number" || ms <= 0) {
+    // Defensive: invalid deadline → return promise unwrapped so the pipeline
+    // never silently breaks if withTimeout is called with bad arguments.
+    return promise;
+  }
+
+  let timerId;
+
+  const timeoutRace = new Promise((_resolve, reject) => {
+    timerId = setTimeout(() => {
+      reject(new TimeoutError(evaluatorName, ms));
+    }, ms);
+  });
+
+  return Promise.race([promise, timeoutRace]).finally(() => {
+    // Always clear the timer — whether the original promise won or timed out.
+    // Prevents the timer from firing after the pipeline has already moved on.
+    clearTimeout(timerId);
+  });
+}
+
+export default withTimeout;

--- a/ai-ml/utils/logger.js
+++ b/ai-ml/utils/logger.js
@@ -24,4 +24,10 @@ export function error(...args) {
   console.error("[ai-ml]", ...formatArgs(args));
 }
 
-export default { info, warn, error, redact };
+export function debug(...args) {
+  if (!isDev) return;
+  console.debug("[ai-ml-debug]", ...formatArgs(args));
+}
+
+export default { info, warn, error, debug, redact };
+


### PR DESCRIPTION


#### **Description**
Implements evaluator-level and global pipeline timeouts in the resume evaluation pipeline to prevent the service from hanging indefinitely on slow or rate-limited external APIs (like HuggingFace).

closes issue #1334

#### **Changes Made**
* **`runPipeline.js`**: Enforces a configurable per-evaluator deadline (default: `10,000ms` via `EVALUATOR_TIMEOUT_MS`) and a global pipeline timeout (default: `30,000ms` via `PIPELINE_TIMEOUT_MS`). Cleanly releases global timeout handles in `finally` to prevent resource leaks.
* **`safeEval.js`**: Handles `TimeoutError` warnings and returns degraded fallback results so the pipeline continues operating.
* **`withTimeout.js`** *(New)*: Promise utility wrapping execution in a hard timeout and throwing structured `TimeoutError`s.
* **`logger.js`**: Added the missing `debug` method to prevent TypeError crashes during pipeline runs.
* **`timeout.test.js`** *(New)*: Added unit tests verifying evaluator timeouts (degraded mode) and global pipeline aborts.

