### PR TITLE
fix: return specific error messages in verifyUserEmail

### DIFF
--- a/server/src/modules/auth/service.js
+++ b/server/src/modules/auth/service.js
@@ -102,10 +102,12 @@ export const registerUserAndIssueToken = async ({ name, email, password, role })
 export const verifyUserEmail = async (email, otp) => {
   const user = await User.findOne({ email });
 
-  if (!user || user.isVerified) {
-    throw new AppError("Invalid request", 400);
-  }
-
+  if (!user) {
+  throw new AppError("No account found with this email", 404);
+}
+if (user.isVerified) {
+  throw new AppError("Email is already verified. Please log in.", 400);
+}
   if (user.otpAttempts >= MAX_OTP_ATTEMPTS) {
     throw new AppError("Too many attempts. Please request a new OTP.", 429);
   }


### PR DESCRIPTION
Fixes #1324

## Problem
verifyUserEmail threw generic "Invalid request" for both 
"user not found" and "already verified" cases.

## Fix
Split into specific messages:
- "No account found with this email" (404)
- "Email is already verified. Please log in." (400)

## Changes
- `server/src/modules/auth/service.js` — 2 specific error messages