### PR TITLE
fix: remove deleted user from tutorsTracking and recruitersTracking arrays

### DIFF
--- a/server/src/utils/cascadeDelete.js
+++ b/server/src/utils/cascadeDelete.js
@@ -65,6 +65,16 @@ export const cascadeDeleteUser = async (userId) => {
     await Notification.deleteMany({ userId }, { session });
     await MatchResult.deleteMany({ user: userId }, { session });
     await LearningProgress.deleteMany({ user: userId }, { session });
+    await LearningProgress.updateMany(
+  { tutorsTracking: userId },
+  { $pull: { tutorsTracking: userId } },
+  { session }
+);
+await LearningProgress.updateMany(
+  { recruitersTracking: userId },
+  { $pull: { recruitersTracking: userId } },
+  { session }
+);
     await JobApplication.deleteMany({ applicant: userId }, { session });
     await CoverLetter.deleteMany({ user: userId }, { session });
     await AnalysisHistory.deleteMany({ user: userId }, { session });


### PR DESCRIPTION
Fixes #1322

## Problem
cascadeDeleteUser didn't remove deleted user ID from other 
users' tutorsTracking and recruitersTracking arrays, leaving stale references.

## Fix
Added cleanup for both tracking arrays using $pull.

## Changes
- `server/src/utils/cascadeDelete.js` — 10 lines added