### PR TITLE
fix(security): remove phantom /api/chat route and isolate OAuth state…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,14 @@ REDIS_URL=redis://localhost:6379
 # Auth Configuration
 JWT_SECRET=replace_with_a_long_random_secret
 JWT_EXPIRES_IN=7d
+
+# REQUIRED — dedicated HMAC-SHA256 secret for signing Google OAuth state tokens.
+# Must be at least 32 characters. Must NOT be the same as JWT_SECRET, ENCRYPTION_KEY,
+# or FILE_URL_SIGNING_SECRET. Each secret must be cryptographically independent so that
+# compromising one does not expose the others.
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+OAUTH_STATE_SECRET=replace_with_a_32_character_random_hex_for_oauth_state_signing
+
 # REQUIRED — dedicated AES-256 key for field-level PII encryption.
 # Must be at least 32 characters. Must NOT be the same as JWT_SECRET.
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"

--- a/server/index.js
+++ b/server/index.js
@@ -12,23 +12,19 @@ validateEnv();
 setupGlobalLogSanitizer();
 
 
-// Trigger nodemon restart!!!!!
-import { GoogleGenerativeAI } from "@google/generative-ai";
 import http from "http";
 import { Server } from "socket.io";
-import swaggerUi from "swagger-ui-express";
 import { logEvaluatorConfig } from "./src/config/evaluatorConfig.js";
 import redisClient, { connectRedis } from "./src/config/redis.js";
 // import swaggerSpec from "./src/config/swaggerConfig.js";
 import connectDB, { isConnected } from "./src/database/db.js";
-import { protect, verifySocketToken } from "./src/middleware/authMiddleware.js";
+import { verifySocketToken } from "./src/middleware/authMiddleware.js";
 import globalErrorHandler from "./src/middleware/errorMiddleware.js";
 import { globalLimiter } from "./src/middleware/rateLimiter.js";
 import requireDB from "./src/middleware/requireDB.js";
 import {
   SOCKET_AUTH_ERROR_CODES,
   createSocketAuthError,
-  getSocketAuthErrorMessage,
 } from "./src/middleware/socketAuthError.js";
 import analyticsRoutes from "./src/modules/analytics/routes.js";
 import authRoutes from "./src/modules/auth/routes.js";
@@ -185,48 +181,14 @@ globalThis.__REDIS_READY__ = didConnectRedis;
 
 logEvaluatorConfig();
 
-
-
-// Initialize Gemini AI client logic moved to src/modules/ai-assistant/controller.js
-
 app.get("/health", (req, res) => {
   res.json({
     status: "OK",
     db: isConnected ? "connected" : "disconnected",
     redis: globalThis.__REDIS_READY__ ? "connected" : "disconnected",
-
   });
 });
 
-// app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
-
-app.post("/api/chat", protect, async (req, res, next) => {
-  try {
-    const { message } = req.body;
-    if (!message) {
-      return res.status(400).json({ error: "Message required" });
-    }
-
-    if (!geminiModel) {
-      return res.status(503).json({
-        error:
-          "AI service is currently unconfigured. Please set GEMINI_API_KEY in .env",
-      });
-    }
-
-    const prompt = `You are the "SkillsSphere Career Assistant", an expert AI specializing in tech careers, resumes, recruitment, and technical interviews. 
-Keep your answers concise, helpful, and professional. If the user asks something completely unrelated to careers or the platform, politely decline to answer.
-User message: ${message}`;
-
-    const result = await geminiModel.generateContent(prompt);
-    const reply = result.response.text();
-
-    res.json({ reply });
-  } catch (error) {
-    logger.error("Chat API error:", error);
-    next(error);
-  }
-});
 
 
 app.use("/api/auth", requireDB, authRoutes);

--- a/server/src/config/validateEnv.js
+++ b/server/src/config/validateEnv.js
@@ -1,5 +1,6 @@
 const REQUIRED_ENV_VARS = [
   { name: "JWT_SECRET", description: "Secret key for signing JWT tokens" },
+  { name: "OAUTH_STATE_SECRET", description: "Dedicated HMAC secret for signing Google OAuth state tokens" },
   { name: "GOOGLE_CLIENT_ID", description: "Google Client ID for OAuth authentication" },
   { name: "FILE_URL_SIGNING_SECRET", description: "Secret key for signing protected file URLs" },
   { name: "ENCRYPTION_KEY", description: "AES-256 key for encrypting user PII at rest" },
@@ -341,6 +342,88 @@ export const validateEncryptionKey = (env = process.env) => {
   return { errors, warnings };
 };
 
+/**
+ * Validates OAUTH_STATE_SECRET — the dedicated HMAC key used exclusively
+ * for signing and verifying the Google OAuth state parameter.
+ *
+ * This must be a separate secret from JWT_SECRET to limit the blast radius
+ * if any single secret is compromised. Using JWT_SECRET for OAuth state
+ * signing means a stolen session key also allows forging OAuth redirects.
+ */
+export const validateOAuthStateSecret = (env = process.env) => {
+  const errors = [];
+  const warnings = [];
+  const production = isProduction(env);
+  const value = env.OAUTH_STATE_SECRET;
+
+  // Presence check — already enforced by REQUIRED_ENV_VARS, but we add
+  // context-aware messaging here for a better developer experience.
+  if (isBlank(value)) {
+    addIssue(
+      production ? errors : warnings,
+      "OAUTH_STATE_SECRET",
+      production
+        ? "is required in production for signing Google OAuth state tokens."
+        : "is not set. OAuth state tokens will not be signed — open-redirect CSRF is possible.",
+    );
+    return { errors, warnings };
+  }
+
+  const secret = String(value);
+
+  // Must not be a known weak/placeholder value.
+  if (hasPlaceholderValue(secret)) {
+    addIssue(
+      production ? errors : warnings,
+      "OAUTH_STATE_SECRET",
+      "must not use a weak, default, or placeholder value.",
+    );
+  }
+
+  // Enforce minimum length — at least 32 chars in production for SHA-256 HMAC.
+  if (production && secret.length < 32) {
+    addIssue(
+      errors,
+      "OAUTH_STATE_SECRET",
+      "must be at least 32 characters in production for secure HMAC-SHA256 signing.",
+    );
+  } else if (!production && secret.length < 16) {
+    addIssue(
+      warnings,
+      "OAUTH_STATE_SECRET",
+      "is short. Use at least 32 random characters before deploying to production.",
+    );
+  }
+
+  // Key isolation — OAUTH_STATE_SECRET must be unique from all other secrets.
+  // Reusing JWT_SECRET means compromising one key breaks both JWT auth AND OAuth flows.
+  if (secret === env.JWT_SECRET) {
+    addIssue(
+      production ? errors : warnings,
+      "OAUTH_STATE_SECRET",
+      "must not be the same as JWT_SECRET. Use a separate dedicated secret for OAuth state signing.",
+    );
+  }
+
+  if (secret === env.FILE_URL_SIGNING_SECRET) {
+    addIssue(
+      production ? errors : warnings,
+      "OAUTH_STATE_SECRET",
+      "must not be the same as FILE_URL_SIGNING_SECRET. Each secret must be cryptographically unique.",
+    );
+  }
+
+  if (secret === env.ENCRYPTION_KEY) {
+    addIssue(
+      production ? errors : warnings,
+      "OAUTH_STATE_SECRET",
+      "must not be the same as ENCRYPTION_KEY. Each secret must be cryptographically unique.",
+    );
+  }
+
+  return { errors, warnings };
+};
+
 export const validateExternalApiKeys = (env = process.env) => {
   const errors = [];
   const warnings = [];
@@ -420,6 +503,7 @@ export const collectEnvValidationIssues = (env = process.env) => {
   const checks = [
     validateRequiredEnv,
     validateJwtSecret,
+    validateOAuthStateSecret,
     validateEncryptionKey,
     validateDatabaseUrl,
     validateEmailConfig,

--- a/server/src/modules/auth/controller.js
+++ b/server/src/modules/auth/controller.js
@@ -118,26 +118,87 @@ export const normalizeOAuthRedirectPath = (
   return decodeRedirectPath(value);
 };
 
+/**
+ * Roles that are allowed to be embedded in OAuth state and assigned
+ * to newly created Google users. Any role not in this set is silently
+ * replaced with the safe default "student" before user creation.
+ *
+ * This prevents a forged or tampered state payload from escalating
+ * privileges (e.g. role=admin) even if signature verification passes.
+ */
+const VALID_OAUTH_ROLES = new Set(["student", "recruiter", "tutor"]);
+
+/**
+ * Returns the HMAC signing secret for OAuth state tokens.
+ * Uses the dedicated OAUTH_STATE_SECRET environment variable — never JWT_SECRET.
+ *
+ * Throws at call time (not silently) if the secret is missing, so that a
+ * misconfigured server fails loudly instead of falling back to a known string.
+ *
+ * @throws {Error} If OAUTH_STATE_SECRET is not set in the environment
+ * @returns {string} The signing secret
+ */
+const getOAuthStateSecret = () => {
+  const secret = process.env.OAUTH_STATE_SECRET;
+  if (!secret || !secret.trim()) {
+    throw new Error(
+      "[AUTH] OAUTH_STATE_SECRET is not configured. " +
+      "Set this environment variable to a strong random string before using Google OAuth.",
+    );
+  }
+  return secret.trim();
+};
+
+/**
+ * Sanitizes a role value decoded from OAuth state against the allowlist.
+ * Returns the role unchanged if valid, or "student" as a safe default.
+ *
+ * @param {*} role - Raw role value from decoded state
+ * @returns {string} A validated, safe role string
+ */
+const sanitizeOAuthRole = (role) => {
+  if (typeof role === "string" && VALID_OAUTH_ROLES.has(role.trim().toLowerCase())) {
+    return role.trim().toLowerCase();
+  }
+  return "student";
+};
+
 export const signOAuthState = (stateObj) => {
-  const secret = process.env.JWT_SECRET || "fallback-secret-for-state-signing";
+  // Throws immediately if OAUTH_STATE_SECRET is missing — no silent fallback.
+  const secret = getOAuthStateSecret();
+
   const payload = {
     ...stateObj,
+    // role must pass the allowlist — sanitize before embedding in the signed payload
+    // so that even if someone manages to call signOAuthState with a bad role,
+    // the embedded value is already safe.
+    role: sanitizeOAuthRole(stateObj.role),
     nonce: crypto.randomBytes(16).toString("hex"),
+    iat: Math.floor(Date.now() / 1000), // issued-at timestamp for replay detection
   };
-  const signString = `${payload.redirect || ""}:${payload.role || ""}:${payload.nonce}`;
+
+  const signString = `${payload.redirect || ""}:${payload.role}:${payload.nonce}:${payload.iat}`;
   const signature = crypto
     .createHmac("sha256", secret)
     .update(signString)
     .digest("hex");
-  
+
   payload.sig = signature;
   return Buffer.from(JSON.stringify(payload), "utf8").toString("base64");
 };
 
 export const verifyAndDecodeOAuthState = (stateStr) => {
   if (!stateStr) return null;
-  const secret = process.env.JWT_SECRET || "fallback-secret-for-state-signing";
-  
+
+  // Throws immediately if OAUTH_STATE_SECRET is missing — no silent fallback.
+  let secret;
+  try {
+    secret = getOAuthStateSecret();
+  } catch (err) {
+    logger.error(err.message);
+    return null;
+  }
+
   let decodedStr = null;
   try {
     const rawState = stateStr.includes("%") ? decodeURIComponent(stateStr) : stateStr;
@@ -146,44 +207,72 @@ export const verifyAndDecodeOAuthState = (stateStr) => {
     decodedStr = null;
   }
 
+  // If base64 decode failed, check if the raw value is a safe redirect path (legacy support).
   if (!decodedStr) {
     if (isSafeRedirectPath(stateStr)) {
-      return { redirect: stateStr };
+      return { redirect: stateStr, role: "student" };
     }
     return null;
   }
 
+  let payload;
   try {
-    const payload = JSON.parse(decodedStr);
-    
-    // Signed state check
-    if (payload && typeof payload === "object" && payload.sig && payload.nonce) {
-      const signString = `${payload.redirect || ""}:${payload.role || ""}:${payload.nonce}`;
-      const computedSignature = crypto
-        .createHmac("sha256", secret)
-        .update(signString)
-        .digest("hex");
-      
-      if (computedSignature !== payload.sig) {
-        logger.error("[AUTH] Google OAuth state signature verification failed");
-        return null;
-      }
-      return payload;
-    }
-
-    // Legacy JSON state
-    if (payload && typeof payload === "object") {
-      return { redirect: payload.redirect, role: payload.role };
-    }
+    payload = JSON.parse(decodedStr);
   } catch {
-    // If JSON parsing failed, it might be a legacy raw string redirect path
+    // JSON parse failed — check if it's a plain redirect path (legacy support).
     if (isSafeRedirectPath(decodedStr)) {
-      return { redirect: decodedStr };
+      return { redirect: decodedStr, role: "student" };
     }
+    return null;
   }
 
+  if (!payload || typeof payload !== "object") return null;
+
+  // Signed state: verify HMAC signature.
+  if (payload.sig && payload.nonce) {
+    const signString = `${payload.redirect || ""}:${payload.role || ""}:${payload.nonce}:${payload.iat || ""}`;;
+    const computedSignature = crypto
+      .createHmac("sha256", secret)
+      .update(signString)
+      .digest("hex");
+
+    // Use timing-safe comparison to prevent timing oracle attacks.
+    const expectedBuf = Buffer.from(computedSignature, "hex");
+    const actualBuf   = Buffer.from(payload.sig,        "hex");
+    const signaturesMatch =
+      expectedBuf.length === actualBuf.length &&
+      crypto.timingSafeEqual(expectedBuf, actualBuf);
+
+    if (!signaturesMatch) {
+      logger.error("[AUTH] Google OAuth state signature verification failed — possible CSRF or tamper attempt");
+      return null;
+    }
+
+    // Enforce state freshness — reject states older than 10 minutes to limit replay window.
+    const STATE_MAX_AGE_SECONDS = 10 * 60;
+    if (payload.iat && Math.floor(Date.now() / 1000) - payload.iat > STATE_MAX_AGE_SECONDS) {
+      logger.error("[AUTH] Google OAuth state is expired (older than 10 minutes) — possible replay attack");
+      return null;
+    }
+
+    return {
+      redirect: payload.redirect,
+      // Always sanitize role through allowlist — even on a valid signed payload —
+      // in case an older signed state embeds a role that is no longer valid.
+      role: sanitizeOAuthRole(payload.role),
+      action: payload.action,
+      nonce: payload.nonce,
+    };
+  }
+
+  // Legacy unsigned JSON state (no sig/nonce) — accept redirect only, force default role.
+  if (isSafeRedirectPath(payload.redirect)) {
+    return { redirect: payload.redirect, role: "student" };
+  }
+
+  // Final fallback: treat raw state string as a plain redirect path.
   if (isSafeRedirectPath(stateStr)) {
-    return { redirect: stateStr };
+    return { redirect: stateStr, role: "student" };
   }
 
   return null;
@@ -391,28 +480,25 @@ export const googleOAuthCallback = asyncHandler(async (req, res, next) => {
   if (typeof state === "string" && state.length > 0) {
     try {
       const stateObj = verifyAndDecodeOAuthState(state);
+
+      // Guard: verifyAndDecodeOAuthState returns null on invalid/tampered state.
+      // Do not crash by accessing properties of null — fall back to defaults.
       if (stateObj) {
-        if (stateObj.role) {
-          requestedRole = stateObj.role;
+        // Role is already sanitized through VALID_OAUTH_ROLES inside verifyAndDecodeOAuthState.
+        requestedRole = sanitizeOAuthRole(stateObj.role);
+
+        if (stateObj.action) {
+          requestedAction = stateObj.action;
         }
 
         const redirectPath = normalizeOAuthRedirectPath(stateObj.redirect);
         callbackUrl = `${frontendRedirectOrigin}${redirectPath}`;
       } else {
+        logger.warn("[AUTH] OAuth state verification returned null — using fallback callback URL");
         callbackUrl = fallbackCallbackUrl;
       }
-
-      if (stateObj.role) {
-        requestedRole = stateObj.role;
-      }
-      
-      if (stateObj.action) {
-        requestedAction = stateObj.action;
-      }
-
-      const redirectPath = normalizeOAuthRedirectPath(stateObj.redirect);
-      callbackUrl = `${frontendRedirectOrigin}${redirectPath}`;
-    } catch {
+    } catch (err) {
+      logger.error("[AUTH] Unexpected error decoding OAuth state:", err.message);
       callbackUrl = fallbackCallbackUrl;
     }
   }


### PR DESCRIPTION

## Summary

Removes a phantom `POST /api/chat` inline route in `server/index.js` that crashed with `ReferenceError: geminiModel is not defined` on every request. Also fixes a security vulnerability where Google OAuth state tokens were signed using `JWT_SECRET` with a hardcoded public fallback — replaced with a dedicated `OAUTH_STATE_SECRET` env var, timing-safe HMAC verification, role allowlist enforcement, and replay protection.

## Type of Change


- [x] Bug fix


## Related Issue

Closes #1333 

## Changes Made

- **`server/index.js`** — Removed orphaned `POST /api/chat` handler referencing undefined `geminiModel` and out-of-scope `next`; removed 4 dead imports (`GoogleGenerativeAI`, `swaggerUi`, `protect`, `getSocketAuthErrorMessage`)
- **`server/src/modules/auth/controller.js`** — Rewrote `signOAuthState` and `verifyAndDecodeOAuthState` to use `OAUTH_STATE_SECRET` (no hardcoded fallback); added `VALID_OAUTH_ROLES` allowlist to block role escalation; added `crypto.timingSafeEqual()` for constant-time HMAC comparison; added 10-minute state expiry to prevent replay attacks; fixed null guard crash in `googleOAuthCallback`
- **`server/src/config/validateEnv.js`** — Added `validateOAuthStateSecret()` validator enforcing presence, minimum length (32 chars in prod), and uniqueness from all other secrets; wired into `collectEnvValidationIssues()`
- **`.env.example`** — Documented `OAUTH_STATE_SECRET` with generation command and key-isolation explanation

## Validation

- [x] Build passes locally

