### PR TITLE
fix(security): harden code executor validations and prevent regex byp…

### DIFF
--- a/server/src/utils/__tests__/codeExecutor.test.js
+++ b/server/src/utils/__tests__/codeExecutor.test.js
@@ -85,4 +85,74 @@ describe("codeExecutor security validation", () => {
     assert.equal(result.output, "hello\n");
     assert.equal(postMock.mock.calls.length, 1);
   });
+
+  it("rejects dangerous JavaScript code patterns (and bypasses)", async () => {
+    const dangerousJS = [
+      "const r = require; r('child_process').execSync('whoami')",
+      "const r = require; r('child' + '_process').execSync('whoami')",
+      "const r = require; r('fs').readFileSync('/etc/passwd')",
+      "const p = process; p.exit(1)",
+      "const p = globalThis.process; p.exit(1)",
+      "import('fs')",
+      "const r = re\\u0071uire; r('fs')",
+      "const r = \\u0072equire; r('fs')",
+      "const r = re\\u{71}uire; r('fs')",
+      "const r = req\\\\\\nuire; r('fs')",
+      "/* ignore me */ require('fs')",
+      "// block me \n require('fs')",
+      "const cp = '\\\\x63hild_process'; require(cp)",
+    ];
+
+    for (const code of dangerousJS) {
+      const validation = validateCodeExecutionRequest("javascript", code);
+      assert.equal(validation.isValid, false, `Should reject JavaScript: ${code}`);
+      assert.equal(
+        validation.result.errorCode,
+        CODE_EXECUTION_ERROR_CODES.SUSPICIOUS_CODE_PATTERN,
+      );
+    }
+  });
+
+  it("rejects dangerous Python code patterns", async () => {
+    const dangerousPython = [
+      "import os; os.system('whoami')",
+      "import subprocess; subprocess.call(['whoami'])",
+      "import sys; sys.exit(1)",
+      "__import__('os').system('whoami')",
+      "eval('__import__(\\'os\\').system(\\'whoami\\')')",
+      "exec('import os')",
+      "open('/etc/passwd', 'r')",
+      "# safe comment\nimport os",
+    ];
+
+    for (const code of dangerousPython) {
+      const validation = validateCodeExecutionRequest("python", code);
+      assert.equal(validation.isValid, false, `Should reject Python: ${code}`);
+      assert.equal(
+        validation.result.errorCode,
+        CODE_EXECUTION_ERROR_CODES.SUSPICIOUS_CODE_PATTERN,
+      );
+    }
+  });
+
+  it("rejects dangerous C++ code patterns", async () => {
+    const dangerousCpp = [
+      "#include <iostream>\nint main() { system(\"whoami\"); }",
+      "#include <fstream>",
+      "#include <filesystem>",
+      "fork()",
+      "popen(\"whoami\", \"r\")",
+      "remove(\"file.txt\")",
+      "rename(\"old.txt\", \"new.txt\")",
+    ];
+
+    for (const code of dangerousCpp) {
+      const validation = validateCodeExecutionRequest("cpp", code);
+      assert.equal(validation.isValid, false, `Should reject C++: ${code}`);
+      assert.equal(
+        validation.result.errorCode,
+        CODE_EXECUTION_ERROR_CODES.SUSPICIOUS_CODE_PATTERN,
+      );
+    }
+  });
 });

--- a/server/src/utils/codeExecutor.js
+++ b/server/src/utils/codeExecutor.js
@@ -38,39 +38,91 @@ const normalizeLanguage = (language) => {
 
 const DANGEROUS_PATTERNS = {
   javascript: [
+    /\brequire\b/i,
+    /\bimport\b/i,
+    /\bprocess\b/i,
+    /\bglobal\b/i,
+    /\bglobalThis\b/i,
+    /\bconstructor\b/i,
+    /\beval\b/i,
+    /\bFunction\b/i,
     /child_process/i,
-    /require\s*\(\s*['"]fs['"]\s*\)/i,
-    /process\.(exit|kill|env|stderr|stdout|stdin)/i,
-    /cluster/i,
     /worker_threads/i,
-    /eval\s*\(/i,
-    /Function\s*\(/i,
+    /cluster/i,
+    /\bfs\b/i,
+    /\b__proto__\b/i,
+    /\bprototype\b/i,
     /setInterval/i,
     /setTimeout/i
   ],
   python: [
-    /import\s+(os|subprocess|sys|shutil|pty|socket|requests|urllib)/i,
-    /from\s+(os|subprocess|sys|shutil|pty|socket|requests|urllib)\s+import/i,
-    /__import__\s*\(/i,
-    /eval\s*\(/i,
-    /exec\s*\(/i,
-    /open\s*\(/i
+    /\bimport\b/i,
+    /\bexec\b/i,
+    /\beval\b/i,
+    /\bopen\b/i,
+    /\b__import__\b/i,
+    /\bos\b/i,
+    /\bsys\b/i,
+    /\bsubprocess\b/i,
+    /\bshutil\b/i,
+    /\bpty\b/i,
+    /\bsocket\b/i,
+    /\brequests\b/i,
+    /\burllib\b/i,
+    /\bimportlib\b/i,
+    /\bgetattr\b/i,
+    /\bsetattr\b/i,
+    /\bglobals\b/i,
+    /\blocals\b/i
   ],
   cpp: [
-    /system\s*\(/i,
-    /popen\s*\(/i,
-    /fork\s*\(/i,
-    /exec(l|p|v)/i,
-    /fstream/i,
-    /remove\s*\(/i,
-    /rename\s*\(/i
+    /\bsystem\b/i,
+    /\bpopen\b/i,
+    /\bfork\b/i,
+    /\bexec(l|p|v|lp|vp|le|ve)?\b/i,
+    /\bfstream\b/i,
+    /\bremove\b/i,
+    /\brename\b/i,
+    /\bfilesystem\b/i
   ]
 };
 
+const preprocessCode = (language, code) => {
+  if (typeof code !== "string") return "";
+
+  let processed = code;
+
+  // 1. Decode hex (\xXX), Unicode (\uXXXX), and braced Unicode (\u{XXXX}) escapes
+  try {
+    processed = processed
+      .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+      .replace(/\\u\{([0-9a-fA-F]+)\}/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+      .replace(/\\x([0-9a-fA-F]{2})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+  } catch (e) {
+    // Ignore malformed escape errors
+  }
+
+  // 2. Remove line continuations (backslash followed by newline)
+  processed = processed.replace(/\\\r?\n/g, "");
+
+  // 3. Strip comments based on language style to prevent keyword hiding
+  if (language === "javascript" || language === "cpp") {
+    processed = processed
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*/g, "");
+  } else if (language === "python") {
+    processed = processed
+      .replace(/#.*/g, "");
+  }
+
+  return processed;
+};
+
 const hasDangerousPatterns = (language, code) => {
+  const preprocessed = preprocessCode(language, code);
   const patterns = DANGEROUS_PATTERNS[language];
   if (!patterns) return false;
-  return patterns.some(pattern => pattern.test(code));
+  return patterns.some(pattern => pattern.test(preprocessed));
 };
 
 class CodeExecutionCache {


### PR DESCRIPTION


## Summary
Hardens the remote code execution utility to prevent regex bypasses. It decodes all common string escape sequences (hex, unicode), removes comments and line continuations, and uses strict word-boundary regular expressions to block dangerous system APIs.

## Type of Change


- [x] Bug fix


## Related Issue

Closes #1356 

## Changes Made

- Created a `preprocessCode` utility in `codeExecutor.js` to normalize the input code block (resolving Unicode/hex escape sequences, stripping line continuations, and deleting comments).
- Replaced the loose regex patterns in `DANGEROUS_PATTERNS` with strict, word-boundary (`\b`) checks for critical language keywords, globals, and packages (e.g., `require`, `process`, `import`, `global`, `constructor`, `eval` in JS; `os`, `sys`, `subprocess` in Python; `system`, `popen`, `fork` in C++).
- Updated `hasDangerousPatterns` to validate the preprocessed/normalized version of the source code.
- Added extensive validation unit tests for JS, Python, and C++ bypass vectors in `codeExecutor.test.js`.

## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated

