### PR TITLE
fix: replace in-memory skill counting with MongoDB aggregation in getRecruiterAnalytics

### DIFF
--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -502,26 +502,15 @@ export const getRecruiterAnalytics = async (recruiterId) => {
     { $sort: { "_id.year": 1, "_id.month": 1 } },
   ]);
 
-  const jobsByMonth = jobsByMonthAgg.map((item) => ({
-    month: `${item._id.year}-${String(item._id.month).padStart(2, "0")}`,
-    count: item.count,
-  }));
-
-  // Top skills across all jobs
-  const skillCount = {};
-  allJobs.forEach((job) => {
-    (job.skills || []).forEach((skill) => {
-      const normalized = skill.toLowerCase().trim();
-      if (normalized) {
-        skillCount[normalized] = (skillCount[normalized] || 0) + 1;
-      }
-    });
-  });
-
-  const topSkills = Object.entries(skillCount)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 10)
-    .map(([skill, count]) => ({ skill, count }));
+  const topSkillsAgg = await JobPosting.aggregate([
+  { $match: { recruiter: new mongoose.Types.ObjectId(recruiterId) } },
+  { $unwind: "$skills" },
+  { $group: { _id: { $toLower: "$skills" }, count: { $sum: 1 } } },
+  { $sort: { count: -1 } },
+  { $limit: 10 },
+  { $project: { skill: "$_id", count: 1, _id: 0 } }
+]);
+const topSkills = topSkillsAgg;
 
   // Recent jobs (last 5)
   const recentJobs = allJobs.slice(0, 5).map((job) => ({


### PR DESCRIPTION
Fixes #1353

## Problem
getRecruiterAnalytics was loading ALL job postings into Node.js 
memory to count skills using JavaScript forEach loops — 
inefficient at scale.

## Fix
Replaced with MongoDB aggregation pipeline that computes 
top skills server-side, loading only the final result.

## Type of Change
- [x] Bug fix
- [x] Refactor

## Changes Made
- Replaced in-memory skill counting with MongoDB aggregation
- `server/src/modules/jobs/service.js` — 20 lines replaced with 9