### PR TITLE
fix: server/index.js sends /api/chat twice with different route stacks

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -190,39 +190,7 @@ app.get("/health", (req, res) => {
 
 // app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
-// Backward compatible chat handler:
-// - New format: { "messages": [{ sender: "user"|"bot", text: "..." }] }
-// - Old format: { "message": "..." }
-//
-// We normalize the request into the `messages` shape expected by
-// server/src/modules/ai-assistant/controller.js and let the AI controller handle generation.
-app.post("/api/chat", protect, async (req, res, next) => {
-  try {
-    const body = req.body || {};
 
-    if (body.messages && Array.isArray(body.messages)) {
-      // Let downstream controller validate required contents.
-      return aiAssistantRoutes.handle(req, res, next);
-    }
-
-    if (typeof body.message === "string" && body.message.trim()) {
-      req.body = {
-        messages: [
-          {
-            sender: "user",
-            text: body.message.trim(),
-          },
-        ],
-      };
-      return aiAssistantRoutes.handle(req, res, next);
-    }
-
-    return res.status(400).json({ error: "Message required" });
-  } catch (err) {
-    logger.error("Chat API error:", err);
-    next(err);
-  }
-});
 
 
 

--- a/server/src/modules/ai-assistant/controller.js
+++ b/server/src/modules/ai-assistant/controller.js
@@ -10,11 +10,25 @@ if (process.env.GEMINI_API_KEY) {
 }
 
 export const generateChatResponse = asyncHandler(async (req, res, next) => {
-  const { messages } = req.body;
+  const body = req.body || {};
+
+  // Backward compatibility:
+  // - New format: { "messages": [{ sender: "user"|"bot", text: "..." }] }
+  // - Old format: { "message": "..." }
+  let messages = body.messages;
+  if (!messages && typeof body.message === "string" && body.message.trim()) {
+    messages = [
+      {
+        sender: "user",
+        text: body.message.trim(),
+      },
+    ];
+  }
 
   if (!messages || !Array.isArray(messages) || messages.length === 0) {
     return next(new AppError("Messages array is required", 400));
   }
+
 
   if (!geminiModel) {
     return next(new AppError("AI service is currently unconfigured. Please set GEMINI_API_KEY in .env", 503));


### PR DESCRIPTION
Resolved duplicate/conflicting /api/chat routing.

Updated server/index.js by removing the earlier ad-hoc app.post('/api/chat', ...) handler that conflicted with the later app.use('/api/chat', ..., aiAssistantRoutes) router.
Updated server/src/modules/ai-assistant/controller.js to preserve legacy payload support by converting { message: '...' } into the expected { messages: [{ sender: 'user', text: '...' }] } shape.


closes  #1336