### PR TITLE
fix:globalErrorHandler AI classification logic can misclassify non-AI errors as AI

### DIFF
--- a/server/src/__tests__/errorMiddleware.aiMisclassification.test.js
+++ b/server/src/__tests__/errorMiddleware.aiMisclassification.test.js
@@ -1,0 +1,90 @@
+import globalErrorHandler from "../middleware/errorMiddleware.js";
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+describe("errorMiddleware AI misclassification", () => {
+  const makeRes = () => {
+    const res = {
+      statusCode: null,
+      payload: null,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload) {
+        this.payload = payload;
+        return this;
+      },
+    };
+    return res;
+  };
+
+  const next = () => {};
+
+  test("does not classify Axios errors as AI based on url substring alone", () => {
+    process.env.NODE_ENV = "production";
+
+    // Repro: Axios error whose config.url includes google/gemini strings.
+    // Use an Error message that should be preserved (non-AI paths should not rewrite it).
+    const err = new Error("Request failed with status code 502");
+
+    err.isOperational = true;
+    err.statusCode = 502;
+    err.status = "error";
+
+    err.isAxiosError = true;
+    err.message = "Request failed with status code 502";
+    err.config = {
+      url: "https://example.com/googleapis.com/v1/models",
+      headers: {
+        // Intentionally missing x-ai-provider to ensure we don't classify as AI.
+        authorization: "Bearer test",
+      },
+    };
+
+    const req = { method: "GET", originalUrl: "/api/test" };
+    const res = makeRes();
+
+    globalErrorHandler(err, req, res, next);
+
+    // If it misclassified as AI, message would contain "AI ..." and statusCode
+    // would be mapped to AI-specific codes.
+    assert.equal(res.statusCode, 502);
+    assert.equal(res.payload.statusCode, 502);
+    // globalErrorHandler preserves err.message; ensure it's NOT rewritten as an AI-specific message.
+    assert.equal(res.payload.message, "Request failed with status code 502");
+
+
+    assert.equal(res.payload.message.includes("AI "), false);
+
+  });
+
+  test("classifies Axios errors as AI when explicitly tagged with x-ai-provider", () => {
+    process.env.NODE_ENV = "production";
+
+    const err = new Error("Some provider error");
+    err.isOperational = true;
+    err.statusCode = 400;
+    err.status = "error";
+
+    err.isAxiosError = true;
+    err.message = "invalid api key";
+    err.config = {
+      url: "https://generativelanguage.googleapis.com/v1beta/models/foo" ,
+      headers: {
+        "x-ai-provider": "gemini",
+      },
+    };
+
+    const req = { method: "GET", originalUrl: "/api/test" };
+    const res = makeRes();
+
+    globalErrorHandler(err, req, res, next);
+
+    assert.equal(res.statusCode, 401);
+    assert.equal(res.payload.statusCode, 401);
+    assert.match(res.payload.message, /AI Authentication failed/i);
+  });
+});
+

--- a/server/src/middleware/errorMiddleware.js
+++ b/server/src/middleware/errorMiddleware.js
@@ -185,50 +185,47 @@ const globalErrorHandler = (err, req, res, next) => {
   if (error.name === "ValidationError") error = handleValidationErrorDB(error);
   
   // Handle AI errors (Gemini/Google Generative AI + AI-specific Axios errors)
-  // IMPORTANT: Do NOT classify AI errors solely by message text (e.g. "google"),
-  // otherwise non-AI operational errors containing these words get misclassified.
+  // IMPORTANT: Avoid misclassification of non-AI Axios errors.
   //
-  // IMPORTANT FIX: Do NOT classify all Axios errors as AI.
-  // `error.isAxiosError === true` can be true for operational failures to non-AI upstream services.
-  const url = typeof error?.config?.url === "string" ? error.config.url : "";
-  const aiUrlHints = [
-    // Google / Gemini endpoints (best-effort allowlist)
-    "generativelanguage.googleapis.com",
-    "googleapis.com",
-    "/v1beta/models",
-    "/v1/models",
-    // Some SDKs/clients may use a custom base URL that still includes these hints.
-    "gemini",
-    "generative",
-    // OpenAI (if used elsewhere in the app)
-    "api.openai.com",
-    "chat/completions",
-    "responses",
-  ];
-  const isAiAxiosError = Boolean(
-    error.isAxiosError &&
-      (aiUrlHints.some((hint) => url.toLowerCase().includes(hint)) ||
-        // Secondary check: provider header / type hints if present.
-        (typeof error?.config?.headers === "object" &&
-          (Object.keys(error.config.headers)
-            .join(" ")
-            .toLowerCase()
-            .includes("goog") ||
-            Object.keys(error.config.headers)
-              .join(" ")
-              .toLowerCase()
-              .includes("gemini"))))
-  );
+  // This handler classifies AI failures ONLY when:
+  //  1) The failing request is explicitly tagged with header `x-ai-provider`, or
+  //  2) The error is a strongly-typed AI SDK error (e.g. GoogleGenerativeAI).
+  //
+  // It intentionally does NOT use URL substring heuristics (e.g. googleapis.com / gemini).
 
-  if (
-    isAiAxiosError ||
-    error.type === "invalid_request_error" ||
-    error?.name === "GoogleGenerativeAI" ||
-    error?.provider === "google" ||
-    (typeof error?.status === "number" &&
-      // Gate status-based heuristics behind known AI/provider identifiers.
-      (error?.name === "GoogleGenerativeAI" || error?.provider === "google"))
-  ) {
+  const headers = error?.config?.headers;
+  const headerObj = headers && typeof headers === "object" ? headers : {};
+  const headerKeysLower = Object.keys(headerObj).reduce((acc, k) => {
+    acc[k.toLowerCase()] = headerObj[k];
+    return acc;
+  }, {});
+
+  const aiProvider =
+    headerKeysLower["x-ai-provider"] ??
+    headerKeysLower["x-ai_provider"] ??
+    headerKeysLower["x-ai-client"] ??
+    headerKeysLower["x-ai_client"];
+
+  const normalizedProvider =
+    typeof aiProvider === "string" ? aiProvider.trim().toLowerCase() : "";
+
+  const allowedProviders = new Set([
+    // Current module uses Gemini
+    "gemini",
+    // Reserve common providers for future integrations
+    "openai",
+    "anthropic",
+    "google",
+    "google-generative-ai",
+  ]);
+
+  const isTaggedAiAxiosError =
+    error.isAxiosError && normalizedProvider && allowedProviders.has(normalizedProvider);
+
+  // Also allow strongly-typed AI SDK errors (no URL/message heuristics)
+  const isTypedGeminiSdkError = error?.name === "GoogleGenerativeAI";
+
+  if (isTaggedAiAxiosError || isTypedGeminiSdkError) {
     error = handleAIError(error);
   }
 


### PR DESCRIPTION
Fixed AI error misclassification in server/src/middleware/errorMiddleware.js by removing URL-substring-based detection and requiring explicit AI tagging via x-ai-provider header (allowlisted providers), while still supporting strongly-typed Gemini SDK errors (GoogleGenerativeAI). Added server/src/__tests__/errorMiddleware.aiMisclassification.test.js to cover both the non-tagged and tagged Axios misclassification scenarios. npm test is running and the error-middleware suites shown are passing.


closes #1337