### PR TITLE
fix: ensure auth runs before rate limiters on resume routes

### DIFF
--- a/server/src/modules/resumes/routes.js
+++ b/server/src/modules/resumes/routes.js
@@ -162,8 +162,8 @@ router.post(
  */
 router.post(
   "/analyze",
-  resumeAnalysisLimiter,
-  protect,
+  protect,                  
+  resumeAnalysisLimiter,    
   authorizeRoles("student"),
   parseResumeUpload,
   validateAndPersistResumeFile,
@@ -256,7 +256,7 @@ router.get("/result/:id", protect, getResumeResult);
  *       200:
  *         description: Strategic comparison generated
  */
-router.post("/compare", aiActionLimiter, protect, compareVersions);
+router.post("/compare", protect, aiActionLimiter, compareVersions);
 
 /**
  * @openapi
@@ -293,6 +293,6 @@ router.post("/compare", aiActionLimiter, protect, compareVersions);
  *       500:
  *         description: AI generation failed
  */
-router.post("/:id/cover-letter", aiActionLimiter, protect, authorizeRoles("student"), generateCoverLetterForResume);
+router.post("/:id/cover-letter", protect, aiActionLimiter, authorizeRoles("student"), generateCoverLetterForResume);
 
 export default router;


### PR DESCRIPTION
## Summary

`resumeAnalysisLimiter` and `aiActionLimiter` were executing before `protect` on resume-related routes, causing `req.user` to be unavailable when the rate limiter ran. As a result, role-based rate limits were never applied and rate-limit keys fell back to IP-based identification instead of authenticated user IDs.

This fix reorders the middleware chain so that authentication runs before rate limiting on all affected routes in `server/src/modules/resumes/routes.js`.

## Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore

## Related Issue

Closes #1352 

## Changes Made

* Moved `protect` before `resumeAnalysisLimiter` on `POST /analyze`
* Moved `protect` before `aiActionLimiter` on `POST /compare`
* Moved `protect` before `aiActionLimiter` on `POST /:id/cover-letter`

## Validation

* [x] Build passes locally
* [ ] Relevant tests added/updated
* [ ] Documentation updated (not required)

## Screenshots

N/A — backend middleware order change, no UI impact.
