### PR TITLE
Fix IDOR in recruiter match-candidate endpoint

### DIFF
--- a/server/src/modules/recruiter/controller.js
+++ b/server/src/modules/recruiter/controller.js
@@ -153,6 +153,10 @@ export const matchCandidate = asyncHandler(async (req, res, next) => {
     return next(new AppError("Job posting not found", 404));
   }
 
+  if (job.recruiter.toString() !== req.user._id.toString()) {
+    return next(new AppError("You are not authorized to access this job", 403));
+  }
+
   let resume = await Resume.findOne({ user: candidateId, isActive: true }).select("+resumeText");
   if (!resume) {
     resume = await Resume.findOne({ user: candidateId }).sort({ createdAt: -1 }).select("+resumeText");


### PR DESCRIPTION
Closes #1354 

This PR fixes a broken access control issue in the recruiter AI matching flow where authenticated recruiters could access AI match results for jobs owned by other recruiters.

The vulnerability existed in POST /api/recruiter/match-candidate, where the supplied jobId was only checked for existence before executing the AI matching pipeline. Since ownership validation was missing, any recruiter could provide another recruiter's job ID and successfully obtain AI candidate matching results.

The endpoint now validates that the requested job belongs to the authenticated recruiter before running the matching process. If the job owner does not match the logged-in recruiter, the request is rejected with a 403 Forbidden response and the AI matching logic is never executed.

I verified that a recruiter attempting to access another recruiter's job now receives an authorization error, while the legitimate job owner can still access AI matching results successfully. Existing recruiter workflows, AI scoring, matching logic, and response structures continue to function normally after the change.
I have also attached screenshots after fixing :-

Ownership Validation Added in Controller : 
<img width="477" height="50" alt="image" src="https://github.com/user-attachments/assets/5d73b2a0-8e43-4d3c-bb19-ef1cef58be5d" />
Unauthorized Cross-Recruiter Access Blocked After Fix (403 Forbidden) : 
<img width="791" height="189" alt="Screenshot 2026-06-08 232723" src="https://github.com/user-attachments/assets/a30e5458-d693-4ecb-a825-c799f5b12baa" />