### PR TITLE
fix(recruiter-dashboard): resolve ATS tab crash and unify light/dark mode UI aesthetics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,12 +2,12 @@
 # Client Configuration
 # ==========================================
 # Backend base URL used by client API calls
-VITE_API_URL=http://localhost:5000
+VITE_API_URL=http://localhost:5001
 
 # ==========================================
 # Server Configuration
 # ==========================================
-PORT=5000
+PORT=5001
 NODE_ENV=development
 
 # Database Configuration
@@ -74,7 +74,7 @@ EMAIL_HOST=smtp
 EMAIL_PORT=2525
 EMAIL_USER=your_username_here
 EMAIL_PASS=your_password_here
-EMAIL_FROM="SkillsSphere AI" <no-reply@skillssphere.ai>
+EMAIL_FROM="SkillsSphere AI <no-reply@skillssphere.ai>"
 
 # AI/ML Configuration (Hugging Face — free tier, required for semantic matching)
 # Get your free token at: https://huggingface.co/settings/tokens

--- a/client/src/modules/dashboard/components/dashboards/RecruiterDashboard.jsx
+++ b/client/src/modules/dashboard/components/dashboards/RecruiterDashboard.jsx
@@ -116,7 +116,7 @@ const RecruiterDashboard = ({ token }) => {
 
       {/* Recruiter Jobs List Preview */}
       <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 overflow-hidden backdrop-blur-md">
-        <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center justify-between">
+        <div className="border-b border-gray-100 dark:border-white/5 bg-gray-50 dark:bg-white/5 px-6 py-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
             <LayoutDashboard className="text-blue-400" size={20} />
             <h2 className="text-lg font-bold">Recent Job Postings</h2>

--- a/client/src/modules/dashboard/components/dashboards/StudentDashboard.jsx
+++ b/client/src/modules/dashboard/components/dashboards/StudentDashboard.jsx
@@ -230,7 +230,7 @@ const StudentDashboard = ({ token }) => {
 
           {/* Latest Analysis Summary */}
           <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 overflow-hidden backdrop-blur-md">
-            <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center justify-between">
+            <div className="border-b border-gray-100 dark:border-white/5 bg-gray-50 dark:bg-white/5 px-6 py-4 flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <Activity className="text-emerald-400" size={20} />
                 <h2 className="text-lg font-bold">
@@ -394,7 +394,7 @@ const StudentDashboard = ({ token }) => {
                     history.map((item, idx) => (
                       <tr 
                         key={idx} 
-                        className={`hover:bg-slate-100 dark:hover:bg-white/5 transition-colors group cursor-pointer ${selectedVersions.includes(item._id) ? 'bg-blue-500/10 border-l-2 border-blue-500' : ''}`}
+                        className={`hover:bg-slate-100 dark:hover:bg-gray-50 dark:bg-white/5 transition-colors group cursor-pointer ${selectedVersions.includes(item._id) ? 'bg-blue-500/10 border-l-2 border-blue-500' : ''}`}
                         onClick={() => toggleVersionSelection(item._id)}
                       >
                         <td className="px-6 py-4 text-center">
@@ -451,7 +451,7 @@ const StudentDashboard = ({ token }) => {
         <div className="space-y-6">
           {/* Smart Suggestions Card */}
           <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-slate-900/50 overflow-hidden backdrop-blur-md">
-            <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center gap-2">
+            <div className="border-b border-gray-100 dark:border-white/5 bg-gray-50 dark:bg-white/5 px-6 py-4 flex items-center gap-2">
               <Target className="text-emerald-400" size={20} />
               <h2 className="text-lg font-bold">Smart Insights</h2>
             </div>

--- a/client/src/modules/recruiter-jobs/components/JobPostingForm.jsx
+++ b/client/src/modules/recruiter-jobs/components/JobPostingForm.jsx
@@ -314,17 +314,17 @@ const JobPostingForm = ({ onSubmit, initialData = {}, isLoading = false, fieldEr
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="description" className="text-sm font-medium text-gray-300">
+        <label htmlFor="description" className="text-sm font-medium text-gray-700 dark:text-gray-300">
           Job Description <span className="text-red-500">*</span>
         </label>
         <textarea
           data-testid="input-description"
           id="description"
           rows={5}
-          className={`w-full rounded-lg border bg-slate-800 px-3.5 py-2.5 text-sm text-white caret-white placeholder:text-gray-500 transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-0 ${
+          className={`w-full rounded-lg border bg-white dark:bg-[#121214] px-3.5 py-2.5 text-sm text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-0 ${
             allErrors.description
               ? "border-red-400 focus:ring-red-400 focus:border-red-400"
-              : "border-slate-600 focus:ring-blue-500 focus:border-blue-500 hover:border-slate-500"
+              : "border-gray-200 dark:border-white/10 focus:ring-blue-500 focus:border-blue-500 hover:border-gray-300 dark:hover:border-white/20"
           }`}
           placeholder="Describe the role, responsibilities, and team..."
           value={formData.description}
@@ -343,77 +343,77 @@ const JobPostingForm = ({ onSubmit, initialData = {}, isLoading = false, fieldEr
 
       {/* skills */}
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="skills" className="text-sm font-medium text-gray-300">
+        <label htmlFor="skills" className="text-sm font-medium text-gray-700 dark:text-gray-300">
           Required Skills <span className="text-red-500">*</span>
         </label>
         <textarea
           data-testid="input-skills"
           id="skills"
           rows={2}
-          className={`w-full rounded-lg border bg-slate-800 px-3.5 py-2.5 text-sm text-white caret-white placeholder:text-gray-500 transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-0 resize-y ${
+          className={`w-full rounded-lg border bg-white dark:bg-[#121214] px-3.5 py-2.5 text-sm text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-0 resize-y ${
             allErrors.skills
               ? "border-red-400 focus:ring-red-400 focus:border-red-400"
-              : "border-slate-600 focus:ring-blue-500 focus:border-blue-500 hover:border-slate-500"
+              : "border-gray-200 dark:border-white/10 focus:ring-blue-500 focus:border-blue-500 hover:border-gray-300 dark:hover:border-white/20"
           }`}
           placeholder="e.g. react, typescript, node.js, aws"
           value={formData.skills}
           onChange={handleChange}
           disabled={isFormSubmitting}
         />
-        <p className="text-xs text-slate-500">Comma-separated. Stored in lowercase — used to match candidates.</p>
+        <p className="text-xs text-gray-500 dark:text-slate-400">Comma-separated. Stored in lowercase — used to match candidates.</p>
         {allErrors.skills && <p data-testid="error-skills" className="text-xs text-red-400">{allErrors.skills}</p>}
       </div>
 
       {/* requirements */}
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="requirements" className="text-sm font-medium text-gray-300">Requirements</label>
+        <label htmlFor="requirements" className="text-sm font-medium text-gray-700 dark:text-gray-300">Requirements</label>
         <textarea
           data-testid="input-requirements"
           id="requirements"
           rows={3}
-          className="w-full rounded-lg border border-slate-600 bg-slate-800 px-3.5 py-2.5 text-sm text-white caret-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 hover:border-slate-500 resize-y"
+          className="w-full rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-[#121214] px-3.5 py-2.5 text-sm text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 hover:border-gray-300 dark:hover:border-white/20 resize-y"
           placeholder="e.g. 3+ years experience, B.Tech in CS, Strong DSA"
           value={formData.requirements}
           onChange={handleChange}
           disabled={isFormSubmitting}
         />
-        <p className="text-xs text-slate-500">Comma-separated list of candidate qualifications.</p>
+        <p className="text-xs text-gray-500 dark:text-slate-400">Comma-separated list of candidate qualifications.</p>
       </div>
 
       {/* responsibilities */}
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="responsibilities" className="text-sm font-medium text-gray-300">Responsibilities</label>
+        <label htmlFor="responsibilities" className="text-sm font-medium text-gray-700 dark:text-gray-300">Responsibilities</label>
         <textarea
           data-testid="input-responsibilities"
           id="responsibilities"
           rows={3}
-          className="w-full rounded-lg border border-slate-600 bg-slate-800 px-3.5 py-2.5 text-sm text-white caret-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 hover:border-slate-500 resize-y"
+          className="w-full rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-[#121214] px-3.5 py-2.5 text-sm text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 hover:border-gray-300 dark:hover:border-white/20 resize-y"
           placeholder="e.g. Design microservices, Lead code reviews, Mentor juniors"
           value={formData.responsibilities}
           onChange={handleChange}
           disabled={isFormSubmitting}
         />
-        <p className="text-xs text-slate-500">Comma-separated list of key responsibilities.</p>
+        <p className="text-xs text-gray-500 dark:text-slate-400">Comma-separated list of key responsibilities.</p>
       </div>
 
       {/* keywords */}
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="keywords" className="text-sm font-medium text-gray-300">Keywords</label>
+        <label htmlFor="keywords" className="text-sm font-medium text-gray-700 dark:text-gray-300">Keywords</label>
         <textarea
           data-testid="input-keywords"
           id="keywords"
           rows={2}
-          className="w-full rounded-lg border border-slate-600 bg-slate-800 px-3.5 py-2.5 text-sm text-white caret-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 hover:border-slate-500 resize-y"
+          className="w-full rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-[#121214] px-3.5 py-2.5 text-sm text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 hover:border-gray-300 dark:hover:border-white/20 resize-y"
           placeholder="e.g. remote, fintech, startup, react"
           value={formData.keywords}
           onChange={handleChange}
           disabled={isFormSubmitting}
         />
-        <p className="text-xs text-slate-500">Comma-separated keywords to improve job discoverability.</p>
+        <p className="text-xs text-gray-500 dark:text-slate-400">Comma-separated keywords to improve job discoverability.</p>
       </div>
 
-      <div className="border-t border-slate-700 pt-6">
-        <h3 className="text-sm font-medium text-gray-300 mb-4">Location</h3>
+      <div className="border-t border-gray-200 dark:border-white/10 pt-6">
+        <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-4">Location</h3>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Input
             id="location.city"
@@ -453,16 +453,16 @@ const JobPostingForm = ({ onSubmit, initialData = {}, isLoading = false, fieldEr
             checked={formData.location.remote}
             onChange={(e) => handleLocationChange("remote", e.target.checked)}
             disabled={isFormSubmitting}
-            className="rounded border-slate-600 bg-slate-800 text-blue-600 focus:ring-blue-500"
+            className="rounded border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-blue-600 focus:ring-blue-500"
           />
-          <label htmlFor="location.remote" className="text-sm text-gray-300">
+          <label htmlFor="location.remote" className="text-sm text-gray-700 dark:text-gray-300">
             Remote position
           </label>
         </div>
       </div>
 
-      <div className="border-t border-slate-700 pt-6">
-        <h3 className="text-sm font-medium text-gray-300 mb-4">Salary</h3>
+      <div className="border-t border-gray-200 dark:border-white/10 pt-6">
+        <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-4">Salary</h3>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Input
             id="salary.min"
@@ -503,9 +503,9 @@ const JobPostingForm = ({ onSubmit, initialData = {}, isLoading = false, fieldEr
             checked={formData.salary.isNegotiable}
             onChange={(e) => handleSalaryChange("isNegotiable", e.target.checked)}
             disabled={isFormSubmitting}
-            className="rounded border-slate-600 bg-slate-800 text-blue-600 focus:ring-blue-500"
+            className="rounded border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-blue-600 focus:ring-blue-500"
           />
-          <label htmlFor="salary.isNegotiable" className="text-sm text-gray-300">
+          <label htmlFor="salary.isNegotiable" className="text-sm text-gray-700 dark:text-gray-300">
             Salary is negotiable
           </label>
         </div>

--- a/client/src/modules/recruiter-jobs/pages/CreateJobPostingPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/CreateJobPostingPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { useNavigate, Link } from "react-router-dom";
-import { ArrowLeft, Briefcase } from "lucide-react";
+import { ArrowLeft, Briefcase, Target, Sparkles } from "lucide-react";
 import Navbar from "../../../shared/components/Navbar";
 import Footer from "../../../shared/components/Footer";
 
@@ -39,29 +39,47 @@ const CreateJobPostingPage = () => {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-[#020617] text-slate-900 dark:text-white flex flex-col">
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col">
       <Navbar />
 
-      <div className="flex-1 pt-24 pb-16 px-4 sm:px-6 mx-auto flex w-full max-w-3xl flex-col gap-6">
-        <Link 
-          to="/recruiter/jobs" 
-          className="inline-flex items-center gap-2 text-slate-600 dark:text-slate-400 hover:text-blue-400 transition-colors w-fit group"
-        >
-          <ArrowLeft size={18} className="group-hover:-translate-x-1 transition-transform" />
-          <span>Back to Jobs</span>
-        </Link>
-
-        <div className="flex flex-col gap-1 mb-2">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-blue-500/10 rounded-lg text-blue-400">
-              <Briefcase size={24} />
-            </div>
-            <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Create Job Posting</h1>
-          </div>
-          <p className="text-slate-600 dark:text-slate-400 mt-2">
-            Fill in the details below to post a new job. We'll use this information to recommend the best candidates.
-          </p>
+      <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
+        <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+          <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+          <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+          <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
         </div>
+
+        <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6">
+          <div className="py-6">
+            <Link 
+              to="/recruiter/jobs" 
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
+            >
+              <ArrowLeft size={16} />
+              Back to Jobs
+            </Link>
+          </div>
+
+          <div className="text-center space-y-4 mb-6 relative">
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <Briefcase className="w-6 h-6 text-purple-600" />
+            </div>
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <Target className="w-6 h-6 text-emerald-600" />
+            </div>
+
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-purple-500" /> NEW OPPORTUNITY
+            </div>
+            
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Create</span> Job Posting
+            </h1>
+            
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
+              Fill in the details below to post a new job. We'll use this information to recommend the best candidates.
+            </p>
+          </div>
 
         {submitError && (
           <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-xl text-red-400 text-sm flex items-start gap-3">
@@ -72,7 +90,7 @@ const CreateJobPostingPage = () => {
           </div>
         )}
 
-        <div className="bg-white dark:bg-slate-900/70 border border-slate-200 dark:border-white/10 rounded-2xl p-6 sm:p-8 shadow-2xl backdrop-blur">
+        <div className="bg-white dark:bg-[#121214] border border-gray-100 dark:border-white/5 rounded-3xl p-6 sm:p-8 shadow-[0_8px_30px_rgb(0,0,0,0.04)] dark:shadow-[0_8px_30px_rgba(0,0,0,0.2)] max-w-3xl mx-auto w-full">
           <JobPostingForm 
             onSubmit={handleSubmit} 
             isLoading={isSubmitting} 
@@ -80,6 +98,7 @@ const CreateJobPostingPage = () => {
           />
         </div>
       </div>
+      </main>
           <Footer />
     </div>
   );

--- a/client/src/modules/recruiter-jobs/pages/EditJobPostingPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/EditJobPostingPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useSelector } from "react-redux";
 import { useNavigate, useParams, Link } from "react-router-dom";
-import { ArrowLeft, Edit3 } from "lucide-react";
+import { ArrowLeft, Edit3, Target, Sparkles } from "lucide-react";
 import Navbar from "../../../shared/components/Navbar";
 import Footer from "../../../shared/components/Footer";
 
@@ -66,29 +66,47 @@ const EditJobPostingPage = () => {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-[#020617] text-slate-900 dark:text-white flex flex-col">
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col">
       <Navbar />
 
-      <div className="flex-1 pt-24 pb-16 px-4 sm:px-6 mx-auto flex w-full max-w-3xl flex-col gap-6">
-        <Link 
-          to="/recruiter/jobs" 
-          className="inline-flex items-center gap-2 text-slate-600 dark:text-slate-400 hover:text-blue-400 transition-colors w-fit group"
-        >
-          <ArrowLeft size={18} className="group-hover:-translate-x-1 transition-transform" />
-          <span>Back to Jobs</span>
-        </Link>
-
-        <div className="flex flex-col gap-1 mb-2">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-blue-500/10 rounded-lg text-blue-400">
-              <Edit3 size={24} />
-            </div>
-            <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Edit Job Posting</h1>
-          </div>
-          <p className="text-slate-600 dark:text-slate-400 mt-2">
-            Update the details below to edit your job posting. Changes will be reflected immediately.
-          </p>
+      <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
+        <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+          <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+          <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+          <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
         </div>
+
+        <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6">
+          <div className="py-6">
+            <Link 
+              to="/recruiter/jobs" 
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
+            >
+              <ArrowLeft size={16} />
+              Back to Jobs
+            </Link>
+          </div>
+
+          <div className="text-center space-y-4 mb-6 relative">
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <Edit3 className="w-6 h-6 text-purple-600" />
+            </div>
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <Target className="w-6 h-6 text-emerald-600" />
+            </div>
+
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-purple-500" /> LIVE EDITING MODE
+            </div>
+            
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Edit</span> Job Posting
+            </h1>
+            
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
+              Update the details below to edit your job posting. Changes will be reflected immediately.
+            </p>
+          </div>
 
         {submitError && (
           <div className="p-4 bg-red-500/10 border border-red-500/20 rounded-xl text-red-400 text-sm flex items-start gap-3">
@@ -99,7 +117,7 @@ const EditJobPostingPage = () => {
           </div>
         )}
 
-        <div className="bg-white dark:bg-slate-900/70 border border-slate-200 dark:border-white/10 rounded-2xl p-6 sm:p-8 shadow-2xl backdrop-blur">
+        <div className="bg-white dark:bg-[#121214] border border-gray-100 dark:border-white/5 rounded-3xl p-6 sm:p-8 shadow-[0_8px_30px_rgb(0,0,0,0.04)] dark:shadow-[0_8px_30px_rgba(0,0,0,0.2)] max-w-3xl mx-auto w-full">
           {isLoadingData ? (
             <div className="py-12">
               <LoadingState message="Loading job details..." />
@@ -118,6 +136,7 @@ const EditJobPostingPage = () => {
           )}
         </div>
       </div>
+      </main>
           <Footer />
     </div>
   );

--- a/client/src/modules/recruiter-jobs/pages/RecruiterAnalyticsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterAnalyticsPage.jsx
@@ -23,7 +23,8 @@ import {
   Code,
   ShieldAlert,
   Download,
-  ChevronDown
+  ChevronDown,
+  FileText
 } from "lucide-react";
 import {
   ResponsiveContainer,
@@ -344,7 +345,7 @@ const RecruiterAnalyticsPage = () => {
             <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
           </div>
           <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6 pt-12">
-            <ErrorState message={error} onRetry={fetchAnalytics} />
+            <ErrorState description={error} onRetry={fetchAnalytics} />
           </div>
         </main>
       </div>
@@ -375,60 +376,58 @@ const RecruiterAnalyticsPage = () => {
           </div>
 
           {/* Header Block */}
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between mb-4">
-            <div className="text-left space-y-4 relative">
-              <div className="hidden md:flex absolute -top-8 -left-12 w-14 h-14 bg-blue-50 dark:bg-blue-500/10 border border-blue-100 dark:border-blue-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
-                 <BarChart3 className="w-6 h-6 text-blue-600" />
-              </div>
-              <div className="hidden md:flex absolute top-4 right-0 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
-                 <Sparkles className="w-6 h-6 text-emerald-600" />
-              </div>
-
-              <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-blue-50 dark:bg-blue-500/10 border border-blue-100 dark:border-blue-500/20 shadow-sm text-[11px] font-bold text-blue-600 dark:text-blue-400 tracking-wide uppercase">
-                <Sparkles size={12} className="text-blue-500" /> HIRING INTELLIGENCE
-              </div>
-              
-              <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
-                <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Intelligence</span> Dashboard
-              </h1>
-              
-              <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl font-medium">
-                Aggregated analytics and insights across all your job postings and applicants.
-              </p>
+          <div className="text-center space-y-4 mb-6 relative">
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-blue-50 dark:bg-blue-500/10 border border-blue-100 dark:border-blue-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <BarChart3 className="w-6 h-6 text-blue-600" />
             </div>
-            <div className="flex items-center gap-3 relative mt-4 md:mt-0">
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <Sparkles className="w-6 h-6 text-emerald-600" />
+            </div>
+
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-blue-50 dark:bg-blue-500/10 border border-blue-100 dark:border-blue-500/20 shadow-sm text-[11px] font-bold text-blue-600 dark:text-blue-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-blue-500" /> HIRING INTELLIGENCE
+            </div>
             
-            <div className="relative">
-              <button
-                onClick={() => setIsExportDropdownOpen(!isExportDropdownOpen)}
-                className="inline-flex items-center gap-2 rounded-xl border border-blue-500/30 bg-blue-600/10 px-4 py-2.5 text-sm font-semibold text-blue-400 hover:bg-blue-600/20 hover:text-blue-300 backdrop-blur-sm transition-all duration-300"
-              >
-                <Download size={16} />
-                Export Report
-                <ChevronDown size={14} className={`transition-transform ${isExportDropdownOpen ? "rotate-180" : ""}`} />
-              </button>
-              
-              {isExportDropdownOpen && (
-                <div className="absolute right-0 top-full mt-2 w-48 rounded-xl border border-gray-200 dark:border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/95 p-2 shadow-2xl backdrop-blur-md z-50 animate-in fade-in slide-in-from-top-2 duration-200">
-                  <button
-                    onClick={handleExportPDF}
-                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-white dark:bg-slate-800 hover:text-slate-900 dark:hover:text-white transition-colors"
-                  >
-                    <FileEdit size={14} />
-                    Export as PDF Snapshot
-                  </button>
-                  <button
-                    onClick={handleExportCSV}
-                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-white dark:bg-slate-800 hover:text-slate-900 dark:hover:text-white transition-colors"
-                  >
-                    <BarChart3 size={14} />
-                    Export Summary (CSV)
-                  </button>
-                </div>
-              )}
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Intelligence</span> Dashboard
+            </h1>
+            
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
+              Aggregated analytics and insights across all your job postings and applicants.
+            </p>
+
+            <div className="pt-2 flex justify-center">
+              <div className="relative">
+                <button
+                  onClick={() => setIsExportDropdownOpen(!isExportDropdownOpen)}
+                  className="inline-flex items-center gap-2 rounded-xl border border-blue-500/30 bg-blue-600/10 px-6 py-2.5 text-sm font-semibold text-blue-500 dark:text-blue-400 hover:bg-blue-600/20 hover:text-blue-600 dark:hover:text-blue-300 backdrop-blur-sm transition-all duration-300 shadow-sm"
+                >
+                  <Download size={16} />
+                  Export Report
+                  <ChevronDown size={14} className={`transition-transform ${isExportDropdownOpen ? "rotate-180" : ""}`} />
+                </button>
+                
+                {isExportDropdownOpen && (
+                  <div className="absolute right-0 top-full mt-2 w-48 rounded-xl border border-gray-200 dark:border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/95 p-2 shadow-2xl backdrop-blur-md z-50 animate-in fade-in slide-in-from-top-2 duration-200 text-left">
+                    <button
+                      onClick={handleExportPDF}
+                      className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-white dark:bg-slate-800 hover:text-slate-900 dark:hover:text-white transition-colors"
+                    >
+                      <FileEdit size={14} />
+                      Export as PDF Snapshot
+                    </button>
+                    <button
+                      onClick={handleExportCSV}
+                      className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-white dark:bg-slate-800 hover:text-slate-900 dark:hover:text-white transition-colors"
+                    >
+                      <BarChart3 size={14} />
+                      Export Summary (CSV)
+                    </button>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
-        </div>
 
         {/* High-Level Overview Metrics */}
         <section className="grid gap-4 sm:gap-6 grid-cols-2 lg:grid-cols-5">
@@ -485,8 +484,8 @@ const RecruiterAnalyticsPage = () => {
             onClick={() => setActiveTab("overview")}
             className={`flex-1 sm:flex-initial px-6 py-2.5 text-xs font-extrabold tracking-wider uppercase rounded-xl transition-all duration-300 ${
               activeTab === "overview"
-                ? "bg-blue-600 text-slate-900 dark:text-white shadow-[0_0_15px_rgba(37,99,235,0.4)]"
-                : "text-slate-600 dark:text-slate-400 hover:text-slate-200"
+                ? "bg-blue-600 text-white shadow-[0_0_15px_rgba(37,99,235,0.4)]"
+                : "text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-800 dark:hover:text-slate-200"
             }`}
           >
             Hiring Overview
@@ -495,8 +494,8 @@ const RecruiterAnalyticsPage = () => {
             onClick={() => setActiveTab("ai_ats")}
             className={`flex-1 sm:flex-initial px-6 py-2.5 text-xs font-extrabold tracking-wider uppercase rounded-xl transition-all duration-300 ${
               activeTab === "ai_ats"
-                ? "bg-blue-600 text-slate-900 dark:text-white shadow-[0_0_15px_rgba(37,99,235,0.4)]"
-                : "text-slate-600 dark:text-slate-400 hover:text-slate-200"
+                ? "bg-blue-600 text-white shadow-[0_0_15px_rgba(37,99,235,0.4)]"
+                : "text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-800 dark:hover:text-slate-200"
             }`}
           >
             AI & ATS Intelligence
@@ -505,8 +504,8 @@ const RecruiterAnalyticsPage = () => {
             onClick={() => setActiveTab("specialty")}
             className={`flex-1 sm:flex-initial px-6 py-2.5 text-xs font-extrabold tracking-wider uppercase rounded-xl transition-all duration-300 ${
               activeTab === "specialty"
-                ? "bg-blue-600 text-slate-900 dark:text-white shadow-[0_0_15px_rgba(37,99,235,0.4)]"
-                : "text-slate-600 dark:text-slate-400 hover:text-slate-200"
+                ? "bg-blue-600 text-white shadow-[0_0_15px_rgba(37,99,235,0.4)]"
+                : "text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-800 dark:hover:text-slate-200"
             }`}
           >
             Technical & OSS Insights
@@ -522,7 +521,7 @@ const RecruiterAnalyticsPage = () => {
               {/* Applicant Workflow Timeline Summary */}
               {totalApplicants > 0 && (
                 <div className="grid gap-4 sm:gap-6 grid-cols-2 lg:grid-cols-4">
-                  <div className="group relative rounded-2xl border border-white/5 bg-white dark:bg-slate-900/30 p-5 shadow-inner transition-all hover:border-amber-500/20">
+                  <div className="group relative rounded-2xl border border-gray-100 dark:border-white/5 bg-white dark:bg-slate-900/30 p-5 shadow-inner transition-all hover:border-amber-500/20">
                     <div className="flex items-center gap-3">
                       <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-amber-500/10 text-amber-400">
                         <Clock size={18} />
@@ -533,7 +532,7 @@ const RecruiterAnalyticsPage = () => {
                       </div>
                     </div>
                   </div>
-                  <div className="group relative rounded-2xl border border-white/5 bg-white dark:bg-slate-900/30 p-5 shadow-inner transition-all hover:border-blue-500/20">
+                  <div className="group relative rounded-2xl border border-gray-100 dark:border-white/5 bg-white dark:bg-slate-900/30 p-5 shadow-inner transition-all hover:border-blue-500/20">
                     <div className="flex items-center gap-3">
                       <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-500/10 text-blue-400">
                         <Eye size={18} />
@@ -544,7 +543,7 @@ const RecruiterAnalyticsPage = () => {
                       </div>
                     </div>
                   </div>
-                  <div className="group relative rounded-2xl border border-white/5 bg-white dark:bg-slate-900/30 p-5 shadow-inner transition-all hover:border-emerald-500/20">
+                  <div className="group relative rounded-2xl border border-gray-100 dark:border-white/5 bg-white dark:bg-slate-900/30 p-5 shadow-inner transition-all hover:border-emerald-500/20">
                     <div className="flex items-center gap-3">
                       <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-400">
                         <UserCheck size={18} />
@@ -555,7 +554,7 @@ const RecruiterAnalyticsPage = () => {
                       </div>
                     </div>
                   </div>
-                  <div className="group relative rounded-2xl border border-white/5 bg-white dark:bg-slate-900/30 p-5 shadow-inner transition-all hover:border-red-500/20">
+                  <div className="group relative rounded-2xl border border-gray-100 dark:border-white/5 bg-white dark:bg-slate-900/30 p-5 shadow-inner transition-all hover:border-red-500/20">
                     <div className="flex items-center gap-3">
                       <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-red-500/10 text-red-400">
                         <UserX size={18} />
@@ -574,9 +573,9 @@ const RecruiterAnalyticsPage = () => {
                 
                 {/* Status Distribution */}
                 <div className="rounded-2xl border border-gray-200 dark:border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/50 overflow-hidden backdrop-blur-md shadow-2xl">
-                  <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center gap-2">
+                  <div className="border-b border-gray-100 dark:border-white/5 bg-gray-50 dark:bg-white/5 px-6 py-4 flex items-center gap-2">
                     <BarChart3 className="text-blue-400" size={18} />
-                    <h2 className="text-sm font-bold uppercase tracking-wider text-slate-200">Postings Status</h2>
+                    <h2 className="text-sm font-bold uppercase tracking-wider text-slate-500 dark:text-slate-200">Postings Status</h2>
                   </div>
                   <div className="p-6 h-[280px] flex items-center justify-center">
                     {statusPieData.length > 0 ? (
@@ -624,12 +623,12 @@ const RecruiterAnalyticsPage = () => {
 
                 {/* Posting Timeline */}
                 <div className="rounded-2xl border border-gray-200 dark:border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/50 overflow-hidden backdrop-blur-md shadow-2xl">
-                  <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center justify-between">
+                  <div className="border-b border-gray-100 dark:border-white/5 bg-gray-50 dark:bg-white/5 px-6 py-4 flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       <TrendingUp className="text-emerald-400" size={18} />
-                      <h2 className="text-sm font-bold uppercase tracking-wider text-slate-200">Posting History</h2>
+                      <h2 className="text-sm font-bold uppercase tracking-wider text-slate-500 dark:text-slate-200">Posting History</h2>
                     </div>
-                    <div className="flex items-center gap-1 text-[10px] text-slate-600 dark:text-slate-400 bg-white/5 px-2 py-0.5 rounded border border-white/5 font-semibold uppercase tracking-wider">
+                    <div className="flex items-center gap-1 text-[10px] text-slate-600 dark:text-slate-400 bg-gray-50 dark:bg-white/5 px-2 py-0.5 rounded border border-gray-100 dark:border-white/5 font-semibold uppercase tracking-wider">
                       <Calendar size={10} /> 6 Months
                     </div>
                   </div>
@@ -664,7 +663,7 @@ const RecruiterAnalyticsPage = () => {
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
                 {/* Top demanded skills */}
                 <div className="rounded-2xl border border-gray-200 dark:border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/50 overflow-hidden backdrop-blur-md p-6 space-y-4">
-                  <h3 className="text-sm font-bold uppercase tracking-wider text-slate-200 flex items-center gap-2 pb-3 border-b border-white/5">
+                  <h3 className="text-sm font-bold uppercase tracking-wider text-slate-500 dark:text-slate-200 flex items-center gap-2 pb-3 border-b border-gray-100 dark:border-white/5">
                     <Zap size={16} className="text-amber-400" /> Dominated Demanded Skills
                   </h3>
                   {topSkills.length > 0 ? (
@@ -698,7 +697,7 @@ const RecruiterAnalyticsPage = () => {
 
                 {/* Applicants Per Job Bar */}
                 <div className="rounded-2xl border border-gray-200 dark:border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/50 overflow-hidden backdrop-blur-md p-6 space-y-4">
-                  <h3 className="text-sm font-bold uppercase tracking-wider text-slate-200 flex items-center gap-2 pb-3 border-b border-white/5">
+                  <h3 className="text-sm font-bold uppercase tracking-wider text-slate-500 dark:text-slate-200 flex items-center gap-2 pb-3 border-b border-gray-100 dark:border-white/5">
                     <Users size={16} className="text-violet-400" /> Applicants Per Job
                   </h3>
                   {applicantsPerJob.length > 0 ? (
@@ -732,7 +731,7 @@ const RecruiterAnalyticsPage = () => {
 
                 {/* Recent Jobs list */}
                 <div className="rounded-2xl border border-gray-200 dark:border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/50 overflow-hidden backdrop-blur-md p-6 space-y-4">
-                  <h3 className="text-sm font-bold uppercase tracking-wider text-slate-200 flex items-center gap-2 pb-3 border-b border-white/5">
+                  <h3 className="text-sm font-bold uppercase tracking-wider text-slate-500 dark:text-slate-200 flex items-center gap-2 pb-3 border-b border-gray-100 dark:border-white/5">
                     <Clock size={16} className="text-indigo-400" /> Recent Posting Activities
                   </h3>
                   {recentJobs.length > 0 ? (
@@ -802,9 +801,9 @@ const RecruiterAnalyticsPage = () => {
                 
                 {/* Match Category Pie Chart */}
                 <div className="lg:col-span-2 rounded-2xl border border-gray-200 dark:border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/50 overflow-hidden backdrop-blur-md shadow-2xl">
-                  <div className="border-b border-white/5 bg-white/5 px-6 py-4 flex items-center gap-2">
+                  <div className="border-b border-gray-100 dark:border-white/5 bg-gray-50 dark:bg-white/5 px-6 py-4 flex items-center gap-2">
                     <Sparkles className="text-blue-400" size={18} />
-                    <h2 className="text-sm font-bold uppercase tracking-wider text-slate-200">Match Category Distributions</h2>
+                    <h2 className="text-sm font-bold uppercase tracking-wider text-slate-500 dark:text-slate-200">Match Category Distributions</h2>
                   </div>
                   <div className="p-6 h-[300px] flex items-center justify-center">
                     {matchCategoryPieData.length > 0 ? (
@@ -852,11 +851,11 @@ const RecruiterAnalyticsPage = () => {
 
                 {/* Recruiter Insight Alerts */}
                 <div className="rounded-2xl border border-gray-200 dark:border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/50 overflow-hidden backdrop-blur-md p-6 space-y-6">
-                  <h3 className="text-sm font-bold uppercase tracking-wider text-slate-200 flex items-center gap-2 pb-3 border-b border-white/5">
+                  <h3 className="text-sm font-bold uppercase tracking-wider text-slate-500 dark:text-slate-200 flex items-center gap-2 pb-3 border-b border-gray-100 dark:border-white/5">
                     <Award size={16} className="text-emerald-400" /> Talent Quality Index
                   </h3>
                   <div className="space-y-4 pt-1">
-                    <div className="p-4 rounded-xl bg-slate-950/40 border border-white/5 space-y-1">
+                    <div className="p-4 rounded-xl bg-gray-50 dark:bg-slate-950/40 border border-gray-100 dark:border-white/5 space-y-1">
                       <span className="text-[10px] font-bold text-slate-500 uppercase tracking-wider">Top Talent Concentration</span>
                       <p className="text-lg font-black text-slate-900 dark:text-white">
                         {totalApplicants > 0 ? Math.round((topCandidatesCount / totalApplicants) * 100) : 0}%
@@ -866,7 +865,7 @@ const RecruiterAnalyticsPage = () => {
                       </p>
                     </div>
 
-                    <div className="p-4 rounded-xl bg-slate-950/40 border border-white/5 space-y-1">
+                    <div className="p-4 rounded-xl bg-gray-50 dark:bg-slate-950/40 border border-gray-100 dark:border-white/5 space-y-1">
                       <span className="text-[10px] font-bold text-slate-500 uppercase tracking-wider">ATS Optimization Index</span>
                       <p className="text-lg font-black text-slate-900 dark:text-white">
                         {atsReadyPercentage}% Ready
@@ -889,7 +888,7 @@ const RecruiterAnalyticsPage = () => {
                 
                 {/* Specialization Bar Chart */}
                 <div className="lg:col-span-2 rounded-2xl border border-gray-200 dark:border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/50 overflow-hidden backdrop-blur-md p-6 shadow-2xl">
-                  <h3 className="text-sm font-bold uppercase tracking-wider text-slate-200 flex items-center gap-2 pb-4 border-b border-white/5 mb-6">
+                  <h3 className="text-sm font-bold uppercase tracking-wider text-slate-500 dark:text-slate-200 flex items-center gap-2 pb-4 border-b border-gray-100 dark:border-white/5 mb-6">
                     <Code size={18} className="text-blue-400" /> Specialization Demographics
                   </h3>
                   <div className="h-[280px]">
@@ -913,13 +912,13 @@ const RecruiterAnalyticsPage = () => {
 
                 {/* Contribution details & stages */}
                 <div className="rounded-2xl border border-gray-200 dark:border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/50 overflow-hidden backdrop-blur-md p-6 space-y-6">
-                  <h3 className="text-sm font-bold uppercase tracking-wider text-slate-200 flex items-center gap-2 pb-3 border-b border-white/5">
+                  <h3 className="text-sm font-bold uppercase tracking-wider text-slate-500 dark:text-slate-200 flex items-center gap-2 pb-3 border-b border-gray-100 dark:border-white/5">
                     <BookOpen size={16} className="text-indigo-400" /> Career & Contributions
                   </h3>
                   <div className="grid grid-cols-1 gap-4 pt-1">
                     
                     {/* OSS Contributor rate */}
-                    <div className="p-4 bg-slate-950/40 border border-white/5 rounded-xl flex items-center justify-between">
+                    <div className="p-4 bg-gray-50 dark:bg-slate-950/40 border border-gray-100 dark:border-white/5 rounded-xl flex items-center justify-between">
                       <div className="space-y-0.5">
                         <span className="block text-[10px] font-bold text-slate-500 uppercase tracking-wider">OSS Activity Rate</span>
                         <span className="block text-lg font-black text-slate-900 dark:text-white">{ossContributorPercentage}%</span>
@@ -931,7 +930,7 @@ const RecruiterAnalyticsPage = () => {
                     </div>
 
                     {/* Career readiness stages */}
-                    <div className="p-4 bg-slate-950/40 border border-white/5 rounded-xl flex items-center justify-between">
+                    <div className="p-4 bg-gray-50 dark:bg-slate-950/40 border border-gray-100 dark:border-white/5 rounded-xl flex items-center justify-between">
                       <div className="space-y-0.5">
                         <span className="block text-[10px] font-bold text-slate-500 uppercase tracking-wider">Roadmap Active Rate</span>
                         <span className="block text-lg font-black text-slate-900 dark:text-white">

--- a/client/src/modules/recruiter-jobs/pages/RecruiterAnalyticsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterAnalyticsPage.jsx
@@ -317,53 +317,86 @@ const RecruiterAnalyticsPage = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-slate-50 dark:bg-[#020617] text-slate-900 dark:text-white flex flex-col">
+      <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col">
         <Navbar />
-        <div className="py-20">
-          <LoadingState message="Aggregating hiring intelligence analytics..." />
-        </div>
+        <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
+          <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+            <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+            <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+            <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
+          </div>
+          <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6 pt-12">
+            <LoadingState message="Aggregating hiring intelligence analytics..." />
+          </div>
+        </main>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="min-h-screen bg-slate-50 dark:bg-[#020617] text-slate-900 dark:text-white flex flex-col">
+      <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col">
         <Navbar />
-        <div className="mx-auto max-w-5xl py-8">
-          <ErrorState message={error} onRetry={fetchAnalytics} />
-        </div>
+        <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
+          <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+            <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+            <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+            <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
+          </div>
+          <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6 pt-12">
+            <ErrorState message={error} onRetry={fetchAnalytics} />
+          </div>
+        </main>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-[#020617] text-slate-900 dark:text-white flex flex-col">
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col">
       <Navbar />
 
-      <div id="analytics-dashboard" className="flex-1 w-full mx-auto flex max-w-7xl flex-col gap-8 pt-24 pb-16 px-4 sm:px-6">
-        
-        {/* Header Block */}
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="space-y-1">
-            <div className="flex items-center gap-2 mb-1">
-              <div className="h-2 w-2 rounded-full bg-emerald-500 animate-pulse" />
-              <p className="text-xs font-extrabold text-emerald-400 uppercase tracking-widest flex items-center gap-1.5">
-                <Sparkles size={14} /> Recruiter Hiring Intelligence
-              </p>
-            </div>
-            <h1 className="text-3xl sm:text-4xl font-black bg-clip-text text-transparent bg-gradient-to-r from-white via-slate-100 to-slate-400">
-              Intelligence Dashboard
-            </h1>
-          </div>
-          <div className="flex items-center gap-3 relative">
-            <Link
-              to="/dashboard"
-              className="inline-flex items-center gap-2 rounded-xl border border-gray-200 dark:border-white/5 bg-white dark:bg-slate-900/40 px-4 py-2.5 text-sm font-semibold text-gray-600 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-800 hover:text-gray-900 dark:hover:text-white backdrop-blur-sm transition-all duration-300 w-fit"
+      <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
+        <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+          <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+          <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+          <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
+        </div>
+
+        <div id="analytics-dashboard" className="w-full max-w-[1200px] relative z-10 flex flex-col gap-8">
+          
+          <div className="py-6 flex justify-between items-center">
+            <Link 
+              to="/dashboard" 
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
             >
               <ArrowLeft size={16} />
               Back to Dashboard
             </Link>
+          </div>
+
+          {/* Header Block */}
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between mb-4">
+            <div className="text-left space-y-4 relative">
+              <div className="hidden md:flex absolute -top-8 -left-12 w-14 h-14 bg-blue-50 dark:bg-blue-500/10 border border-blue-100 dark:border-blue-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+                 <BarChart3 className="w-6 h-6 text-blue-600" />
+              </div>
+              <div className="hidden md:flex absolute top-4 right-0 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+                 <Sparkles className="w-6 h-6 text-emerald-600" />
+              </div>
+
+              <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-blue-50 dark:bg-blue-500/10 border border-blue-100 dark:border-blue-500/20 shadow-sm text-[11px] font-bold text-blue-600 dark:text-blue-400 tracking-wide uppercase">
+                <Sparkles size={12} className="text-blue-500" /> HIRING INTELLIGENCE
+              </div>
+              
+              <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+                <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Intelligence</span> Dashboard
+              </h1>
+              
+              <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl font-medium">
+                Aggregated analytics and insights across all your job postings and applicants.
+              </p>
+            </div>
+            <div className="flex items-center gap-3 relative mt-4 md:mt-0">
             
             <div className="relative">
               <button
@@ -918,9 +951,10 @@ const RecruiterAnalyticsPage = () => {
             </div>
           )}
 
+          </div>
         </div>
-      </div>
-          <Footer />
+      </main>
+      <Footer />
     </div>
   );
 };

--- a/client/src/modules/recruiter-jobs/pages/RecruiterApplicantsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterApplicantsPage.jsx
@@ -299,46 +299,23 @@ const RecruiterApplicantsPage = () => {
         </div>
 
         <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6">
-          <div className="py-6 flex justify-between items-center w-full">
+          <div className="py-6 flex justify-start items-center w-full">
             <Link 
               to="/recruiter/jobs" 
               className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
             >
               <ArrowLeft size={16} /> Back to Jobs
             </Link>
-          
-          <div className="relative z-20">
-            <button
-              onClick={() => setIsExportDropdownOpen(!isExportDropdownOpen)}
-              className="inline-flex items-center gap-2 rounded-xl border border-blue-500/30 bg-blue-600/10 px-4 py-2.5 text-sm font-semibold text-blue-400 hover:bg-blue-600/20 hover:text-blue-300 backdrop-blur-sm transition-all duration-300"
-            >
-              <Download size={16} />
-              Export Candidates
-              <ChevronDown size={14} className={`transition-transform ${isExportDropdownOpen ? "rotate-180" : ""}`} />
-            </button>
-            
-            {isExportDropdownOpen && (
-              <div className="absolute right-0 top-full mt-2 w-48 rounded-xl border border-gray-200 dark:border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/95 p-2 shadow-2xl backdrop-blur-md animate-in fade-in slide-in-from-top-2 duration-200">
-                <button
-                  onClick={handleExportPDF}
-                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-white dark:bg-slate-800 hover:text-gray-900 dark:hover:text-white transition-colors"
-                >
-                  <FileText size={14} />
-                  Export List (PDF)
-                </button>
-                <button
-                  onClick={handleExportCSV}
-                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-white dark:bg-slate-800 hover:text-gray-900 dark:hover:text-white transition-colors"
-                >
-                  <Filter size={14} />
-                  Export Data (CSV)
-                </button>
-              </div>
-            )}
           </div>
-        </div>
 
         <div className="text-center space-y-4 mb-6 relative">
+          <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+             <Users className="w-6 h-6 text-purple-600" />
+          </div>
+          <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+             <Filter className="w-6 h-6 text-emerald-600" />
+          </div>
+
           <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
             <Sparkles size={12} className="text-purple-500" /> APPLICANT TRACKING
           </div>
@@ -348,10 +325,41 @@ const RecruiterApplicantsPage = () => {
           </h1>
           
           <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
-            Reviewing applicants for <span className="text-indigo-600 dark:text-indigo-400 font-bold">{job?.title || 'Loading...'}</span>
+            Review, evaluate, and manage applications for <span className="text-indigo-600 dark:text-indigo-400 font-bold">{job?.title || "this position"}</span>.
           </p>
-          
-          <div className="flex items-center justify-center gap-4 text-gray-500 dark:text-slate-400 text-sm mt-2">
+
+          <div className="pt-2 flex justify-center">
+            <div className="relative z-20">
+              <button
+                onClick={() => setIsExportDropdownOpen(!isExportDropdownOpen)}
+                className="inline-flex items-center gap-2 rounded-xl border border-blue-500/30 bg-blue-600/10 px-6 py-2.5 text-sm font-semibold text-blue-500 dark:text-blue-400 hover:bg-blue-600/20 hover:text-blue-600 dark:hover:text-blue-300 backdrop-blur-sm transition-all duration-300 shadow-sm"
+              >
+                <Download size={16} />
+                Export Candidates
+                <ChevronDown size={14} className={`transition-transform ${isExportDropdownOpen ? "rotate-180" : ""}`} />
+              </button>
+              
+              {isExportDropdownOpen && (
+                <div className="absolute right-0 top-full mt-2 w-48 rounded-xl border border-gray-200 dark:border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/95 p-2 shadow-2xl backdrop-blur-md animate-in fade-in slide-in-from-top-2 duration-200 text-left">
+                  <button
+                    onClick={handleExportPDF}
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-white dark:bg-slate-800 hover:text-slate-900 dark:hover:text-white transition-colors"
+                  >
+                    <FileText size={14} />
+                    Export List (PDF)
+                  </button>
+                  <button
+                    onClick={handleExportCSV}
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-white dark:bg-slate-800 hover:text-slate-900 dark:hover:text-white transition-colors"
+                  >
+                    <Filter size={14} />
+                    Export Data (CSV)
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center justify-center gap-4 text-gray-500 dark:text-slate-400 text-sm mt-4">
             <span className="flex items-center gap-1.5">
               <Users size={16} /> {applicants.length} Matching Candidate{applicants.length !== 1 ? 's' : ''}
             </span>
@@ -627,7 +635,7 @@ const RecruiterApplicantsPage = () => {
                 <LoadingState message="Filtering candidates dynamically..." />
               </div>
             ) : error ? (
-              <ErrorState message={error} onRetry={fetchData} />
+              <ErrorState description={error} onRetry={fetchData} />
             ) : applicants.length === 0 ? (
               <EmptyState 
                 icon={<Users size={48} className="text-slate-700 animate-pulse" />}
@@ -760,7 +768,7 @@ const RecruiterApplicantsPage = () => {
 
                       {/* Expanded Details Section */}
                       {expandedId === app._id && (
-                        <div className="p-8 border-t border-white/5 bg-slate-950/30 space-y-8 animate-in slide-in-from-top-4 duration-300">
+                        <div className="p-8 border-t border-gray-100 dark:border-white/5 bg-slate-950/30 space-y-8 animate-in slide-in-from-top-4 duration-300">
                           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
                             {/* Left Side: Resume & Note */}
                             <div className="space-y-6">
@@ -774,18 +782,18 @@ const RecruiterApplicantsPage = () => {
                                       href={app.resumeLink} 
                                       target="_blank" 
                                       rel="noreferrer"
-                                      className="flex items-center justify-between p-4 bg-white dark:bg-slate-900 border border-white/5 rounded-2xl hover:border-blue-500/30 hover:bg-blue-500/5 transition-all group/link"
+                                      className="flex items-center justify-between p-4 bg-white dark:bg-slate-900 border border-gray-100 dark:border-white/5 rounded-2xl hover:border-blue-500/30 hover:bg-blue-500/5 transition-all group/link"
                                     >
                                       <div className="flex items-center gap-3">
                                         <div className="p-2 bg-red-500/10 rounded-lg text-red-400">
                                           <FileText size={20} />
                                         </div>
-                                        <span className="text-sm font-medium text-slate-200">View Candidate Resume</span>
+                                        <span className="text-sm font-medium text-slate-500 dark:text-slate-200">View Candidate Resume</span>
                                       </div>
                                       <ExternalLink size={18} className="text-slate-600 group-hover/link:text-blue-400 transition-colors" />
                                     </a>
                                   )}
-                                  <div className="p-4 bg-white dark:bg-slate-900/50 border border-white/5 rounded-2xl">
+                                  <div className="p-4 bg-white dark:bg-slate-900/50 border border-gray-100 dark:border-white/5 rounded-2xl">
                                     <h5 className="text-xs font-bold text-slate-500 uppercase mb-2">Cover Note</h5>
                                     <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed italic">
                                       &ldquo;{app.coverNote || 'No cover note provided.'}&rdquo;
@@ -795,7 +803,7 @@ const RecruiterApplicantsPage = () => {
                               </div>
 
                               {app.aiHiringSignals && app.aiHiringSignals.length > 0 && (
-                                <div className="space-y-3 pt-6 border-t border-white/5">
+                                <div className="space-y-3 pt-6 border-t border-gray-100 dark:border-white/5">
                                   <h4 className="text-sm font-bold text-purple-400 uppercase tracking-widest flex items-center gap-2">
                                     <Award size={16} /> Interview Readiness Signals
                                   </h4>
@@ -811,7 +819,7 @@ const RecruiterApplicantsPage = () => {
                               )}
 
                               {app.aiRecruiterInsights && app.aiRecruiterInsights.length > 0 && (
-                                <div className="space-y-3 pt-6 border-t border-white/5">
+                                <div className="space-y-3 pt-6 border-t border-gray-100 dark:border-white/5">
                                   <h4 className="text-sm font-bold text-blue-400 uppercase tracking-widest flex items-center gap-2">
                                     <Sparkles size={16} /> AI Recruiter Insights
                                   </h4>
@@ -829,7 +837,7 @@ const RecruiterApplicantsPage = () => {
                               )}
 
                               {app.aiWeaknesses && app.aiWeaknesses.length > 0 && (
-                                <div className="space-y-3 pt-6 border-t border-white/5">
+                                <div className="space-y-3 pt-6 border-t border-gray-100 dark:border-white/5">
                                   <h4 className="text-sm font-bold text-amber-400 uppercase tracking-widest flex items-center gap-2">
                                     <AlertTriangle size={16} /> AI Weakness Detection
                                   </h4>
@@ -847,15 +855,15 @@ const RecruiterApplicantsPage = () => {
                               )}
 
                               {app.matchBreakdown && (
-                                <div className="space-y-3 pt-6 border-t border-white/5">
+                                <div className="space-y-3 pt-6 border-t border-gray-100 dark:border-white/5">
                                   <h4 className="text-sm font-bold text-emerald-400 uppercase tracking-widest flex items-center gap-2">
                                     <Sparkles size={16} /> AI Match Breakdown
                                   </h4>
-                                  <div className="p-4 bg-white dark:bg-slate-900/80 border border-white/5 rounded-2xl space-y-4">
+                                  <div className="p-4 bg-white dark:bg-slate-900/80 border border-gray-100 dark:border-white/5 rounded-2xl space-y-4">
                                     <div>
                                       <div className="flex justify-between items-center mb-1.5">
                                         <span className="text-sm text-slate-600 dark:text-slate-400">ATS Compatibility</span>
-                                        <span className="text-sm font-bold text-slate-200">{app.matchBreakdown.atsCompatibility || 0}%</span>
+                                        <span className="text-sm font-bold text-slate-500 dark:text-slate-200">{app.matchBreakdown.atsCompatibility || 0}%</span>
                                       </div>
                                       <div className="w-full bg-white dark:bg-slate-800 rounded-full h-1.5">
                                         <div className="bg-emerald-500 h-1.5 rounded-full transition-all duration-1000" style={{ width: `${app.matchBreakdown.atsCompatibility || 0}%` }} />
@@ -865,7 +873,7 @@ const RecruiterApplicantsPage = () => {
                                     <div>
                                       <div className="flex justify-between items-center mb-1.5">
                                         <span className="text-sm text-slate-600 dark:text-slate-400">Skill Match</span>
-                                        <span className="text-sm font-bold text-slate-200">{app.matchBreakdown.skillMatch || 0}%</span>
+                                        <span className="text-sm font-bold text-slate-500 dark:text-slate-200">{app.matchBreakdown.skillMatch || 0}%</span>
                                       </div>
                                       <div className="w-full bg-white dark:bg-slate-800 rounded-full h-1.5">
                                         <div className="bg-blue-500 h-1.5 rounded-full transition-all duration-1000" style={{ width: `${app.matchBreakdown.skillMatch || 0}%` }} />
@@ -875,14 +883,14 @@ const RecruiterApplicantsPage = () => {
                                     <div>
                                       <div className="flex justify-between items-center mb-1.5">
                                         <span className="text-sm text-slate-600 dark:text-slate-400">Project Strength</span>
-                                        <span className="text-sm font-bold text-slate-200">{app.matchBreakdown.projectStrength || 0}%</span>
+                                        <span className="text-sm font-bold text-slate-500 dark:text-slate-200">{app.matchBreakdown.projectStrength || 0}%</span>
                                       </div>
                                       <div className="w-full bg-white dark:bg-slate-800 rounded-full h-1.5">
                                         <div className="bg-purple-500 h-1.5 rounded-full transition-all duration-1000" style={{ width: `${app.matchBreakdown.projectStrength || 0}%` }} />
                                       </div>
                                     </div>
 
-                                    <div className="flex justify-between items-center pt-2 border-t border-white/5">
+                                    <div className="flex justify-between items-center pt-2 border-t border-gray-100 dark:border-white/5">
                                       <span className="text-sm text-slate-600 dark:text-slate-400">Contribution Activity</span>
                                       <span className={`text-xs font-bold uppercase tracking-wider px-2 py-0.5 rounded border ${
                                         app.matchBreakdown.contributionActivity === 'High' ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20' : 
@@ -933,7 +941,7 @@ const RecruiterApplicantsPage = () => {
             
             {/* Pagination Controls */}
             {!loading && !error && applicants.length > 0 && totalPages > 1 && (
-              <div className="flex items-center justify-between bg-slate-50 dark:bg-slate-900/40 border border-white/5 rounded-2xl p-4 mt-6">
+              <div className="flex items-center justify-between bg-slate-50 dark:bg-slate-900/40 border border-gray-100 dark:border-white/5 rounded-2xl p-4 mt-6">
                 <div className="text-sm text-slate-600 dark:text-slate-400 font-medium">
                   Showing <span className="text-slate-900 dark:text-white">{(page - 1) * 20 + 1}</span> to <span className="text-slate-900 dark:text-white">{Math.min(page * 20, totalCount)}</span> of <span className="text-slate-900 dark:text-white">{totalCount}</span> candidates
                 </div>

--- a/client/src/modules/recruiter-jobs/pages/RecruiterApplicantsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterApplicantsPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { 
   Users, 
@@ -288,31 +288,24 @@ const RecruiterApplicantsPage = () => {
     careerReadiness !== '';
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-[#020617] text-slate-900 dark:text-white flex flex-col">
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col">
       <Navbar />
 
-      <div className="flex-1 pt-24 pb-16 px-4 sm:px-6 mx-auto max-w-7xl w-full space-y-8">
-        {/* Header */}
-        <div className="flex flex-col md:flex-row md:items-center justify-between gap-6">
-          <div className="space-y-2">
-            <button 
-              onClick={() => navigate('/recruiter/jobs')}
-              className="flex items-center gap-2 text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white transition-colors text-sm mb-4"
+      <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
+        <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+          <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+          <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+          <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
+        </div>
+
+        <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6">
+          <div className="py-6 flex justify-between items-center w-full">
+            <Link 
+              to="/recruiter/jobs" 
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
             >
               <ArrowLeft size={16} /> Back to Jobs
-            </button>
-            <h1 className="text-3xl sm:text-4xl font-black tracking-tight text-gray-900 dark:text-white">
-              Applicants for <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 via-indigo-400 to-purple-400">{job?.title || 'Loading...'}</span>
-            </h1>
-            <div className="flex items-center gap-4 text-gray-500 dark:text-slate-400 text-sm">
-              <span className="flex items-center gap-1.5">
-                <Users size={16} /> {applicants.length} Matching Candidate{applicants.length !== 1 ? 's' : ''}
-              </span>
-              <span className="flex items-center gap-1.5 uppercase tracking-wider text-[10px] font-bold bg-gray-100 dark:bg-white/5 px-2 py-0.5 rounded border border-gray-200 dark:border-white/5">
-                Job ID: {jobId.slice(-6)}
-              </span>
-            </div>
-          </div>
+            </Link>
           
           <div className="relative z-20">
             <button
@@ -345,8 +338,31 @@ const RecruiterApplicantsPage = () => {
           </div>
         </div>
 
+        <div className="text-center space-y-4 mb-6 relative">
+          <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+            <Sparkles size={12} className="text-purple-500" /> APPLICANT TRACKING
+          </div>
+          
+          <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+            <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Job</span> Applicants
+          </h1>
+          
+          <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
+            Reviewing applicants for <span className="text-indigo-600 dark:text-indigo-400 font-bold">{job?.title || 'Loading...'}</span>
+          </p>
+          
+          <div className="flex items-center justify-center gap-4 text-gray-500 dark:text-slate-400 text-sm mt-2">
+            <span className="flex items-center gap-1.5">
+              <Users size={16} /> {applicants.length} Matching Candidate{applicants.length !== 1 ? 's' : ''}
+            </span>
+            <span className="flex items-center gap-1.5 uppercase tracking-wider text-[10px] font-bold bg-white dark:bg-slate-900/40 px-2 py-0.5 rounded border border-gray-200 dark:border-white/5">
+              Job ID: {jobId.slice(-6)}
+            </span>
+          </div>
+        </div>
+
         {/* AI-Powered Filter Chips Presets */}
-        <div className="space-y-3 bg-white dark:bg-slate-900/20 border border-gray-200 dark:border-white/5 rounded-2xl p-4">
+        <div className="space-y-3 bg-white dark:bg-slate-900/40 border border-gray-200 dark:border-white/5 rounded-3xl p-4 shadow-sm">
           <div className="flex items-center gap-2 text-xs font-bold text-gray-500 dark:text-slate-400 uppercase tracking-widest">
             <Sparkles size={14} className="text-blue-400" />
             AI Intelligence Presets
@@ -947,6 +963,7 @@ const RecruiterApplicantsPage = () => {
           </div>
         </div>
       </div>
+      </main>
 
       <StatusUpdateModal 
         isOpen={isModalOpen}

--- a/client/src/modules/recruiter-jobs/pages/RecruiterInsightsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterInsightsPage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
-import { ArrowLeft, Search, Filter, TrendingUp, Users, Award, Briefcase } from "lucide-react";
+import { ArrowLeft, Search, Filter, TrendingUp, Users, Award, Briefcase, Sparkles } from "lucide-react";
 import Navbar from "../../../shared/components/Navbar";
 import Button from "../../../shared/components/Button";
 import Input from "../../../shared/components/Input";
@@ -115,32 +115,51 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
     : 0;
 
   return (
-    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] p-3 sm:p-5 pt-20 sm:pt-28 text-slate-100">
+    <main className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col">
       <Navbar />
 
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 py-8">
-        <div className="flex flex-col gap-4">
-          <button
-            type="button"
-            onClick={() => navigate("/recruiter/jobs")}
-            className="inline-flex items-center gap-2 text-sm text-slate-400 hover:text-slate-200 transition-colors"
-          >
-            <ArrowLeft size={16} />
-            Back to Jobs
-          </button>
-
-          <div className="flex flex-col gap-3">
-            <h1 className="text-3xl font-bold text-white">
-              Recruiter Insights
-            </h1>
-            <p className="text-slate-400 max-w-3xl">
-              Ranked candidates for {job?.title || "this job posting"}.
-            </p>
-          </div>
+      <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
+        <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+          <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+          <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+          <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
         </div>
 
+        <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6">
+          <div className="py-6">
+            <button
+              type="button"
+              onClick={() => navigate("/recruiter/jobs")}
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
+            >
+              <ArrowLeft size={16} />
+              Back to Jobs
+            </button>
+          </div>
+
+          <div className="text-center space-y-4 mb-6 relative">
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <Briefcase className="w-6 h-6 text-purple-600" />
+            </div>
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <Award className="w-6 h-6 text-emerald-600" />
+            </div>
+
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-purple-500" /> CANDIDATE MATCHING
+            </div>
+            
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Recruiter</span> Insights
+            </h1>
+            
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
+              Ranked candidates for <span className="text-indigo-600 dark:text-indigo-400 font-bold">{job?.title || "this job posting"}</span>.
+            </p>
+          </div>
+
         {loading ? (
-          <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-6 shadow-lg shadow-black/10">
+          <div className="rounded-3xl border border-gray-100 dark:border-white/5 bg-white dark:bg-[#121214] p-6 shadow-sm">
             <LoadingState message="Loading ranked candidates..." />
           </div>
         ) : error ? (
@@ -163,7 +182,7 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
         ) : (
           <>
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-              <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-5 shadow-lg shadow-black/10">
+              <div className="rounded-3xl border border-gray-100 dark:border-white/5 bg-white dark:bg-[#121214] p-5 shadow-sm">
                 <div className="flex items-center justify-between gap-4">
                   <div>
                     <p className="text-xs uppercase tracking-widest text-slate-500">Total Candidates</p>
@@ -175,7 +194,7 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
                 </div>
               </div>
 
-              <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-5 shadow-lg shadow-black/10">
+              <div className="rounded-3xl border border-gray-100 dark:border-white/5 bg-white dark:bg-[#121214] p-5 shadow-sm">
                 <div className="flex items-center justify-between gap-4">
                   <div>
                     <p className="text-xs uppercase tracking-widest text-slate-500">Average Score</p>
@@ -187,7 +206,7 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
                 </div>
               </div>
 
-              <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-5 shadow-lg shadow-black/10">
+              <div className="rounded-3xl border border-gray-100 dark:border-white/5 bg-white dark:bg-[#121214] p-5 shadow-sm">
                 <div className="flex items-center justify-between gap-4">
                   <div>
                     <p className="text-xs uppercase tracking-widest text-slate-500">Top Ranked</p>
@@ -202,7 +221,7 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
 
             <form
               onSubmit={handleApplyFilters}
-              className="flex flex-col gap-4 rounded-xl border border-white/10 bg-slate-900/60 p-4 shadow-lg shadow-black/10 lg:flex-row lg:flex-wrap lg:items-end"
+              className="flex flex-col gap-4 rounded-3xl border border-gray-100 dark:border-white/5 bg-white dark:bg-[#121214] p-4 shadow-sm lg:flex-row lg:flex-wrap lg:items-end"
             >
               <div className="relative w-full lg:max-w-sm">
                 <Input
@@ -301,7 +320,7 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
                 {candidates.map((candidate) => (
                   <article
                     key={candidate._id}
-                    className="rounded-2xl border border-white/10 bg-slate-900/60 p-5 shadow-lg shadow-black/10"
+                    className="rounded-3xl border border-gray-100 dark:border-white/5 bg-white dark:bg-[#121214] p-5 shadow-sm"
                   >
                     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                       <div className="space-y-3">
@@ -391,6 +410,7 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
           </>
         )}
       </div>
+      </main>
     </main>
   );
 };

--- a/client/src/modules/recruiter-jobs/pages/RecruiterInsightsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterInsightsPage.jsx
@@ -163,7 +163,7 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
             <LoadingState message="Loading ranked candidates..." />
           </div>
         ) : error ? (
-          <ErrorState message={error} onRetry={() => fetchInsights(1)} />
+          <ErrorState description={error} onRetry={() => fetchInsights(1)} />
         ) : !job ? (
           <EmptyState
             icon={<Users size={48} className="text-slate-600" />}
@@ -294,7 +294,7 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
                 <Button
                   type="button"
                   variant="secondary"
-                  className="border border-slate-700 bg-slate-800/80 text-slate-200 hover:bg-slate-700"
+                  className="border border-slate-700 bg-slate-800/80 text-slate-500 dark:text-slate-200 hover:bg-slate-700"
                   onClick={() => {
                     setSearchTerm("");
                     setStatusFilter("all");
@@ -336,7 +336,7 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
                               {candidate.applicant?.email || "No email available"}
                             </p>
                           </div>
-                          <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-slate-300">
+                          <span className="rounded-full border border-white/10 bg-gray-50 dark:bg-white/5 px-3 py-1 text-xs font-semibold text-slate-600 dark:text-slate-300">
                             {candidate.status}
                           </span>
                         </div>
@@ -351,7 +351,7 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
                             </span>
                           )}
                           {candidate.resume?.fileName && (
-                            <span className="rounded-full bg-slate-500/10 px-3 py-1 text-slate-300">
+                            <span className="rounded-full bg-slate-500/10 px-3 py-1 text-slate-600 dark:text-slate-300">
                               Resume attached
                             </span>
                           )}
@@ -360,7 +360,7 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
                         <div className="grid gap-3 sm:grid-cols-2">
                           <div className="rounded-xl border border-white/10 bg-slate-950/30 p-3">
                             <p className="text-xs uppercase tracking-widest text-slate-500">Insights</p>
-                            <ul className="mt-2 space-y-1 text-sm text-slate-300">
+                            <ul className="mt-2 space-y-1 text-sm text-slate-600 dark:text-slate-300">
                               {(candidate.aiRecruiterInsights || []).slice(0, 3).map((item, index) => (
                                 <li key={index}>• {item}</li>
                               ))}
@@ -372,7 +372,7 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
 
                           <div className="rounded-xl border border-white/10 bg-slate-950/30 p-3">
                             <p className="text-xs uppercase tracking-widest text-slate-500">Weaknesses</p>
-                            <ul className="mt-2 space-y-1 text-sm text-slate-300">
+                            <ul className="mt-2 space-y-1 text-sm text-slate-600 dark:text-slate-300">
                               {(candidate.aiWeaknesses || []).slice(0, 3).map((item, index) => (
                                 <li key={index}>• {item}</li>
                               ))}
@@ -384,13 +384,13 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
                         </div>
                       </div>
 
-                      <div className="min-w-[180px] rounded-2xl border border-white/10 bg-slate-950/40 p-4 text-center">
+                      <div className="min-w-[180px] rounded-2xl border border-white/10 bg-gray-50 dark:bg-slate-950/40 p-4 text-center">
                         <p className="text-xs uppercase tracking-widest text-slate-500">Candidate Score</p>
                         <p className="mt-3 text-4xl font-black text-white">
                           {candidate.aiMatchScore != null ? candidate.aiMatchScore : 0}
                         </p>
                         <p className="mt-1 text-xs text-slate-400">out of 100</p>
-                        <div className="mt-4 rounded-xl bg-slate-800/70 px-3 py-2 text-xs text-slate-300">
+                        <div className="mt-4 rounded-xl bg-slate-800/70 px-3 py-2 text-xs text-slate-600 dark:text-slate-300">
                           Applied {candidate.createdAt ? new Date(candidate.createdAt).toLocaleDateString() : "recently"}
                         </div>
                       </div>

--- a/client/src/modules/recruiter-jobs/pages/RecruiterInsightsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterInsightsPage.jsx
@@ -115,7 +115,7 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
     : 0;
 
   return (
-    <main className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col">
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col">
       <Navbar />
 
       <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
@@ -411,7 +411,8 @@ const RecruiterInsightsPage = ({ jobId: propJobId }) => {
         )}
       </div>
       </main>
-    </main>
+      <Footer />
+    </div>
   );
 };
 

--- a/client/src/modules/recruiter-jobs/pages/RecruiterJobsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterJobsPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useSelector } from "react-redux";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
-import { Plus, Briefcase, Search, ArrowLeft } from "lucide-react";
+import { Plus, Briefcase, Search, ArrowLeft, Target, Sparkles } from "lucide-react";
 import Navbar from "../../../shared/components/Navbar";
 import Footer from "../../../shared/components/Footer";
 
@@ -174,38 +174,58 @@ const RecruiterJobsPage = () => {
       {insightsJobId ? (
         <RecruiterInsightsPage jobId={insightsJobId} />
       ) : (
-        <div className="min-h-screen bg-slate-50 dark:bg-[#020617] text-slate-900 dark:text-white flex flex-col">
+        <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col">
       <Navbar />
 
-      <div className="flex-1 w-full mx-auto max-w-5xl flex flex-col gap-6 pt-24 pb-16 px-4 sm:px-6">
-        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
-          <div>
+      <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
+        <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+          <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+          <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+          <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
+        </div>
+
+        <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6">
+          <div className="py-6 flex justify-between items-center">
             <Link 
               to="/dashboard" 
-              className="inline-flex items-center gap-2 text-sm text-blue-500 hover:text-blue-400 mb-4 transition-colors"
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
             >
               <ArrowLeft size={16} />
               Back to Dashboard
             </Link>
-            <h1 className="text-3xl font-bold text-slate-900 dark:text-white">
-              Manage Job Postings
+            <Link to="/recruiter/jobs/new">
+              <Button
+                variant="primary"
+                leftIcon={<Plus size={18} />}
+                className="bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 border-none shadow-[0_8px_20px_rgb(59,130,246,0.3)]"
+              >
+                Post New Job
+              </Button>
+            </Link>
+          </div>
+
+          <div className="text-center space-y-4 mb-6 relative">
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <Briefcase className="w-6 h-6 text-purple-600" />
+            </div>
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <Target className="w-6 h-6 text-emerald-600" />
+            </div>
+
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-purple-500" /> RECRUITMENT COMMAND CENTER
+            </div>
+            
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Manage</span> Job Postings
             </h1>
-            <p className="text-slate-600 dark:text-slate-400 mt-1">
+            
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
               View and manage your active job listings and recommendations.
             </p>
           </div>
-          <Link to="/recruiter/jobs/new">
-            <Button
-              variant="primary"
-              leftIcon={<Plus size={18} />}
-              className="bg-blue-600 hover:bg-blue-500"
-            >
-              Post New Job
-            </Button>
-          </Link>
-        </div>
 
-        <div className="flex flex-col gap-4 rounded-xl border border-slate-200 dark:border-white/10 bg-white dark:bg-slate-900/60 p-4 shadow-lg shadow-black/10 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-4 rounded-3xl border border-gray-100 dark:border-white/5 bg-white dark:bg-[#121214] p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
           <div className="relative w-full sm:max-w-md">
             <Input
               id="search-jobs"
@@ -300,6 +320,7 @@ const RecruiterJobsPage = () => {
           />
         )}
       </div>
+      </main>
           <Footer />
     </div>
       )}

--- a/client/src/modules/recruiter-jobs/pages/RecruiterJobsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterJobsPage.jsx
@@ -270,7 +270,7 @@ const RecruiterJobsPage = () => {
             ))}
           </div>
         ) : error ? (
-          <ErrorState message={error} onRetry={fetchJobs} />
+          <ErrorState description={error} onRetry={fetchJobs} />
         ) : filteredJobs.length === 0 ? (
           <EmptyState
             icon={<Briefcase size={48} className="text-slate-600" />}

--- a/client/src/modules/recruiter-jobs/pages/RecruiterJobsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterJobsPage.jsx
@@ -252,7 +252,7 @@ const RecruiterJobsPage = () => {
                   onClick={() => setStatusFilter(filter.value)}
                   className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
                     isActive
-                      ? "border-blue-400 bg-blue-500/20 text-blue-100"
+                      ? "border-blue-400 bg-blue-50 dark:bg-blue-500/20 text-blue-600 dark:text-blue-100"
                       : "border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800/80 text-slate-700 dark:text-slate-300 hover:border-slate-400 dark:hover:border-slate-500 hover:bg-slate-50 dark:hover:bg-slate-800"
                   }`}
                 >

--- a/client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx
@@ -489,7 +489,7 @@ const TalentFinderPage = () => {
                 <LoadingState message="Searching candidates..." />
               </div>
             ) : error ? (
-              <ErrorState message={error} onRetry={fetchCandidatesDirectory} />
+              <ErrorState description={error} onRetry={fetchCandidatesDirectory} />
             ) : candidates.length === 0 ? (
               <EmptyState
                 icon={<User size={52} className="text-gray-300 dark:text-slate-700 animate-pulse" />}

--- a/client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx
@@ -381,7 +381,7 @@ const TalentFinderPage = () => {
               <select
                 value={specialization}
                 onChange={(e) => { setSpecialization(e.target.value); setPage(1); }}
-                className="w-full bg-gray-50 dark:bg-slate-950 border border-gray-300 dark:border-white/10 rounded-xl px-3 py-2.5 text-sm font-semibold text-gray-700 dark:text-slate-200 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 outline-none transition-all cursor-pointer"
+                className="w-full bg-gray-50 dark:bg-slate-950/60 border border-gray-200 dark:border-white/10 rounded-xl px-3 py-2.5 text-sm font-semibold text-gray-800 dark:text-slate-200 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/20 outline-none transition-all cursor-pointer shadow-inner"
               >
                 <option value="" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">All Fields</option>
                 <option value="frontend" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">Frontend Engineer</option>
@@ -425,7 +425,7 @@ const TalentFinderPage = () => {
                   placeholder="e.g. React, Node, AWS"
                   value={skillsFilter}
                   onChange={(e) => { setSkillsFilter(e.target.value); setPage(1); }}
-                  className="w-full bg-gray-50 dark:bg-slate-950/60 border border-gray-300 dark:border-white/10 rounded-xl pl-10 pr-3 py-2.5 text-sm text-gray-800 dark:text-slate-200 focus:border-blue-500/50 outline-none transition-all shadow-inner"
+                  className="w-full bg-gray-50 dark:bg-slate-950/60 border border-gray-200 dark:border-white/10 rounded-xl pl-10 pr-3 py-2.5 text-sm text-gray-800 dark:text-slate-200 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/20 outline-none transition-all shadow-inner"
                 />
               </div>
               <p className="text-[10px] text-gray-400 dark:text-slate-500 italic px-1">Updates automatically as you type.</p>
@@ -444,7 +444,7 @@ const TalentFinderPage = () => {
                   maxLength={4}
                   value={graduationYear}
                   onChange={(e) => { setGraduationYear(e.target.value.replace(/\D/g, '')); setPage(1); }}
-                  className="w-full bg-gray-50 dark:bg-slate-950/60 border border-gray-300 dark:border-white/10 rounded-xl pl-10 pr-3 py-2.5 text-sm text-gray-800 dark:text-slate-200 focus:border-blue-500/50 outline-none transition-all shadow-inner"
+                  className="w-full bg-gray-50 dark:bg-slate-950/60 border border-gray-200 dark:border-white/10 rounded-xl pl-10 pr-3 py-2.5 text-sm text-gray-800 dark:text-slate-200 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/20 outline-none transition-all shadow-inner"
                 />
               </div>
             </div>
@@ -462,7 +462,7 @@ const TalentFinderPage = () => {
                   placeholder="Search candidates by name, email, or keywords..."
                   value={searchQuery}
                   onChange={(e) => { setSearchQuery(e.target.value); setPage(1); }}
-                  className="w-full bg-gray-50 dark:bg-slate-950 border border-gray-300 dark:border-white/10 rounded-xl pl-12 pr-4 py-3 text-sm font-semibold text-gray-800 dark:text-slate-200 focus:border-blue-500/50 outline-none transition-all"
+                  className="w-full bg-gray-50 dark:bg-slate-950 border border-gray-200 dark:border-white/10 rounded-xl pl-12 pr-4 py-3 text-sm font-semibold text-gray-800 dark:text-slate-200 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/20 outline-none transition-all shadow-inner"
                 />
               </div>
               <div className="hidden sm:flex items-center px-4 bg-gray-100 dark:bg-slate-950 border border-gray-200 dark:border-white/10 text-xs font-bold text-gray-500 dark:text-slate-400 rounded-xl select-none">

--- a/client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx
@@ -863,6 +863,7 @@ const TalentFinderPage = () => {
             )}
           </div>
         </div>
+        </div>
       </main>
       <Footer />
     </div>

--- a/client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx
@@ -282,34 +282,53 @@ const TalentFinderPage = () => {
   // PRESENTATION LAYER (MARKDOWN VIEW LAYOUT)
   // ============================================================================
   return (
-    <main className="min-h-screen bg-gray-50 dark:bg-[radial-gradient(circle_at_top_left,#0f172a,#020617)] p-4 sm:p-6 pt-24 sm:pt-32 text-gray-900 dark:text-slate-100 transition-colors duration-200">
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col">
       <Navbar />
 
-      <div className="mx-auto max-w-7xl w-full space-y-8">
-        
-        {/* Module Header Segment */}
-        <div className="flex flex-col md:flex-row md:items-center justify-between gap-6 bg-white dark:bg-slate-900/20 p-6 rounded-3xl border border-gray-200/60 dark:border-white/5 shadow-sm">
-          <div className="space-y-2">
+      <main className="flex-grow flex flex-col items-center justify-start px-4 sm:px-6 lg:px-8 pb-12 animate-fade-in relative overflow-hidden w-full">
+        <div className="absolute top-0 left-0 w-full h-full overflow-hidden pointer-events-none z-0">
+          <div className="absolute -top-[10%] -left-[5%] w-[40%] h-[40%] rounded-full bg-blue-100/40 dark:bg-blue-900/10 blur-[120px]" />
+          <div className="absolute top-[20%] -right-[5%] w-[35%] h-[35%] rounded-full bg-purple-100/40 dark:bg-purple-900/10 blur-[100px]" />
+          <div className="absolute top-[5%] right-[20%] w-[35%] h-[35%] rounded-full bg-teal-50/40 dark:bg-teal-900/10 blur-[100px]" />
+        </div>
+
+        <div className="w-full max-w-[1200px] relative z-10 flex flex-col gap-6">
+          <div className="py-6 flex justify-between items-center">
             <Link 
               to="/dashboard" 
-              className="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:text-blue-500 dark:hover:text-blue-300 mb-1 transition-colors"
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
             >
               <ArrowLeft size={16} />
-              Back to Recruiter Central
+              Back to Dashboard
             </Link>
-            <h1 className="text-3xl sm:text-4xl font-black tracking-tight text-gray-900 dark:text-white">
-              Talent <span className="text-gradient bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 bg-clip-text text-transparent">Finder</span>
+          </div>
+
+          <div className="text-center space-y-4 mb-6 relative">
+            <div className="hidden md:flex absolute top-4 left-4 xl:left-8 w-14 h-14 bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 rounded-2xl items-center justify-center shadow-sm transform -rotate-3 hover:rotate-0 transition-transform">
+               <User className="w-6 h-6 text-purple-600" />
+            </div>
+            <div className="hidden md:flex absolute top-8 right-4 xl:right-8 w-14 h-14 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-100 dark:border-emerald-500/20 rounded-2xl items-center justify-center shadow-sm transform rotate-3 hover:rotate-0 transition-transform">
+               <Search className="w-6 h-6 text-emerald-600" />
+            </div>
+
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
+              <Sparkles size={12} className="text-purple-500" /> AI TALENT DISCOVERY
+            </div>
+            
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+              <span className="bg-gradient-to-r from-blue-600 via-purple-500 to-teal-400 bg-clip-text text-transparent">Talent</span> Finder
             </h1>
-            <p className="text-gray-500 dark:text-slate-400 text-sm max-w-2xl leading-relaxed">
-              Query the absolute candidate directory database with dynamic debouncing optimization layers. Run semantic neural intelligence match pipelines directly against live openings.
+            
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
+              Query the global candidate registry and run neural matching against your open roles.
             </p>
           </div>
-          
+
           {/* Active Target Job Dropdown Controller Card */}
-          <div className="bg-gray-100 dark:bg-slate-900/60 border border-gray-200 dark:border-white/5 p-4 rounded-2xl flex flex-col gap-2 min-w-[320px] shadow-sm">
-            <span className="text-xs uppercase font-extrabold tracking-widest text-slate-500 dark:text-slate-400 flex items-center gap-1.5">
+          <div className="bg-white dark:bg-[#121214] border border-gray-100 dark:border-white/5 p-4 rounded-3xl flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 shadow-sm w-full mx-auto">
+            <span className="text-xs uppercase font-extrabold tracking-widest text-slate-500 dark:text-slate-400 flex items-center gap-1.5 shrink-0">
               <Sparkles size={12} className="text-purple-500 dark:text-purple-400 animate-pulse" />
-              Evaluation Benchmark Node
+              Evaluation Benchmark
             </span>
             {jobsLoading ? (
               <div className="flex items-center gap-2 text-sm text-slate-400 py-1.5">
@@ -326,7 +345,7 @@ const TalentFinderPage = () => {
                   setSelectedJobId(e.target.value);
                   setMatchResultMap({}); // Purge score map arrays to prevent stale index cross-matching
                 }}
-                className="w-full bg-white dark:bg-slate-950 border border-gray-300 dark:border-white/10 rounded-xl px-3 py-2.5 text-sm font-bold text-gray-800 dark:text-slate-200 shadow-inner outline-none focus:ring-2 focus:ring-blue-500/50 transition-all"
+                className="w-full sm:max-w-md bg-gray-50 dark:bg-slate-900 border border-gray-200 dark:border-white/10 rounded-xl px-3 py-2.5 text-sm font-bold text-gray-800 dark:text-slate-200 shadow-inner outline-none focus:ring-2 focus:ring-blue-500/50 transition-all"
               >
                 {jobs.map(job => (
                   <option key={job._id} value={job._id} className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">
@@ -336,10 +355,9 @@ const TalentFinderPage = () => {
               </select>
             )}
           </div>
-        </div>
 
-        {/* Workspace Dual-Column Core UI Layout Grid */}
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-8 items-start">
+          {/* Workspace Dual-Column Core UI Layout Grid */}
+          <div className="grid grid-cols-1 lg:grid-cols-4 gap-8 items-start mt-4">
           
           {/* Sidebar Panel: Advanced Filtering Parameters Controls */}
           <div className="lg:col-span-1 bg-white dark:bg-slate-900/40 border border-gray-200 dark:border-white/5 backdrop-blur-md p-6 rounded-3xl space-y-6 shadow-xl relative group">
@@ -845,9 +863,9 @@ const TalentFinderPage = () => {
             )}
           </div>
         </div>
-      </div>
+      </main>
       <Footer />
-    </main>
+    </div>
   );
 };
 

--- a/client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx
@@ -223,7 +223,7 @@ const TalentFinderPage = () => {
   const handleCalculateMatch = async (event, candidateId) => {
     event.stopPropagation();
     if (!selectedJobId) {
-      alert("Please designate an active job posting workspace matrix to run matching evaluations against.");
+      alert("Please select a target job to match this candidate against.");
       return;
     }
 
@@ -235,7 +235,7 @@ const TalentFinderPage = () => {
       // Automatically toggle element frame visibility matrix to feature the analysis layout
       setExpandedCardId(candidateId);
     } catch (err) {
-      alert(err.message || "AI Matching execution matrix crashed. Please try parsing again.");
+      alert(err.message || "Match analysis failed. Please try again.");
     } finally {
       setMatchLoadingMap(prevMap => ({ ...prevMap, [candidateId]: false }));
     }
@@ -248,7 +248,7 @@ const TalentFinderPage = () => {
   const handleInviteCandidate = async (event, candidateId) => {
     event.stopPropagation();
     if (!selectedJobId) {
-      alert("Please declare a valid active job profile to issue an invitation link layout.");
+      alert("Please select an active job to invite this candidate to.");
       return;
     }
 
@@ -257,7 +257,7 @@ const TalentFinderPage = () => {
       await inviteCandidate(candidateId, selectedJobId, token);
       setInvitedMap(prevMap => ({ ...prevMap, [candidateId]: true }));
     } catch (err) {
-      alert(err.message || "Failed to finalize socket message transaction link.");
+      alert(err.message || "Failed to send invitation.");
     } finally {
       setInviteLoadingMap(prevMap => ({ ...prevMap, [candidateId]: false }));
     }
@@ -312,7 +312,7 @@ const TalentFinderPage = () => {
             </div>
 
             <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-purple-50 dark:bg-purple-500/10 border border-purple-100 dark:border-purple-500/20 shadow-sm text-[11px] font-bold text-purple-600 dark:text-purple-400 mx-auto tracking-wide uppercase">
-              <Sparkles size={12} className="text-purple-500" /> AI TALENT DISCOVERY
+              <Sparkles size={12} className="text-purple-500" /> TALENT SEARCH
             </div>
             
             <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
@@ -320,7 +320,7 @@ const TalentFinderPage = () => {
             </h1>
             
             <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
-              Query the global candidate registry and run neural matching against your open roles.
+              Search the candidate database and find the best matches for your open roles.
             </p>
           </div>
 
@@ -328,7 +328,7 @@ const TalentFinderPage = () => {
           <div className="bg-white dark:bg-[#121214] border border-gray-100 dark:border-white/5 p-4 rounded-3xl flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 shadow-sm w-full mx-auto">
             <span className="text-xs uppercase font-extrabold tracking-widest text-slate-500 dark:text-slate-400 flex items-center gap-1.5 shrink-0">
               <Sparkles size={12} className="text-purple-500 dark:text-purple-400 animate-pulse" />
-              Evaluation Benchmark
+              Select Target Job
             </span>
             {jobsLoading ? (
               <div className="flex items-center gap-2 text-sm text-slate-400 py-1.5">
@@ -359,11 +359,11 @@ const TalentFinderPage = () => {
           {/* Workspace Dual-Column Core UI Layout Grid */}
           <div className="grid grid-cols-1 lg:grid-cols-4 gap-8 items-start mt-4">
           
-          {/* Sidebar Panel: Advanced Filtering Parameters Controls */}
+          {/* Sidebar Panel: Advanced Search Filters Controls */}
           <div className="lg:col-span-1 bg-white dark:bg-slate-900/40 border border-gray-200 dark:border-white/5 backdrop-blur-md p-6 rounded-3xl space-y-6 shadow-xl relative group">
             <div className="flex items-center justify-between pb-4 border-b border-gray-100 dark:border-white/5">
               <span className="font-extrabold tracking-tight text-gray-900 dark:text-white flex items-center gap-2 text-md">
-                <Sliders size={16} className="text-blue-500" /> Filtering Parameters
+                <Sliders size={16} className="text-blue-500" /> Search Filters
               </span>
               <button 
                 onClick={handleResetFilters}
@@ -376,20 +376,20 @@ const TalentFinderPage = () => {
             {/* Parameter Node: Technical Specialization Tag Dropdown */}
             <div className="space-y-2">
               <label className="block text-xs uppercase font-black tracking-wider text-gray-400 dark:text-slate-500">
-                Core Engineering Vector
+                Specialization
               </label>
               <select
                 value={specialization}
                 onChange={(e) => { setSpecialization(e.target.value); setPage(1); }}
                 className="w-full bg-gray-50 dark:bg-slate-950 border border-gray-300 dark:border-white/10 rounded-xl px-3 py-2.5 text-sm font-semibold text-gray-700 dark:text-slate-200 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 outline-none transition-all cursor-pointer"
               >
-                <option value="" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">All Fields Cataloged</option>
-                <option value="frontend" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">Frontend Architects</option>
-                <option value="backend" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">Backend System Specialists</option>
-                <option value="fullstack" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">Full-Stack Operators</option>
-                <option value="devops" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">Cloud Infrastructure Engineers</option>
-                <option value="aiml" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">AI / Deep Learning Specialists</option>
-                <option value="database" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">Database Architects</option>
+                <option value="" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">All Fields</option>
+                <option value="frontend" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">Frontend Engineer</option>
+                <option value="backend" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">Backend Engineer</option>
+                <option value="fullstack" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">Full-Stack Engineer</option>
+                <option value="devops" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">DevOps / Cloud Engineer</option>
+                <option value="aiml" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">AI / ML Engineer</option>
+                <option value="database" className="bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">Database Administrator</option>
               </select>
             </div>
 
@@ -397,7 +397,7 @@ const TalentFinderPage = () => {
             <div className="space-y-3 bg-gray-50/50 dark:bg-slate-950/20 p-3 rounded-2xl border border-gray-100 dark:border-white/5 shadow-inner">
               <div className="flex justify-between items-center">
                 <label className="block text-xs uppercase font-black tracking-wider text-gray-400 dark:text-slate-500">
-                  Minimum ATS Threshold
+                  Minimum Match Score
                 </label>
                 <span className="text-xs font-black px-2 py-0.5 rounded-md bg-blue-100 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-200 dark:border-blue-500/20">
                   {minAtsScore || 'All Base'}%
@@ -416,7 +416,7 @@ const TalentFinderPage = () => {
             {/* Parameter Node: Skills Keyword Buffer Field */}
             <div className="space-y-2">
               <label className="block text-xs uppercase font-black tracking-wider text-gray-400 dark:text-slate-500">
-                Skills Stack Requirements
+                Required Skills
               </label>
               <div className="relative">
                 <Code className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400" size={14} />
@@ -428,13 +428,13 @@ const TalentFinderPage = () => {
                   className="w-full bg-gray-50 dark:bg-slate-950/60 border border-gray-300 dark:border-white/10 rounded-xl pl-10 pr-3 py-2.5 text-sm text-gray-800 dark:text-slate-200 focus:border-blue-500/50 outline-none transition-all shadow-inner"
                 />
               </div>
-              <p className="text-[10px] text-gray-400 dark:text-slate-500 italic px-1">Monitored via 500ms core debounce loop.</p>
+              <p className="text-[10px] text-gray-400 dark:text-slate-500 italic px-1">Updates automatically as you type.</p>
             </div>
 
             {/* Parameter Node: Graduation Metric Filter */}
             <div className="space-y-2">
               <label className="block text-xs uppercase font-black tracking-wider text-gray-400 dark:text-slate-500">
-                Target Graduation Cycle
+                Graduation Year
               </label>
               <div className="relative">
                 <Clock className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400" size={14} />
@@ -459,14 +459,14 @@ const TalentFinderPage = () => {
                 <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400" size={16} />
                 <input
                   type="text"
-                  placeholder="Query global talent registry index via contextual tokens..."
+                  placeholder="Search candidates by name, email, or keywords..."
                   value={searchQuery}
                   onChange={(e) => { setSearchQuery(e.target.value); setPage(1); }}
                   className="w-full bg-gray-50 dark:bg-slate-950 border border-gray-300 dark:border-white/10 rounded-xl pl-12 pr-4 py-3 text-sm font-semibold text-gray-800 dark:text-slate-200 focus:border-blue-500/50 outline-none transition-all"
                 />
               </div>
               <div className="hidden sm:flex items-center px-4 bg-gray-100 dark:bg-slate-950 border border-gray-200 dark:border-white/10 text-xs font-bold text-gray-500 dark:text-slate-400 rounded-xl select-none">
-                Auto-Sync Active
+                Live Search
               </div>
             </div>
 
@@ -474,11 +474,11 @@ const TalentFinderPage = () => {
             <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-3 bg-white dark:bg-slate-900/10 border border-gray-200 dark:border-white/5 rounded-2xl px-5 py-4 text-sm font-bold text-gray-600 dark:text-slate-300 shadow-sm">
               <span className="flex items-center gap-2">
                 <SlidersHorizontal size={14} className="text-gray-400" />
-                Discovery Engine returned <span className="text-blue-600 dark:text-blue-400 px-1.5 py-0.5 rounded-md bg-blue-50 dark:bg-blue-500/10 border border-blue-100 dark:border-blue-500/20">{totalCount}</span> validated files
+                Found <span className="text-blue-600 dark:text-blue-400 px-1.5 py-0.5 rounded-md bg-blue-50 dark:bg-blue-500/10 border border-blue-100 dark:border-blue-500/20">{totalCount}</span> candidates
               </span>
               {selectedJob && (
                 <span className="text-xs font-extrabold text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-500/10 border border-indigo-100 dark:border-indigo-500/20 px-3 py-1 rounded-xl flex items-center gap-1.5 self-start sm:self-auto">
-                  <Bookmark size={12} /> Target Context: {selectedJob.title}
+                  <Bookmark size={12} /> Matching for: {selectedJob.title}
                 </span>
               )}
             </div>
@@ -486,15 +486,15 @@ const TalentFinderPage = () => {
             {/* Pipeline State Selector Branch */}
             {loading ? (
               <div className="py-24 bg-white dark:bg-slate-900/10 border border-gray-200 dark:border-white/5 rounded-3xl shadow-inner">
-                <LoadingState message="Querying platform directory index structures..." />
+                <LoadingState message="Searching candidates..." />
               </div>
             ) : error ? (
               <ErrorState message={error} onRetry={fetchCandidatesDirectory} />
             ) : candidates.length === 0 ? (
               <EmptyState
                 icon={<User size={52} className="text-gray-300 dark:text-slate-700 animate-pulse" />}
-                title="No Candidate Clusters Match"
-                description="The search registry index resolved zero instances. Try clearing or relaxing active filter elements."
+                title="No Candidates Found"
+                description="We couldn't find any candidates matching your criteria. Try adjusting your filters."
               />
             ) : (
               <div className="grid grid-cols-1 gap-4">
@@ -581,12 +581,12 @@ const TalentFinderPage = () => {
                                 {isMatchLoading ? (
                                   <>
                                     <Loader2 className="animate-spin" size={12} />
-                                    <span>Processing Matrix...</span>
+                                    <span>Analyzing...</span>
                                   </>
                                 ) : (
                                   <>
                                     <Sparkles size={12} />
-                                    <span>Run AI Evaluator</span>
+                                    <span>Match Candidate</span>
                                   </>
                                 )}
                               </button>
@@ -633,7 +633,7 @@ const TalentFinderPage = () => {
                               {/* Cluster Grid Segment: Educational Timeline Block */}
                               <div className="space-y-2.5">
                                 <h4 className="text-xs font-black text-blue-600 dark:text-blue-400 uppercase tracking-widest flex items-center gap-2">
-                                  <GraduationCap size={14} /> Education Context Log
+                                  <GraduationCap size={14} /> Education History
                                 </h4>
                                 <div className="p-4 bg-white dark:bg-slate-900/60 border border-gray-200 dark:border-white/5 rounded-2xl space-y-3 shadow-inner">
                                   {candidate.education && candidate.education.length > 0 ? (
@@ -645,7 +645,7 @@ const TalentFinderPage = () => {
                                     ))
                                   ) : (
                                     <div className="text-xs text-gray-400 dark:text-slate-500 italic flex items-center gap-1.5">
-                                      <Info size={12} /> No educational registry array block parsed.
+                                      <Info size={12} /> No education details provided.
                                     </div>
                                   )}
                                 </div>
@@ -654,28 +654,28 @@ const TalentFinderPage = () => {
                               {/* Cluster Grid Segment: Project / Practical Trajectory Logs */}
                               <div className="space-y-2.5">
                                 <h4 className="text-xs font-black text-blue-600 dark:text-blue-400 uppercase tracking-widest flex items-center gap-2">
-                                  <Briefcase size={14} /> Direct Profile Snippets
+                                  <Briefcase size={14} /> Experience & Projects
                                 </h4>
                                 <div className="p-4 bg-white dark:bg-slate-900/60 border border-gray-200 dark:border-white/5 rounded-2xl space-y-4 shadow-inner">
                                   <div>
-                                    <h5 className="text-[10px] font-black text-gray-400 dark:text-slate-500 uppercase tracking-wider mb-1.5">Parsed Employment/Experience Path</h5>
+                                    <h5 className="text-[10px] font-black text-gray-400 dark:text-slate-500 uppercase tracking-wider mb-1.5">Work Experience</h5>
                                     {candidate.experience && candidate.experience.length > 0 ? (
                                       <p className="text-sm text-gray-700 dark:text-slate-300 font-medium leading-relaxed">
                                         {candidate.experience.slice(0, 3).join(" | ")}
                                       </p>
                                     ) : (
-                                      <p className="text-xs text-gray-400 dark:text-slate-500 italic flex items-center gap-1.5"><Info size={12} /> No historical timeline parsed.</p>
+                                      <p className="text-xs text-gray-400 dark:text-slate-500 italic flex items-center gap-1.5"><Info size={12} /> No work experience listed.</p>
                                     )}
                                   </div>
 
                                   <div className="border-t border-gray-100 dark:border-white/5 pt-3">
-                                    <h5 className="text-[10px] font-black text-gray-400 dark:text-slate-500 uppercase tracking-wider mb-1.5">Technical Project Deployments</h5>
+                                    <h5 className="text-[10px] font-black text-gray-400 dark:text-slate-500 uppercase tracking-wider mb-1.5">Projects</h5>
                                     {candidate.projects && candidate.projects.length > 0 ? (
                                       <p className="text-sm text-gray-700 dark:text-slate-300 font-medium leading-relaxed">
                                         {candidate.projects.slice(0, 3).join(" | ")}
                                       </p>
                                     ) : (
-                                      <p className="text-xs text-gray-400 dark:text-slate-500 italic flex items-center gap-1.5"><Info size={12} /> No projects registered.</p>
+                                      <p className="text-xs text-gray-400 dark:text-slate-500 italic flex items-center gap-1.5"><Info size={12} /> No projects listed.</p>
                                     )}
                                   </div>
                                 </div>
@@ -710,13 +710,13 @@ const TalentFinderPage = () => {
                                   {/* Section Block: Dimensional Progress Components */}
                                   <div className="space-y-3">
                                     <h4 className="text-xs font-black text-emerald-600 dark:text-emerald-400 uppercase tracking-widest flex items-center gap-2">
-                                      <Sparkles size={14} /> AI Analysis Quantization Matrix
+                                      <Sparkles size={14} /> Match Breakdown
                                     </h4>
                                     
                                     <div className="p-5 bg-white dark:bg-slate-900 border border-gray-200 dark:border-white/5 rounded-2xl space-y-4.5 shadow-sm">
                                       <div>
                                         <div className="flex justify-between items-center mb-1">
-                                          <span className="text-xs font-bold text-gray-500 dark:text-slate-400">ATS Parsing Compatibility</span>
+                                          <span className="text-xs font-bold text-gray-500 dark:text-slate-400">Resume Quality</span>
                                           <span className="text-xs font-black text-gray-900 dark:text-slate-200">{matchResult.matchBreakdown?.atsCompatibility || 0}%</span>
                                         </div>
                                         <div className="w-full bg-gray-100 dark:bg-slate-800 rounded-full h-1.5 shadow-inner">
@@ -726,7 +726,7 @@ const TalentFinderPage = () => {
 
                                       <div>
                                         <div className="flex justify-between items-center mb-1">
-                                          <span className="text-xs font-bold text-gray-500 dark:text-slate-400">Contextual Skill Alignment</span>
+                                          <span className="text-xs font-bold text-gray-500 dark:text-slate-400">Skills Match</span>
                                           <span className="text-xs font-black text-gray-900 dark:text-slate-200">{matchResult.matchBreakdown?.skillMatch || 0}%</span>
                                         </div>
                                         <div className="w-full bg-gray-100 dark:bg-slate-800 rounded-full h-1.5 shadow-inner">
@@ -736,7 +736,7 @@ const TalentFinderPage = () => {
 
                                       <div>
                                         <div className="flex justify-between items-center mb-1">
-                                          <span className="text-xs font-bold text-gray-500 dark:text-slate-400">Project Vector Intensity</span>
+                                          <span className="text-xs font-bold text-gray-500 dark:text-slate-400">Project Experience</span>
                                           <span className="text-xs font-black text-gray-900 dark:text-slate-200">{matchResult.matchBreakdown?.projectStrength || 0}%</span>
                                         </div>
                                         <div className="w-full bg-gray-100 dark:bg-slate-800 rounded-full h-1.5 shadow-inner">
@@ -746,11 +746,11 @@ const TalentFinderPage = () => {
 
                                       <div className="flex justify-between gap-4 pt-3 text-[11px] font-bold border-t border-gray-100 dark:border-white/5 text-gray-500 dark:text-slate-400">
                                         <div className="flex items-center gap-1">
-                                          <span>Readiness Index:</span>
+                                          <span>Career Readiness:</span>
                                           <span className="text-gray-800 dark:text-slate-200 uppercase font-black">{matchResult.matchBreakdown?.careerReadiness || "N/A"}</span>
                                         </div>
                                         <div className="flex items-center gap-1">
-                                          <span>OSS Signature:</span>
+                                          <span>Open Source Activity:</span>
                                           <span className="text-gray-800 dark:text-slate-200 uppercase font-black">{matchResult.matchBreakdown?.contributionActivity || "N/A"}</span>
                                         </div>
                                       </div>
@@ -760,7 +760,7 @@ const TalentFinderPage = () => {
                                   {/* Dynamic Neural Verification Badge Cloud */}
                                   {matchResult.aiHiringSignals && matchResult.aiHiringSignals.length > 0 && (
                                     <div className="space-y-2">
-                                      <h5 className="text-[10px] font-black text-gray-400 dark:text-slate-500 uppercase tracking-wider">Hiring Signal Attestation Identifiers</h5>
+                                      <h5 className="text-[10px] font-black text-gray-400 dark:text-slate-500 uppercase tracking-wider">Highlighted Strengths</h5>
                                       <div className="flex flex-wrap gap-2">
                                         {matchResult.aiHiringSignals.map((signal, idx) => (
                                           <span key={idx} className={`px-2.5 py-1 rounded-lg border text-[9px] font-black tracking-wider uppercase ${getSignalStyle(signal)}`}>
@@ -776,7 +776,7 @@ const TalentFinderPage = () => {
                                     {matchResult.aiRecruiterInsights && matchResult.aiRecruiterInsights.length > 0 && (
                                       <div className="space-y-1">
                                         <h5 className="text-[10px] font-black text-blue-600 dark:text-blue-400 uppercase tracking-wider flex items-center gap-1">
-                                          <Sparkles size={10} /> Neural Fit Justification Statement
+                                          <Sparkles size={10} /> Why They're a Match
                                         </h5>
                                         <ul className="space-y-1 text-xs font-medium text-gray-600 dark:text-slate-400 list-disc list-inside bg-white dark:bg-slate-900/30 p-2.5 rounded-xl border border-gray-100 dark:border-white/5">
                                           {matchResult.aiRecruiterInsights.map((insight, idx) => (
@@ -789,7 +789,7 @@ const TalentFinderPage = () => {
                                     {matchResult.aiWeaknesses && matchResult.aiWeaknesses.length > 0 && (
                                       <div className="space-y-1 mt-2.5">
                                         <h5 className="text-[10px] font-black text-amber-600 dark:text-amber-400 uppercase tracking-wider flex items-center gap-1">
-                                          <AlertTriangle size={10} /> Identified Delta Warnings
+                                          <AlertTriangle size={10} /> Areas of Concern
                                         </h5>
                                         <ul className="space-y-1 text-xs font-medium text-gray-600 dark:text-slate-400 list-disc list-inside bg-white dark:bg-slate-900/30 p-2.5 rounded-xl border border-gray-100 dark:border-white/5">
                                           {matchResult.aiWeaknesses.map((weakness, idx) => (
@@ -803,9 +803,9 @@ const TalentFinderPage = () => {
                               ) : (
                                 <div className="h-full flex flex-col items-center justify-center p-8 bg-white dark:bg-slate-900 border border-gray-200 dark:border-white/5 rounded-2xl text-center shadow-sm">
                                   <Sparkles size={32} className="text-gray-300 dark:text-slate-700 mb-3 animate-pulse" />
-                                  <span className="text-sm font-bold text-gray-700 dark:text-slate-400">Pipeline Engine Idle</span>
+                                  <span className="text-sm font-bold text-gray-700 dark:text-slate-400">Not Yet Evaluated</span>
                                   <p className="text-xs text-gray-400 dark:text-slate-500 mt-1.5 max-w-xs leading-relaxed font-medium">
-                                    Trigger the AI execution matrix to establish fit telemetry vectors for this candidate against your benchmark template description.
+                                    Run a match analysis to see how well this candidate fits your open role.
                                   </p>
                                 </div>
                               )}
@@ -814,7 +814,7 @@ const TalentFinderPage = () => {
 
                           {/* Cataloged Core Skills Tag Cloud Base strip */}
                           <div className="pt-5 border-t border-gray-200 dark:border-white/5">
-                            <h5 className="text-[10px] font-black text-gray-400 dark:text-slate-500 uppercase tracking-wider mb-2.5">Verified Knowledge Graph Token Indices</h5>
+                            <h5 className="text-[10px] font-black text-gray-400 dark:text-slate-500 uppercase tracking-wider mb-2.5">Verified Skills</h5>
                             <div className="flex flex-wrap gap-1.5">
                               {candidate.skills && candidate.skills.length > 0 ? (
                                 candidate.skills.map((skill, idx) => (
@@ -823,7 +823,7 @@ const TalentFinderPage = () => {
                                   </span>
                                 ))
                               ) : (
-                                <span className="text-xs text-gray-400 dark:text-slate-500 italic">No explicit index arrays mapped inside resume fields.</span>
+                                <span className="text-xs text-gray-400 dark:text-slate-500 italic">No skills listed.</span>
                               )}
                             </div>
                           </div>
@@ -845,10 +845,10 @@ const TalentFinderPage = () => {
                   size="sm"
                   className="font-bold shadow-sm"
                 >
-                  <ArrowLeft size={14} className="mr-1" /> Previous Block
+                  <ArrowLeft size={14} className="mr-1" /> Previous
                 </Button>
                 <span className="text-xs font-black text-gray-500 dark:text-slate-400 px-3 py-1.5 rounded-lg bg-gray-100 dark:bg-slate-900 border border-gray-200 dark:border-white/5 select-none shadow-inner">
-                  Cluster Index {page} / {totalPages}
+                  Page {page} / {totalPages}
                 </span>
                 <Button
                   disabled={page === totalPages}
@@ -857,7 +857,7 @@ const TalentFinderPage = () => {
                   size="sm"
                   className="font-bold shadow-sm"
                 >
-                  Next Block <ArrowRight size={14} className="ml-1" />
+                  Next <ArrowRight size={14} className="ml-1" />
                 </Button>
               </div>
             )}

--- a/interview-ai-service/requirements.txt
+++ b/interview-ai-service/requirements.txt
@@ -3,4 +3,4 @@ uvicorn[standard]==0.30.0
 python-multipart==0.0.9
 faster-whisper==1.0.3
 sentence-transformers==3.0.1
-spacy>=3.8.0,<3.9.0
+spacy>=3.7.0,<3.8.0

--- a/scripts/python-setup.js
+++ b/scripts/python-setup.js
@@ -47,6 +47,10 @@ async function main() {
   }
 
   printHeader("Installing Python dependencies");
+  await run(venvPython, ["-m", "pip", "install", "--upgrade", "pip"], {
+    cwd: serviceDir,
+    label: "pip-upgrade",
+  });
   await run(venvPython, ["-m", "pip", "install", "-r", "requirements.txt"], {
     cwd: serviceDir,
     label: "pip",

--- a/server/index.js
+++ b/server/index.js
@@ -18,7 +18,7 @@ import { logEvaluatorConfig } from "./src/config/evaluatorConfig.js";
 import redisClient, { connectRedis } from "./src/config/redis.js";
 // import swaggerSpec from "./src/config/swaggerConfig.js";
 import connectDB, { isConnected } from "./src/database/db.js";
-import { verifySocketToken } from "./src/middleware/authMiddleware.js";
+import { protect, verifySocketToken } from "./src/middleware/authMiddleware.js";
 import globalErrorHandler from "./src/middleware/errorMiddleware.js";
 import { globalLimiter } from "./src/middleware/rateLimiter.js";
 import requireDB from "./src/middleware/requireDB.js";

--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -525,7 +525,7 @@ const topSkills = topSkillsAgg;
   const result = {
     totalJobs: allJobs.length,
     statusBreakdown,
-    jobsByMonth,
+    jobsByMonth: jobsByMonthAgg,
     topSkills,
     recentJobs,
   };


### PR DESCRIPTION
### Summary
This PR patches a critical unhandled `ReferenceError` crashing the Recruiter Analytics ATS tab, standardizes dynamic theming (Light/Dark mode compatibility) across the entire dashboard ecosystem, and unifies the premium Hero layouts.

### Key Changes
* **Bug Fix (React Crash)**: Added the missing `FileText` icon import from `lucide-react` inside `RecruiterAnalyticsPage.jsx`, resolving the exception that caused the `CircularProgressRing` component to crash the "AI & ATS INTELLIGENCE" tab.
* **Global Theming Overhaul**: Deployed an extensive dynamic styling rewrite across `/recruiter-jobs` and `/dashboard` components. 
  * Replaced hardcoded `text-slate-200` with `text-slate-500 dark:text-slate-200` to restore legibility in Light Mode.
  * Corrected invisible borders and backgrounds (`border-gray-100 dark:border-white/5` and `bg-gray-50 dark:bg-white/5`).
  * Fixed nested element visibility on active tabs (`bg-blue-600 text-white`).
* **Hero Layout Standardization**: Refactored the headers in the Analytics and Applicants pages to feature a perfectly centered UI with floating decorative icons and aligned export buttons, matching the premium design language set by the `TalentFinder` page.

### Screen Recording

#### Before

https://github.com/user-attachments/assets/a557702c-6a8c-4968-99da-0e7c9d88db00



#### After


https://github.com/user-attachments/assets/fb3ab8bb-5541-4c5d-af4b-7911e530d555


### Verification
- [x] Verified `npm run build` succeeds locally with absolutely no JSX syntax/reference errors.
- [x] Verified Analytics tab renders all complex charts flawlessly.
- [x] Verified toggle between Light/Dark mode transitions perfectly without any washed-out UI components.

### Related Issue
Resolves #1387 
