### PR TITLE
add proficiency classification, alias map, weighted scoring,  and per-domain suggestions to techStandardEvaluator [ GSSOC'26 ]

### DIFF
--- a/ai-ml/evaluators/techStandardEvaluator.js
+++ b/ai-ml/evaluators/techStandardEvaluator.js
@@ -18,13 +18,11 @@ function matchesAlias(skill, text) {
   return aliases.some((alias) => text.includes(alias));
 }
 
-// --- Compute domain coverage ratio ---
 function domainCoverage(matches, total) {
   if (total === 0) return 0;
   return parseFloat((matches / total).toFixed(2));
 }
 
-// --- Classify domain proficiency ---
 function classifyProficiency(coverage) {
   if (coverage >= 0.7) return "expert";
   if (coverage >= 0.4) return "proficient";
@@ -72,7 +70,6 @@ export const techStandardEvaluator = ({ resumeText = "" }) => {
   );
 
   // --- Weighted score ---
-  // Expert domain = 25pts, Proficient = 15pts, Beginner = 5pts, capped at 100
   let score = 0;
   Object.keys(domainProficiency).forEach((d) => {
     if (domainProficiency[d] === "expert") score += 25;
@@ -100,7 +97,7 @@ export const techStandardEvaluator = ({ resumeText = "" }) => {
     );
   }
 
-  // --- Per-domain missing skill hints (top 3 per domain) ---
+  // --- Per-domain missing skill hints ---
   Object.keys(domainMissing).forEach((domain) => {
     if (
       domainMatches[domain].length > 0 &&

--- a/ai-ml/evaluators/techStandardEvaluator.js
+++ b/ai-ml/evaluators/techStandardEvaluator.js
@@ -1,73 +1,174 @@
 import techKeywords from "../config/keywords.js";
 import { normalizeSkillArray } from "../utils/skillNormalizer.js";
 
-/**
- * Evaluates the tech profile strength by checking for domain-specific skills.
- * Identifies if a profile is specialized or missing core tools for a domain.
- */
+// --- Skill alias map for raw-text matching ---
+const SKILL_ALIASES = {
+  nodejs: ["node.js", "node js", "nodejs"],
+  csharp: ["c#", "c sharp"],
+  cpp: ["c++", "cplusplus"],
+  dotnet: [".net", "dotnet"],
+  postgresql: ["postgres", "postgresql", "pg"],
+  mongodb: ["mongo", "mongodb"],
+  kubernetes: ["k8s", "kubernetes"],
+  googlecloud: ["gcp", "google cloud"],
+};
+
+function matchesAlias(skill, text) {
+  const aliases = SKILL_ALIASES[skill] ?? [skill];
+  return aliases.some((alias) => text.includes(alias));
+}
+
+// --- Compute domain coverage ratio ---
+function domainCoverage(matches, total) {
+  if (total === 0) return 0;
+  return parseFloat((matches / total).toFixed(2));
+}
+
+// --- Classify domain proficiency ---
+function classifyProficiency(coverage) {
+  if (coverage >= 0.7) return "expert";
+  if (coverage >= 0.4) return "proficient";
+  if (coverage > 0) return "beginner";
+  return "none";
+}
+
 export const techStandardEvaluator = ({ resumeText = "" }) => {
   const lowerText = resumeText.toLowerCase();
   const domainMatches = {};
   const domainMissing = {};
+  const domainCoverageMap = {};
+  const domainProficiency = {};
 
-  Object.keys(techKeywords).forEach(domain => {
-    // Normalize domain keywords to match our canonical forms
+  Object.keys(techKeywords).forEach((domain) => {
     const normDomainKeywords = normalizeSkillArray(techKeywords[domain]);
-    
-    const matches = normDomainKeywords.filter(skill => 
-      lowerText.includes(skill) || 
-      (skill === 'nodejs' && lowerText.includes('node.js')) ||
-      (skill === 'csharp' && lowerText.includes('c#'))
+
+    const matches = normDomainKeywords.filter(
+      (skill) => lowerText.includes(skill) || matchesAlias(skill, lowerText)
     );
+
+    const missing = normDomainKeywords.filter((skill) => !matches.includes(skill));
+    const coverage = domainCoverage(matches.length, normDomainKeywords.length);
+    const proficiency = classifyProficiency(coverage);
+
     domainMatches[domain] = matches;
-    domainMissing[domain] = normDomainKeywords.filter(skill => !matches.includes(skill));
+    domainMissing[domain] = missing;
+    domainCoverageMap[domain] = coverage;
+    domainProficiency[domain] = proficiency;
   });
 
   const feedback = [];
   const suggestions = [];
-  let score = 0;
 
-  // Analysis
-  const domainsWithMatches = Object.keys(domainMatches).filter(d => domainMatches[d].length > 0);
-  
-  if (domainsWithMatches.length >= 3) {
-    score = 100;
+  const domainsWithMatches = Object.keys(domainMatches).filter(
+    (d) => domainMatches[d].length > 0
+  );
+
+  const expertDomains = Object.keys(domainProficiency).filter(
+    (d) => domainProficiency[d] === "expert"
+  );
+
+  const proficientDomains = Object.keys(domainProficiency).filter(
+    (d) => domainProficiency[d] === "proficient"
+  );
+
+  // --- Weighted score ---
+  // Expert domain = 25pts, Proficient = 15pts, Beginner = 5pts, capped at 100
+  let score = 0;
+  Object.keys(domainProficiency).forEach((d) => {
+    if (domainProficiency[d] === "expert") score += 25;
+    else if (domainProficiency[d] === "proficient") score += 15;
+    else if (domainProficiency[d] === "beginner") score += 5;
+  });
+  score = Math.min(100, score);
+
+  // --- Feedback ---
+  if (expertDomains.length >= 2) {
+    feedback.push(`Expert-level proficiency detected in: ${expertDomains.join(", ")}.`);
+  } else if (domainsWithMatches.length >= 3) {
     feedback.push("Strong multi-domain technical profile detected.");
   } else if (domainsWithMatches.length === 2) {
-    score = 70;
-    feedback.push("Solid technical profile, but could benefit from broader domain exposure (e.g., Cloud/DevOps).");
+    feedback.push(
+      "Solid technical profile — consider broader domain exposure (e.g., Cloud/DevOps)."
+    );
   } else if (domainsWithMatches.length === 1) {
-    score = 40;
-    feedback.push("Highly specialized or narrow technical focus. Consider adding cross-functional skills.");
+    feedback.push(
+      `Specialized in ${domainsWithMatches[0]} — consider adding cross-functional skills.`
+    );
   } else {
-    score = 0;
-    feedback.push("Limited technical keywords found. Ensure your core stack is explicitly mentioned.");
+    feedback.push(
+      "Limited technical keywords found. Ensure your core stack is explicitly mentioned."
+    );
   }
 
-  // Domain-specific suggestions
-  if (domainMatches.frontend.length > 0 && domainMatches.backend.length === 0) {
-    suggestions.push("As a Frontend dev, consider learning basic Backend (Node.js/SQL) to become Fullstack.");
+  // --- Per-domain missing skill hints (top 3 per domain) ---
+  Object.keys(domainMissing).forEach((domain) => {
+    if (
+      domainMatches[domain].length > 0 &&
+      domainMissing[domain].length > 0 &&
+      domainProficiency[domain] !== "expert"
+    ) {
+      const top3 = domainMissing[domain].slice(0, 3);
+      suggestions.push(
+        `To strengthen ${domain} proficiency, consider adding: ${top3.join(", ")}.`
+      );
+    }
+  });
+
+  // --- Cross-domain suggestions ---
+  if (
+    domainMatches.frontend?.length > 0 &&
+    domainMatches.backend?.length === 0
+  ) {
+    suggestions.push(
+      "As a Frontend dev, consider learning basic Backend (Node.js/SQL) to become Fullstack."
+    );
   }
-  if ((domainMatches.frontend?.length > 0 || domainMatches.backend?.length > 0) && 
-      (domainMatches.cloud?.length === 0 && domainMatches.devops?.length === 0)) {
-    suggestions.push("Add Cloud/DevOps skills (Docker, AWS) to demonstrate modern deployment knowledge.");
+
+  if (
+    (domainMatches.frontend?.length > 0 || domainMatches.backend?.length > 0) &&
+    domainMatches.cloud?.length === 0 &&
+    domainMatches.devops?.length === 0
+  ) {
+    suggestions.push(
+      "Add Cloud/DevOps skills (Docker, AWS) to demonstrate modern deployment knowledge."
+    );
   }
+
+  if (
+    domainsWithMatches.length >= 2 &&
+    domainMatches.testing?.length === 0
+  ) {
+    suggestions.push(
+      "No testing skills detected — add Jest, Cypress, or Pytest to strengthen code quality signal."
+    );
+  }
+
+  const summary =
+    score >= 80
+      ? "Well-rounded technical profile with expert-level domain coverage."
+      : score >= 50
+      ? "Solid technical profile — a few domain gaps to address."
+      : score >= 25
+      ? "Narrow technical focus — consider broadening your stack."
+      : "Limited technical keywords found — explicitly list your core stack.";
 
   return {
     key: "tech_standard",
     label: "Technical Breadth",
     score,
-    summary: score > 70 
-      ? "Well-rounded technical profile across multiple domains." 
-      : "The technical profile appears narrow; consider highlighting more cross-stack tools.",
+    summary,
     details: {
       domainMatches,
       domainMissing,
+      domainCoverage: domainCoverageMap,
+      domainProficiency,
       feedback,
-      suggestions
+      suggestions,
     },
     meta: {
-      domainsDetected: domainsWithMatches.length
-    }
+      domainsDetected: domainsWithMatches.length,
+      expertDomains,
+      proficientDomains,
+    },
   };
 };


### PR DESCRIPTION
## Summary
Replaced flat domain-count scoring with a weighted proficiency model 
(expert/proficient/beginner based on coverage ratio). Centralized alias 
handling into SKILL_ALIASES covering c++, .net, postgres, k8s, gcp. 
Added per-domain missing skill suggestions, testing gap detection, and 
4-tier summary output.

## Type of Change
- [x] Feature — proficiency tiers, weighted scoring, per-domain suggestions
- [x] Bug fix — c++, .net, postgres, k8s, gcp aliases silently unmatched

## Related Issue
Closes #1391 

## Changes Made
- Added SKILL_ALIASES map and matchesAlias() to centralize alias resolution
- Added domainCoverage() — per-domain matched/total ratio
- Added classifyProficiency() — expert/proficient/beginner from coverage
- Replaced fixed 0/40/70/100 score with weighted points per proficiency tier
- Added per-domain missing skill suggestions (top 3 for non-expert domains)
- Added testing domain gap suggestion when 2+ domains detected but no testing skills
- Added domainCoverage, domainProficiency to details output
- Added expertDomains, proficientDomains to meta output
- Updated summary to 4-tier score-based messages

## Validation
- [x] Build passes locally
- [x] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)
N/A