### PR TITLE
feat: add interview answer draft autosave and recovery

### DIFF
--- a/client/src/modules/mock-interview/hooks/useInterviewState.js
+++ b/client/src/modules/mock-interview/hooks/useInterviewState.js
@@ -5,7 +5,10 @@ import { apiRequest } from "../../../services/apiClient";
 import {
   saveInterviewSession,
   loadInterviewSession,
-  clearInterviewSession
+  clearInterviewSession,
+  saveInterviewAnswerDraft,
+  loadInterviewAnswerDraft,
+  clearInterviewAnswerDraft,
 } from "../../../utils/interviewSessionStorage";
 import { analyzeText, debounce } from "../utils/sentiment";
 import logger from "../../../utils/logger";
@@ -147,7 +150,7 @@ export const useInterviewState = (sessionId, isObserver) => {
   const formatTime = (seconds) => {
     const mins = Math.floor(seconds / 60);
     const secs = seconds % 60;
-    return `${mins}:${secs.toString().padStart(2, "0")}`;
+    return `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
   };
 
   // Load session from API or localStorage rehydration
@@ -186,23 +189,38 @@ export const useInterviewState = (sessionId, isObserver) => {
           idx = unansweredIdx >= 0 ? unansweredIdx : 0;
         }
 
-        setCurrentIndex(idx);
-        setCurrentQuestion({
+        const question = {
           questionText: data.answers[idx]?.questionText,
           questionId: data.answers[idx]?.questionId,
+        };
+        const savedDraft = loadInterviewAnswerDraft({
+          sessionId,
+          currentIndex: idx,
+          questionId: question.questionId,
         });
+        const restoredAnswer =
+          savedSession?.answer ||
+          savedSession?.messages?.at(-1)?.content ||
+          savedDraft?.answer ||
+          "";
+
+        if (savedDraft?.answer && !savedSession?.answer) {
+          setAnswer(savedDraft.answer);
+          setRecoveryMessage("Restored your saved answer draft.");
+          setTimeout(() => setRecoveryMessage(null), 3000);
+        }
+
+        setCurrentIndex(idx);
+        setCurrentQuestion(question);
         setIsLastQuestion(idx === data.answers.length - 1);
         
         saveInterviewSession({
           sessionId,
           currentIndex: idx,
-          answer: savedSession?.answer || "",
+          answer: restoredAnswer,
           elapsedTime: savedSession?.elapsedTime || 0,
           uploadStatus: savedSession?.uploadStatus || "idle",
-          currentQuestion: {
-            questionText: data.answers[idx]?.questionText,
-            questionId: data.answers[idx]?.questionId,
-          },
+          currentQuestion: question,
           messages: savedSession?.messages || [],
         });
       } catch (err) {
@@ -221,6 +239,11 @@ export const useInterviewState = (sessionId, isObserver) => {
   }, [sessionId]);
 
   const handleEvaluationResult = useCallback((data, textareaRef) => {
+    clearInterviewAnswerDraft({
+      sessionId,
+      currentIndex,
+      questionId: currentQuestion?.questionId,
+    });
     setLastScores(data.scores);
     setShowScores(true);
     setAnswer("");
@@ -233,14 +256,20 @@ export const useInterviewState = (sessionId, isObserver) => {
       setIsLastQuestion(true);
     } else if (data.nextQuestion) {
       setTimeout(() => {
+        const savedDraft = loadInterviewAnswerDraft({
+          sessionId,
+          currentIndex: data.nextQuestion.index,
+          questionId: data.nextQuestion.questionId,
+        });
         setCurrentQuestion(data.nextQuestion);
         setCurrentIndex(data.nextQuestion.index);
+        setAnswer(savedDraft?.answer || "");
         setShowScores(false);
         setLastScores(null);
         if (textareaRef?.current) textareaRef.current.focus();
       }, 3000);
     }
-  }, []);
+  }, [currentIndex, currentQuestion?.questionId, sessionId]);
 
   const handleAnswerChange = (e, socket) => {
     const nextAnswer = e.target.value;
@@ -250,6 +279,12 @@ export const useInterviewState = (sessionId, isObserver) => {
     persistBackup({
       answer: nextAnswer,
       messages: [{ role: "candidate", content: nextAnswer, timestamp: Date.now() }],
+    });
+    saveInterviewAnswerDraft({
+      sessionId,
+      currentIndex,
+      questionId: currentQuestion?.questionId,
+      answer: nextAnswer,
     });
 
     if (socket && !isObserver) {
@@ -302,6 +337,7 @@ export const useInterviewState = (sessionId, isObserver) => {
         (attempt) => setRequestStatus(`Retrying final submission (${attempt}/${MAX_RETRY_ATTEMPTS})...`),
       );
       clearInterviewSession();
+      clearInterviewAnswerDraft();
       navigate(`/mock-interview/${sessionId}/results`, { replace: true });
     } catch (err) {
       setFailedAction("complete");

--- a/client/src/modules/mock-interview/pages/InterviewSession.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewSession.jsx
@@ -249,9 +249,9 @@ const InterviewSession = () => {
                   <Loader2 size={14} className="animate-spin" /> {state.requestStatus}
                 </div>
               )}
-              {audioState.mediaWarning && (
+              {state.mediaWarning && (
                 <div className="text-xs text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10 p-2 rounded-lg flex items-center gap-2" role="alert">
-                  <MicOff size={14} /> {audioState.mediaWarning}
+                  <MicOff size={14} /> {state.mediaWarning}
                 </div>
               )}
               {state.uploadStatus !== "idle" && (

--- a/client/src/utils/__tests__/interviewSessionStorage.test.js
+++ b/client/src/utils/__tests__/interviewSessionStorage.test.js
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  saveInterviewAnswerDraft,
+  loadInterviewAnswerDraft,
+  clearInterviewAnswerDraft,
+} from "../interviewSessionStorage";
+
+const DRAFT_STORAGE_KEY = "skillssphere.mockInterview.answerDrafts";
+
+describe("interview answer draft storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("saves and restores a draft for the active session question", () => {
+    saveInterviewAnswerDraft({
+      sessionId: "session-1",
+      currentIndex: 0,
+      questionId: "q1",
+      answer: "React state is component memory.",
+    });
+
+    expect(
+      loadInterviewAnswerDraft({
+        sessionId: "session-1",
+        currentIndex: 0,
+        questionId: "q1",
+      }),
+    ).toMatchObject({
+      sessionId: "session-1",
+      currentIndex: 0,
+      questionId: "q1",
+      answer: "React state is component memory.",
+    });
+  });
+
+  it("keeps drafts scoped by session and question", () => {
+    saveInterviewAnswerDraft({
+      sessionId: "session-1",
+      currentIndex: 0,
+      questionId: "q1",
+      answer: "First answer",
+    });
+
+    expect(
+      loadInterviewAnswerDraft({
+        sessionId: "session-2",
+        currentIndex: 0,
+        questionId: "q1",
+      }),
+    ).toBeNull();
+    expect(
+      loadInterviewAnswerDraft({
+        sessionId: "session-1",
+        currentIndex: 1,
+        questionId: "q2",
+      }),
+    ).toBeNull();
+  });
+
+  it("clears a saved draft after submission", () => {
+    const draftRef = {
+      sessionId: "session-1",
+      currentIndex: 0,
+      questionId: "q1",
+    };
+
+    saveInterviewAnswerDraft({
+      ...draftRef,
+      answer: "Submitted answer",
+    });
+    clearInterviewAnswerDraft(draftRef);
+
+    expect(loadInterviewAnswerDraft(draftRef)).toBeNull();
+  });
+
+  it("removes a draft when the answer is emptied", () => {
+    const draftRef = {
+      sessionId: "session-1",
+      currentIndex: 0,
+      questionId: "q1",
+    };
+
+    saveInterviewAnswerDraft({
+      ...draftRef,
+      answer: "Temporary answer",
+    });
+    saveInterviewAnswerDraft({
+      ...draftRef,
+      answer: "   ",
+    });
+
+    expect(loadInterviewAnswerDraft(draftRef)).toBeNull();
+  });
+
+  it("fails safely and clears corrupted draft storage", () => {
+    localStorage.setItem(DRAFT_STORAGE_KEY, "{not-json");
+
+    expect(
+      loadInterviewAnswerDraft({
+        sessionId: "session-1",
+        currentIndex: 0,
+        questionId: "q1",
+      }),
+    ).toBeNull();
+    expect(localStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/client/src/utils/interviewSessionStorage.js
+++ b/client/src/utils/interviewSessionStorage.js
@@ -1,4 +1,5 @@
 const STORAGE_KEY = "skillssphere.mockInterview.backup";
+const DRAFT_STORAGE_KEY = "skillssphere.mockInterview.answerDrafts";
 
 const canUseStorage = () => typeof window !== "undefined" && window.localStorage;
 
@@ -61,4 +62,113 @@ export const clearInterviewSession = () => {
   } catch {
     // Ignore cleanup failures.
   }
+};
+
+const getDraftKey = ({ sessionId, currentIndex, questionId }) => {
+  if (!sessionId) return null;
+
+  const normalizedIndex = Math.max(0, Number(currentIndex || 0));
+  return [
+    String(sessionId),
+    String(questionId || "unknown-question"),
+    normalizedIndex,
+  ].join(":");
+};
+
+const readDrafts = () => {
+  if (!canUseStorage()) return {};
+
+  try {
+    const raw = window.localStorage.getItem(DRAFT_STORAGE_KEY);
+    if (!raw) return {};
+
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : {};
+  } catch {
+    window.localStorage.removeItem(DRAFT_STORAGE_KEY);
+    return {};
+  }
+};
+
+const writeDrafts = (drafts) => {
+  if (!canUseStorage()) return;
+
+  try {
+    window.localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(drafts));
+  } catch {
+    // Draft persistence is best-effort and must not block typing.
+  }
+};
+
+export const saveInterviewAnswerDraft = ({
+  sessionId,
+  currentIndex,
+  questionId,
+  answer,
+}) => {
+  const draftKey = getDraftKey({ sessionId, currentIndex, questionId });
+  if (!draftKey) return;
+
+  const normalizedAnswer = typeof answer === "string" ? answer : "";
+  const drafts = readDrafts();
+
+  if (!normalizedAnswer.trim()) {
+    delete drafts[draftKey];
+  } else {
+    drafts[draftKey] = {
+      sessionId: String(sessionId),
+      currentIndex: Math.max(0, Number(currentIndex || 0)),
+      questionId: questionId ? String(questionId) : null,
+      answer: normalizedAnswer,
+      savedAt: Date.now(),
+    };
+  }
+
+  writeDrafts(drafts);
+};
+
+export const loadInterviewAnswerDraft = ({
+  sessionId,
+  currentIndex,
+  questionId,
+}) => {
+  const draftKey = getDraftKey({ sessionId, currentIndex, questionId });
+  if (!draftKey) return null;
+
+  const draft = readDrafts()[draftKey];
+  if (!draft || typeof draft.answer !== "string") return null;
+
+  return {
+    sessionId: String(draft.sessionId || sessionId),
+    currentIndex: Math.max(0, Number(draft.currentIndex || currentIndex || 0)),
+    questionId: draft.questionId ? String(draft.questionId) : null,
+    answer: draft.answer,
+    savedAt: Number(draft.savedAt || Date.now()),
+  };
+};
+
+export const clearInterviewAnswerDraft = ({
+  sessionId,
+  currentIndex,
+  questionId,
+} = {}) => {
+  if (!canUseStorage()) return;
+
+  if (!sessionId) {
+    try {
+      window.localStorage.removeItem(DRAFT_STORAGE_KEY);
+    } catch {
+      // Ignore cleanup failures.
+    }
+    return;
+  }
+
+  const draftKey = getDraftKey({ sessionId, currentIndex, questionId });
+  if (!draftKey) return;
+
+  const drafts = readDrafts();
+  delete drafts[draftKey];
+  writeDrafts(drafts);
 };


### PR DESCRIPTION
## Summary

Implemented automatic draft persistence for mock interview answers to prevent data loss during page refreshes, navigation, or accidental browser closures.

## Changes Made

### Draft Storage Utilities

Added reusable interview draft helper functions in:

`client/src/utils/interviewSessionStorage.js`

Functions:

* `saveInterviewAnswerDraft`
* `loadInterviewAnswerDraft`
* `clearInterviewAnswerDraft`

### Interview State Integration

Updated:

`client/src/modules/mock-interview/hooks/useInterviewState.js`

Features:

* Automatically saves answer drafts while the user types.
* Restores saved drafts when the interview page is reloaded or revisited.
* Clears the draft after successful answer evaluation.
* Removes all remaining drafts when the interview is completed.

### UI Improvements

* Fixed interview warning display to correctly use `state.mediaWarning`.
* Standardized timer formatting across interview sessions to `MM:SS`.

### Testing

Added unit tests:

`client/src/utils/__tests__/interviewSessionStorage.test.js`

## Verification

Executed:

```bash
.\node_modules\.bin\vitest.cmd run src\utils\__tests__\interviewSessionStorage.test.js src\modules\mock-interview\pages\InterviewSession.test.jsx
```

### Results

* 2 test files passed
* 12 tests passed

## Benefits

* Prevents accidental loss of interview answers.
* Improves user experience during long interview sessions.
* Provides reliable draft recovery after refreshes or navigation.
* Ensures proper cleanup of saved drafts after evaluation and interview completion.
