### PR TITLE
fix(notifications): align system and message types category filtering…

### DIFF
--- a/client/src/modules/notifications/pages/NotificationsPage.jsx
+++ b/client/src/modules/notifications/pages/NotificationsPage.jsx
@@ -119,7 +119,7 @@ const NotificationsPage = () => {
       return ["interview"].includes(notificationType);
     }
     if (categoryFilter === "system") {
-      return ["info", "warning", "success", "error", "skill_gap_alert"].includes(notificationType);
+      return ["info", "warning", "success", "error", "skill_gap_alert", "system", "message"].includes(notificationType);
     }
     return false;
   };

--- a/server/src/modules/notifications/__tests__/controller.test.js
+++ b/server/src/modules/notifications/__tests__/controller.test.js
@@ -124,6 +124,26 @@ describe("Notification Controller", () => {
       assert.equal(res.status.mock.calls[0].arguments[0], 200);
       assert.equal(res.json.mock.calls[0].arguments[0].success, true);
     });
+
+    it("should query for system and message types when system filter is requested", async () => {
+      let passedFilters;
+      mock.method(Notification, "find", (filters) => {
+        passedFilters = filters;
+        return {
+          sort: () => ({ skip: () => ({ limit: () => ({ populate: () => [] }) }) }),
+        };
+      });
+      mock.method(Notification, "countDocuments", () => 0);
+
+      req.query = { type: "system" };
+      getNotifications(req, res, next);
+      await flush();
+
+      assert.equal(res.status.mock.calls[0].arguments[0], 200);
+      assert.deepEqual(passedFilters.type, {
+        $in: ["info", "warning", "success", "error", "skill_gap_alert", "system", "message"],
+      });
+    });
   });
 
   describe("getUnreadCount", () => {

--- a/server/src/modules/notifications/service.js
+++ b/server/src/modules/notifications/service.js
@@ -49,7 +49,7 @@ export const getUserNotifications = async (userId, queryParams = {}) => {
     } else if (type === "interviews") {
       filters.type = { $in: ["interview"] };
     } else if (type === "system") {
-      filters.type = { $in: ["info", "warning", "success", "error", "skill_gap_alert"] };
+      filters.type = { $in: ["info", "warning", "success", "error", "skill_gap_alert", "system", "message"] };
     } else {
       filters.type = type;
     }


### PR DESCRIPTION
## Overview

Fixes a notification filtering inconsistency where the newly introduced `system` and `message` notification types were correctly stored and displayed under **All Categories**, but were excluded from category-specific filtering in both the backend and frontend.

As a result, roadmap collaboration notifications such as resource assignments, topic verification updates, and comments were not visible when users filtered notifications using the **System Alerts** category.

This PR aligns backend query logic and frontend category filtering to ensure these notifications appear consistently across the application.

---

## Related Issue

Closes #1398 

---

## Type of Change

* [x] Bug Fix

---

## Changes Made

### Backend Notification Filtering

Updated:

```text
server/src/modules/notifications/service.js
```

Changes:

* Extended the notification type mapping for the `system` category.
* Added support for:

  * `system`
  * `message`
* Ensured backend queries return these notification types when filtering by system-related categories.

### Frontend Category Filtering

Updated:

```text
client/src/modules/notifications/pages/NotificationsPage.jsx
```

Changes:

* Updated the `matchesCategory` helper function.
* Added support for displaying:

  * `system`
  * `message`
* Ensured the **System Alerts** filter correctly displays roadmap collaboration notifications.

### Test Coverage

Updated:

```text
server/src/modules/notifications/__tests__/controller.test.js
```

Added tests to verify:

* System category filtering includes all expected notification types.
* Generated database queries contain:

  * `info`
  * `warning`
  * `success`
  * `error`
  * `skill_gap_alert`
  * `system`
  * `message`

---

## Files Updated

```text
server/src/modules/notifications/service.js
server/src/modules/notifications/__tests__/controller.test.js
client/src/modules/notifications/pages/NotificationsPage.jsx
```

---

## Test Results

Verified:

* Notifications appear under **All Categories**
* Notifications appear under **System Alerts**
* Backend filtering returns expected results
* Frontend filtering remains synchronized with backend behavior

---

## Screenshots

*The System Alerts category now correctly displays roadmap collaboration notifications, including resource assignments, comments, and other system-generated updates.*
<img width="1918" height="1007" alt="image" src="https://github.com/user-attachments/assets/d34432c0-1729-4d59-827f-3238d84b22b5" />


---

## Result

Notification filtering is now consistent across the backend and frontend. Newly introduced `system` and `message` notification types are included in category-specific queries and UI filters, ensuring users can access roadmap-related notifications regardless of the selected notification category.
