### PR TITLE
Fix IDOR in recruiter invite-candidate endpoint

### DIFF
--- a/server/src/modules/recruiter/controller.js
+++ b/server/src/modules/recruiter/controller.js
@@ -338,6 +338,10 @@ export const inviteCandidate = asyncHandler(async (req, res, next) => {
     return next(new AppError("Job posting not found", 404));
   }
 
+  if (job.recruiter.toString() !== req.user._id.toString()) {
+    return next(new AppError("You are not authorized to access this job", 403));
+  }
+
   const candidate = await User.findById(candidateId);
   if (!candidate || candidate.role !== "student") {
     return next(new AppError("Invalid candidate or user is not a student", 404));


### PR DESCRIPTION
Closes #1381 

This PR fixes a broken access control issue in the recruiter invitation flow where authenticated recruiters could send candidate invitations using job postings owned by other recruiters.

The vulnerability existed in POST /api/recruiter/invite-candidate, where the supplied jobId was only checked for existence before processing the invitation request. Since ownership validation was missing, any recruiter could provide another recruiter's job ID and successfully send invitations referencing that job posting.

The endpoint now validates that the requested job belongs to the authenticated recruiter before sending any invitation. If the job owner does not match the logged-in recruiter, the request is rejected with a 403 Forbidden response and the invitation logic is never executed.

I verified that a recruiter attempting to send invitations using another recruiter's job now receives an authorization error, while legitimate recruiters can continue sending invitations for their own jobs successfully. Existing invitation workflows, notification behavior, and response structures continue to function normally after the change.

I have also attached screenshots after fixing :-

Ownership Validation Added in inviteCandidate Controller :
<img width="1389" height="430" alt="image" src="https://github.com/user-attachments/assets/777e7baf-ecc0-4186-8a76-1c539377a9e0" />

Unauthorized Recruiter Invitation Blocked After Fix (403 Forbidden) :
<img width="1405" height="415" alt="image" src="https://github.com/user-attachments/assets/a13245e8-9a7f-4325-bd60-0f94ad96ed46" />
