### PR TITLE
fix(classrooms): prevent classroom state desynchronization in cluster…

### DIFF
--- a/server/src/modules/classrooms/__tests__/sweeper.test.js
+++ b/server/src/modules/classrooms/__tests__/sweeper.test.js
@@ -1,0 +1,284 @@
+import { describe, it, afterEach, beforeEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import { initClassroomSockets } from "../socket.js";
+import ClassroomSession from "../../../database/models/ClassroomSession.js";
+import { getRoomLock, Mutex } from "../../../utils/mutex.js";
+import redisClient from "../../../config/redis.js";
+
+describe("Classroom Background Sweeper (Clustered & Single Node)", () => {
+  let sweeperCallback;
+  let mockIo;
+  let activeSockets;
+  let acquireCalls;
+  let lockReleased;
+  let redisStore;
+  let isRedisReady;
+
+  // Save original descriptor of isReady to restore later
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(redisClient),
+    "isReady"
+  ) || Object.getOwnPropertyDescriptor(redisClient, "isReady");
+
+  beforeEach(() => {
+    // Intercept setInterval to capture the sweeper callback
+    mock.method(globalThis, "setInterval", (callback) => {
+      sweeperCallback = callback;
+      return "mock-timer-id";
+    });
+
+    activeSockets = [];
+    mockIo = {
+      in: mock.fn(() => ({
+        fetchSockets: mock.fn(async () => activeSockets)
+      })),
+      on: mock.fn()
+    };
+
+    acquireCalls = [];
+    lockReleased = false;
+
+    mock.method(Mutex.prototype, "acquire", async function() {
+      acquireCalls.push(this);
+      return () => {
+        lockReleased = true;
+      };
+    });
+
+    // Reset Redis mock store
+    redisStore = new Map();
+    isRedisReady = false; // Default to single-node mode
+
+    // Override isReady using defineProperty
+    try {
+      Object.defineProperty(redisClient, "isReady", {
+        get: () => isRedisReady,
+        configurable: true
+      });
+    } catch (err) {
+      // If direct definition fails, try prototype redefinition
+      try {
+        Object.defineProperty(Object.getPrototypeOf(redisClient), "isReady", {
+          get: () => isRedisReady,
+          configurable: true
+        });
+      } catch (protoErr) {
+        // Safe fallback
+      }
+    }
+
+    mock.method(redisClient, "get", async (key) => redisStore.get(key));
+    mock.method(redisClient, "set", async (key, val) => {
+      redisStore.set(key, val);
+      return "OK";
+    });
+    mock.method(redisClient, "del", async (key) => {
+      redisStore.delete(key);
+      return 1;
+    });
+    mock.method(redisClient, "keys", async (pattern) => {
+      const regex = new RegExp("^" + pattern.replace(/\*/g, ".*") + "$");
+      return Array.from(redisStore.keys()).filter((key) => regex.test(key));
+    });
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+    isRedisReady = false;
+    // Restore original property if possible
+    if (originalDescriptor) {
+      try {
+        Object.defineProperty(redisClient, "isReady", originalDescriptor);
+      } catch (err) {
+        try {
+          Object.defineProperty(Object.getPrototypeOf(redisClient), "isReady", originalDescriptor);
+        } catch (protoErr) {
+          // ignore
+        }
+      }
+    }
+  });
+
+  /* --- Single Node Fallback Tests --- */
+
+  it("should acquire lock, reload session, and start countdown when room is empty (single node)", async () => {
+    initClassroomSockets(mockIo);
+    assert.ok(sweeperCallback, "Sweeper callback should be registered");
+
+    const mockSession = {
+      _id: "session-1",
+      roomId: "room-1",
+      status: "active",
+      emptySince: null,
+      participants: [{ socketId: "socket-1", user: { id: "user-1" } }],
+      save: mock.fn(async () => {})
+    };
+
+    mock.method(ClassroomSession, "find", async () => [mockSession]);
+    mock.method(ClassroomSession, "findOne", async () => mockSession);
+
+    await sweeperCallback();
+
+    assert.equal(acquireCalls.length, 1);
+    assert.equal(ClassroomSession.findOne.mock.calls.length, 1);
+    assert.ok(mockSession.emptySince instanceof Date);
+    assert.equal(mockSession.save.mock.calls.length, 1);
+    assert.equal(lockReleased, true);
+  });
+
+  it("should end session and clear locks/state when empty longer than grace period (single node)", async () => {
+    initClassroomSockets(mockIo);
+
+    const oldDate = new Date(Date.now() - 40000);
+    const mockSession = {
+      _id: "session-2",
+      roomId: "room-2",
+      status: "active",
+      emptySince: oldDate,
+      endedAt: null,
+      participants: [],
+      save: mock.fn(async () => {})
+    };
+
+    const firstLock = getRoomLock("room-2");
+
+    mock.method(ClassroomSession, "find", async () => [mockSession]);
+    mock.method(ClassroomSession, "findOne", async () => mockSession);
+
+    await sweeperCallback();
+
+    assert.equal(mockSession.status, "ended");
+    assert.ok(mockSession.endedAt instanceof Date);
+    assert.equal(mockSession.save.mock.calls.length, 1);
+
+    const secondLock = getRoomLock("room-2");
+    assert.notEqual(firstLock, secondLock);
+    assert.equal(lockReleased, true);
+  });
+
+  it("should reset emptySince and prune inactive participants if sockets are active (single node)", async () => {
+    initClassroomSockets(mockIo);
+
+    activeSockets = [{ id: "socket-1" }];
+
+    const mockSession = {
+      _id: "session-3",
+      roomId: "room-3",
+      status: "active",
+      emptySince: new Date(),
+      participants: [
+        { socketId: "socket-1", user: { id: "user-1" } },
+        { socketId: "socket-stale", user: { id: "user-2" } }
+      ],
+      save: mock.fn(async () => {})
+    };
+
+    mock.method(ClassroomSession, "find", async () => [mockSession]);
+    mock.method(ClassroomSession, "findOne", async () => mockSession);
+
+    await sweeperCallback();
+
+    assert.equal(mockSession.emptySince, null);
+    assert.equal(mockSession.participants.length, 1);
+    assert.equal(mockSession.participants[0].socketId, "socket-1");
+    assert.equal(mockSession.save.mock.calls.length, 1);
+    assert.equal(lockReleased, true);
+  });
+
+  /* --- Clustered Deployment Tests (Redis Active) --- */
+
+  it("should NOT start countdown if local is empty but remote node has active connections (clustered)", async () => {
+    isRedisReady = true;
+    initClassroomSockets(mockIo);
+
+    // Local sockets is empty, but simulate remote server having active sockets in Redis
+    activeSockets = [];
+    redisStore.set("classroom:presence:room-cluster-1:server-remote-99", JSON.stringify(["socket-remote-1"]));
+
+    const mockSession = {
+      _id: "session-4",
+      roomId: "room-cluster-1",
+      status: "active",
+      emptySince: null,
+      participants: [{ socketId: "socket-remote-1", user: { id: "user-remote" } }],
+      save: mock.fn(async () => {})
+    };
+
+    mock.method(ClassroomSession, "find", async () => [mockSession]);
+    mock.method(ClassroomSession, "findOne", async () => mockSession);
+
+    await sweeperCallback();
+
+    // Verify emptySince countdown did NOT start because remote socket is active
+    assert.equal(mockSession.emptySince, null);
+    assert.equal(mockSession.participants.length, 1);
+    assert.equal(mockSession.participants[0].socketId, "socket-remote-1");
+    assert.equal(lockReleased, true);
+  });
+
+  it("should start countdown if both local and remote nodes are empty (clustered)", async () => {
+    isRedisReady = true;
+    initClassroomSockets(mockIo);
+
+    activeSockets = [];
+    // Simulate remote server has cleaned up its presence
+    redisStore.set("classroom:presence:room-cluster-2:server-remote-99", JSON.stringify([]));
+
+    const mockSession = {
+      _id: "session-5",
+      roomId: "room-cluster-2",
+      status: "active",
+      emptySince: null,
+      participants: [],
+      save: mock.fn(async () => {})
+    };
+
+    mock.method(ClassroomSession, "find", async () => [mockSession]);
+    mock.method(ClassroomSession, "findOne", async () => mockSession);
+
+    await sweeperCallback();
+
+    assert.ok(mockSession.emptySince instanceof Date);
+    assert.equal(mockSession.save.mock.calls.length, 1);
+    assert.equal(lockReleased, true);
+  });
+
+  it("should combine local and remote active sockets to prune stale participants (clustered)", async () => {
+    isRedisReady = true;
+    initClassroomSockets(mockIo);
+
+    // Local server has active socket-local
+    activeSockets = [{ id: "socket-local" }];
+    // Remote server has active socket-remote
+    redisStore.set("classroom:presence:room-cluster-3:server-remote-99", JSON.stringify(["socket-remote"]));
+
+    const mockSession = {
+      _id: "session-6",
+      roomId: "room-cluster-3",
+      status: "active",
+      emptySince: new Date(),
+      participants: [
+        { socketId: "socket-local", user: { id: "user-1" } },
+        { socketId: "socket-remote", user: { id: "user-2" } },
+        { socketId: "socket-dead-ghost", user: { id: "user-3" } } // stale ghost socket
+      ],
+      save: mock.fn(async () => {})
+    };
+
+    mock.method(ClassroomSession, "find", async () => [mockSession]);
+    mock.method(ClassroomSession, "findOne", async () => mockSession);
+
+    await sweeperCallback();
+
+    // Verify emptySince was reset
+    assert.equal(mockSession.emptySince, null);
+    // Verify socket-local and socket-remote are retained, but socket-dead-ghost is pruned
+    assert.equal(mockSession.participants.length, 2);
+    const retainedSocketIds = mockSession.participants.map((p) => p.socketId);
+    assert.ok(retainedSocketIds.includes("socket-local"));
+    assert.ok(retainedSocketIds.includes("socket-remote"));
+    assert.ok(!retainedSocketIds.includes("socket-dead-ghost"));
+    assert.equal(mockSession.save.mock.calls.length, 1);
+    assert.equal(lockReleased, true);
+  });
+});

--- a/server/src/modules/classrooms/socket.js
+++ b/server/src/modules/classrooms/socket.js
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import ClassroomSession from "../../database/models/ClassroomSession.js";
 import { getRoomLock, clearRoomLock } from "../../utils/mutex.js";
 import logger from "../../utils/logger.js";
@@ -11,8 +12,11 @@ import registerCodeEditorHandler from "./socketHandlers/codeEditorHandler.js";
 import redisClient from "../../config/redis.js";
 
 const roomStates = new Map();
+const serverId = crypto.randomUUID();
 
 const getRedisKey = (roomId) => `classroom:state:${roomId}`;
+const getPresenceKey = (roomId, sId) => `classroom:presence:${roomId}:${sId}`;
+const getPresencePattern = (roomId) => `classroom:presence:${roomId}:*`;
 
 export async function loadRoomState(roomId, session = null) {
   if (roomStates.has(roomId)) return roomStates.get(roomId);
@@ -95,54 +99,101 @@ export function initClassroomSockets(io) {
       const activeSessions = await ClassroomSession.find({ status: "active" });
 
       for (const session of activeSessions) {
-        let activeSockets = [];
+        const lock = getRoomLock(session.roomId);
+        const release = await lock.acquire();
         try {
-          activeSockets = await io.in(session.roomId).fetchSockets();
-        } catch (fetchErr) {
-          logger.error(`Error fetching sockets for room ${session.roomId}:`, fetchErr);
-          continue;
-        }
+          // Fetch fresh db instance under lock to avoid overwriting concurrent socket updates
+          const freshSession = await ClassroomSession.findOne({
+            roomId: session.roomId,
+            status: "active",
+          });
+          if (!freshSession) {
+            continue;
+          }
 
-        if (activeSockets.length === 0) {
-          // If the room has no active socket connections, check/set emptySince
-          if (!session.emptySince) {
-            logger.info(`Background Sweeper: Room ${session.roomId} is empty. Starting 30-second teardown countdown...`);
-            session.emptySince = new Date();
-            await session.save();
+          let localSockets = [];
+          try {
+            localSockets = await io.in(freshSession.roomId).fetchSockets();
+          } catch (fetchErr) {
+            logger.error(`Error fetching sockets for room ${freshSession.roomId}:`, fetchErr);
+            continue;
+          }
+
+          const localSocketIds = localSockets.map((s) => s.id);
+          const activeSocketIds = new Set();
+
+          if (redisClient.isReady) {
+            const presenceKey = getPresenceKey(freshSession.roomId, serverId);
+            if (localSocketIds.length > 0) {
+              await redisClient.set(presenceKey, JSON.stringify(localSocketIds), { EX: 20 });
+            } else {
+              await redisClient.del(presenceKey);
+            }
+
+            // Retrieve all presence keys for this room across all active nodes in the cluster
+            const presenceKeys = await redisClient.keys(getPresencePattern(freshSession.roomId));
+            for (const key of presenceKeys) {
+              try {
+                const data = await redisClient.get(key);
+                if (data) {
+                  const ids = JSON.parse(data);
+                  if (Array.isArray(ids)) {
+                    ids.forEach((id) => activeSocketIds.add(id));
+                  }
+                }
+              } catch (parseErr) {
+                logger.error(`Error reading presence key ${key}:`, parseErr);
+              }
+            }
           } else {
-            const gracePeriodMs = 30000; // 30 seconds
-            const cutoffTime = new Date(Date.now() - gracePeriodMs);
-            if (session.emptySince < cutoffTime) {
-              logger.info(`Background Sweeper: Ending empty classroom session ${session.roomId}`);
-              session.status = "ended";
-              session.endedAt = new Date();
-              await session.save();
+            // Fallback to local active sockets in single-server deployments
+            localSocketIds.forEach((id) => activeSocketIds.add(id));
+          }
 
-              await clearRoomState(session.roomId);
-              clearRoomLock(session.roomId);
+          if (activeSocketIds.size === 0) {
+            // If the room has no active socket connections, check/set emptySince
+            if (!freshSession.emptySince) {
+              logger.info(`Background Sweeper: Room ${freshSession.roomId} is empty. Starting 30-second teardown countdown...`);
+              freshSession.emptySince = new Date();
+              await freshSession.save();
+            } else {
+              const gracePeriodMs = 30000; // 30 seconds
+              const cutoffTime = new Date(Date.now() - gracePeriodMs);
+              if (freshSession.emptySince < cutoffTime) {
+                logger.info(`Background Sweeper: Ending empty classroom session ${freshSession.roomId}`);
+                freshSession.status = "ended";
+                freshSession.endedAt = new Date();
+                await freshSession.save();
+
+                await clearRoomState(freshSession.roomId);
+                clearRoomLock(freshSession.roomId);
+              }
+            }
+          } else {
+            // If there are active sockets, ensure emptySince is null and participants list in DB is updated/cleaned
+            let dbChanged = false;
+            if (freshSession.emptySince !== null) {
+              freshSession.emptySince = null;
+              dbChanged = true;
+            }
+
+            // Clean up participants in DB that are no longer active sockets
+            const updatedParticipants = (freshSession.participants || []).filter((p) =>
+              activeSocketIds.has(p.socketId)
+            );
+            if (updatedParticipants.length !== (freshSession.participants || []).length) {
+              freshSession.participants = updatedParticipants;
+              dbChanged = true;
+            }
+
+            if (dbChanged) {
+              await freshSession.save();
             }
           }
-        } else {
-          // If there are active sockets, ensure emptySince is null and participants list in DB is updated/cleaned
-          let dbChanged = false;
-          if (session.emptySince !== null) {
-            session.emptySince = null;
-            dbChanged = true;
-          }
-
-          // Clean up participants in DB that are no longer active sockets
-          const activeSocketIds = new Set(activeSockets.map((s) => s.id));
-          const updatedParticipants = (session.participants || []).filter((p) =>
-            activeSocketIds.has(p.socketId)
-          );
-          if (updatedParticipants.length !== (session.participants || []).length) {
-            session.participants = updatedParticipants;
-            dbChanged = true;
-          }
-
-          if (dbChanged) {
-            await session.save();
-          }
+        } catch (err) {
+          logger.error(`Background Sweeper error for room ${session.roomId}:`, err);
+        } finally {
+          release();
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Overview

Fixes a classroom state desynchronization issue that could occur in clustered or load-balanced deployments.

Previously, the background sweeper relied solely on the local Socket.IO registry to determine whether a classroom was active. In multi-node environments, this could incorrectly mark an active classroom as empty if all connected participants were attached to a different server instance.

This PR introduces cluster-wide presence tracking using Redis, ensuring classroom activity is evaluated across all active server nodes before cleanup actions are performed.

---

## Related Issue

Closes #1449

---

## Type of Change

* [x] Architectural Improvement
* [x] Bug Fix
---

## Problem

The classroom sweeper previously verified activity using only local in-memory socket state.

As a result:

* Active classrooms could be mistaken as inactive.
* Participant lists could be pruned incorrectly.
* Teardown countdowns could start even when users were connected on another node.
* Classroom sessions could be terminated prematurely in clustered deployments.

This issue only appeared in multi-node or load-balanced environments and was not visible during single-node local development.

---

## Changes Made

### Cluster-Wide Presence Tracking

Updated:

```text
server/src/modules/classrooms/socket.js
```

Changes:

* Added a unique `serverId` for each application instance using Node.js crypto utilities.
* Introduced Redis-backed classroom presence tracking.
* Registered active room presence using:

```text
classroom:presence:${roomId}:${serverId}
```

* Added automatic TTL expiration (20 seconds) to prevent stale presence records after unexpected node failures.

### Distributed Activity Verification

* Updated the background sweeper to aggregate active socket presence across all server instances.
* Ensured classroom activity checks use cluster-wide presence instead of local memory state.
* Prevented active classrooms from being incorrectly terminated when participants are connected to remote nodes.

### Fallback Support

Implemented graceful degradation when Redis is unavailable:

* Falls back to existing local socket registry checks.
* Preserves compatibility for local development and single-node deployments.

### Test Coverage

Added and updated tests for both single-node and clustered deployment scenarios.

---

## Files Updated

```text
server/src/modules/classrooms/socket.js
server/src/modules/classrooms/__tests__/sweeper.test.js
```

---
## Result

The classroom sweeper now evaluates activity using cluster-wide presence information rather than node-local socket state. This prevents premature classroom termination, participant loss, and state desynchronization in distributed deployments while maintaining compatibility with single-node environments.
