### PR TITLE
fix: support standalone MongoDB topologies by bypassing transactions …

### DIFF
--- a/server/src/modules/interviews/service.js
+++ b/server/src/modules/interviews/service.js
@@ -300,28 +300,46 @@ export const finalizeInterview = async (sessionId, userId) => {
   // Calculate duration
   const duration = Math.round((Date.now() - session.startedAt.getTime()) / 1000);
 
-  const dbSession = await mongoose.startSession();
-  dbSession.startTransaction();
+  const client = mongoose.connection?.client;
+  const topologyType = client?.topology?.description?.type;
+  const useTransaction = topologyType && (
+    topologyType.includes("ReplicaSet") ||
+    topologyType === "Sharded" ||
+    (client?.topology?.description?.servers && client.topology.description.servers.size > 1)
+  );
 
-  try {
+  if (useTransaction) {
+    const dbSession = await mongoose.startSession();
+    dbSession.startTransaction();
+
+    try {
+      session.status = "completed";
+      session.overallScore = overallScore;
+      session.weakConcepts = weakConcepts;
+      session.duration = duration;
+      session.completedAt = new Date();
+      
+      // Save within the transaction
+      await session.save({ session: dbSession });
+      
+      // If future logic updates LearningProgress here, it should pass { session: dbSession }
+      
+      await dbSession.commitTransaction();
+    } catch (error) {
+      await dbSession.abortTransaction();
+      logger.error("Transaction aborted in finalizeInterview:", error);
+      throw error;
+    } finally {
+      dbSession.endSession();
+    }
+  } else {
     session.status = "completed";
     session.overallScore = overallScore;
     session.weakConcepts = weakConcepts;
     session.duration = duration;
     session.completedAt = new Date();
     
-    // Save within the transaction
-    await session.save({ session: dbSession });
-    
-    // If future logic updates LearningProgress here, it should pass { session: dbSession }
-    
-    await dbSession.commitTransaction();
-  } catch (error) {
-    await dbSession.abortTransaction();
-    logger.error("Transaction aborted in finalizeInterview:", error);
-    throw error;
-  } finally {
-    dbSession.endSession();
+    await session.save();
   }
 
   return {

--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -609,11 +609,54 @@ export const applyToJob = async (jobId, applicantId, options = {}) => {
     throw new AppError("You have already applied to this job", 409);
   }
 
-  const session = await mongoose.startSession();
-  session.startTransaction();
+  const client = mongoose.connection?.client;
+  const topologyType = client?.topology?.description?.type;
+  const useTransaction = topologyType && (
+    topologyType.includes("ReplicaSet") ||
+    topologyType === "Sharded" ||
+    (client?.topology?.description?.servers && client.topology.description.servers.size > 1)
+  );
 
   let application;
-  try {
+  if (useTransaction) {
+    const session = await mongoose.startSession();
+    session.startTransaction();
+
+    try {
+      const appDocs = await JobApplication.create([{
+        job: jobId,
+        applicant: applicantId,
+        resume: options.resumeId || null,
+        resumeLink: options.resumeLink.trim(),
+        coverNote: options.coverNote?.trim() || "",
+        statusHistory: [{ status: "pending", comment: "Application submitted" }],
+      }], { session });
+      
+      application = appDocs[0];
+
+      const notifDocs = await Notification.create([{
+        userId: job.recruiter,
+        type: "new_application",
+        title: "New Job Application",
+        message: `A new candidate has applied for ${job.title}.`,
+        relatedData: { jobId: job._id, applicationId: application._id, studentId: applicantId }
+      }], { session });
+
+      await session.commitTransaction();
+
+      const io = getIO();
+      if (io && notifDocs[0]) {
+        io.to(`user_${job.recruiter}`).emit("new-notification", notifDocs[0]);
+      }
+
+    } catch (error) {
+      await session.abortTransaction();
+      logger.error("Transaction aborted in applyToJob:", error);
+      throw error;
+    } finally {
+      session.endSession();
+    }
+  } else {
     const appDocs = await JobApplication.create([{
       job: jobId,
       applicant: applicantId,
@@ -621,7 +664,7 @@ export const applyToJob = async (jobId, applicantId, options = {}) => {
       resumeLink: options.resumeLink.trim(),
       coverNote: options.coverNote?.trim() || "",
       statusHistory: [{ status: "pending", comment: "Application submitted" }],
-    }], { session });
+    }]);
     
     application = appDocs[0];
 
@@ -631,21 +674,12 @@ export const applyToJob = async (jobId, applicantId, options = {}) => {
       title: "New Job Application",
       message: `A new candidate has applied for ${job.title}.`,
       relatedData: { jobId: job._id, applicationId: application._id, studentId: applicantId }
-    }], { session });
-
-    await session.commitTransaction();
+    }]);
 
     const io = getIO();
-    if (io) {
+    if (io && notifDocs[0]) {
       io.to(`user_${job.recruiter}`).emit("new-notification", notifDocs[0]);
     }
-
-  } catch (error) {
-    await session.abortTransaction();
-    logger.error("Transaction aborted in applyToJob:", error);
-    throw error;
-  } finally {
-    session.endSession();
   }
 
   // Evaluate candidate match asynchronously

--- a/server/src/modules/users/__tests__/controller.delete.test.js
+++ b/server/src/modules/users/__tests__/controller.delete.test.js
@@ -65,6 +65,7 @@ test("deleteProfile - cascades deletion to files and relational models", async (
   mock.method(MatchResult, "deleteMany", async () => ({ deletedCount: 1 }));
   mock.method(MatchResult, "updateMany", async () => ({ modifiedCount: 1 }));
   mock.method(LearningProgress, "deleteMany", async () => ({ deletedCount: 1 }));
+  mock.method(LearningProgress, "updateMany", async () => ({ modifiedCount: 1 }));
   mock.method(JobApplication, "deleteMany", async () => ({ deletedCount: 1 }));
   mock.method(CoverLetter, "deleteMany", async () => ({ deletedCount: 1 }));
   mock.method(InterviewSession, "find", () => ({ session: async () => [mockInterviewSession] }));

--- a/server/src/utils/__tests__/cascadeDelete.test.js
+++ b/server/src/utils/__tests__/cascadeDelete.test.js
@@ -63,6 +63,7 @@ test("cascadeDeleteUser sweeps all physical files and databases", async () => {
   mock.method(MatchResult, "deleteMany", async () => ({ deletedCount: 1 }));
   mock.method(MatchResult, "updateMany", async () => ({ modifiedCount: 1 }));
   mock.method(LearningProgress, "deleteMany", async () => ({ deletedCount: 1 }));
+  mock.method(LearningProgress, "updateMany", async () => ({ modifiedCount: 1 }));
   mock.method(JobApplication, "deleteMany", async () => ({ deletedCount: 1 }));
   mock.method(CoverLetter, "deleteMany", async () => ({ deletedCount: 1 }));
   mock.method(InterviewSession, "find", () => ({ session: async () => [mockInterviewSession] }));

--- a/server/src/utils/cascadeDelete.js
+++ b/server/src/utils/cascadeDelete.js
@@ -31,8 +31,18 @@ export const cascadeDeleteUser = async (userId) => {
     return;
   }
 
-  const session = await mongoose.startSession();
-  session.startTransaction();
+  const client = mongoose.connection?.client;
+  const topologyType = client?.topology?.description?.type;
+  const useTransaction = topologyType && (
+    topologyType.includes("ReplicaSet") ||
+    topologyType === "Sharded" ||
+    (client?.topology?.description?.servers && client.topology.description.servers.size > 1)
+  );
+
+  const session = useTransaction ? await mongoose.startSession() : null;
+  if (session) {
+    session.startTransaction();
+  }
 
   let resumes = [];
   let interviewSessions = [];
@@ -130,13 +140,19 @@ await LearningProgress.updateMany(
     // 6. Delete User document itself
     await User.findByIdAndDelete(userId, { session });
 
-    await session.commitTransaction();
+    if (session) {
+      await session.commitTransaction();
+    }
   } catch (error) {
-    await session.abortTransaction();
+    if (session) {
+      await session.abortTransaction();
+    }
     logger.error("Transaction aborted in cascadeDeleteUser:", error);
     throw error;
   } finally {
-    session.endSession();
+    if (session) {
+      session.endSession();
+    }
   }
 
   // 1. Delete profile picture from Cloudinary, or from disk for legacy local avatars.


### PR DESCRIPTION
## Summary

This change resolves runtime crashes on standalone MongoDB deployments (such as local setups and the default docker-compose stack) by detecting if the MongoDB topology supports transactions, bypassing transaction sessions, and falling back to sequential database writes where needed.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #1455 

## Changes Made

- **Environment-Aware Transaction Bypassing**: Updated `applyToJob`, `finalizeInterview`, and `cascadeDeleteUser` to check MongoDB client topology before starting sessions.
- **Fixed Mocks in Unit Tests**: Mocked `LearningProgress.updateMany()` in `cascadeDelete.test.js` and `controller.delete.test.js` to resolve timeout failures during unit tests.

## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated

