### PR TITLE
fix(server): clear classroom cleanup timer on process shutdown

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -33,7 +33,7 @@ import analyticsRoutes from "./src/modules/analytics/routes.js";
 import authRoutes from "./src/modules/auth/routes.js";
 import createChatRouter from "./src/modules/chat/routes.js";
 import classroomRoutes from "./src/modules/classrooms/routes.js";
-import { initClassroomSockets } from "./src/modules/classrooms/socket.js";
+import { initClassroomSockets, stopClassroomSweeper } from "./src/modules/classrooms/socket.js";
 import coverLetterRoutes from "./src/modules/coverLetters/routes.js";
 import dashboardRoutes from "./src/modules/dashboard/routes.js";
 import errorReportRoutes from "./src/modules/errors/routes.js";
@@ -252,6 +252,7 @@ server.listen(PORT, () => {
 const gracefulShutdown = async (signal) => {
   logger.info(`\nReceived ${signal}. Gracefully shutting down...`);
   try {
+    stopClassroomSweeper();
     if (redisClient && redisClient.isReady) {
       await redisClient.quit();
       logger.info("Redis client disconnected.");

--- a/server/src/modules/classrooms/__tests__/sweeper.test.js
+++ b/server/src/modules/classrooms/__tests__/sweeper.test.js
@@ -1,6 +1,6 @@
 import { describe, it, afterEach, beforeEach, mock } from "node:test";
 import assert from "node:assert/strict";
-import { initClassroomSockets } from "../socket.js";
+import { initClassroomSockets, stopClassroomSweeper } from "../socket.js";
 import ClassroomSession from "../../../database/models/ClassroomSession.js";
 import { getRoomLock, Mutex } from "../../../utils/mutex.js";
 
@@ -155,5 +155,45 @@ describe("Classroom Background Sweeper", () => {
 
     assert.equal(ClassroomSession.findOne.mock.calls.length, 1);
     assert.equal(lockReleased, true);
+  });
+});
+
+describe("Classroom Sweeper Lifecycle", () => {
+  let mockIo;
+  let clearIntervalCalls;
+
+  beforeEach(() => {
+    mockIo = {
+      in: mock.fn(() => ({
+        fetchSockets: mock.fn(async () => [])
+      })),
+      on: mock.fn()
+    };
+
+    clearIntervalCalls = [];
+
+    // Mock setInterval and clearInterval
+    mock.method(globalThis, "setInterval", () => {
+      return "mock-timer-12345";
+    });
+
+    mock.method(globalThis, "clearInterval", (id) => {
+      clearIntervalCalls.push(id);
+    });
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  it("should start interval on init and clear it on stop", () => {
+    // 1. Initialize classroom sockets (should start interval)
+    initClassroomSockets(mockIo);
+    assert.equal(globalThis.setInterval.mock.calls.length, 1);
+
+    // 2. Stop classroom sweeper (should clear the interval)
+    stopClassroomSweeper();
+    assert.equal(clearIntervalCalls.length, 1);
+    assert.equal(clearIntervalCalls[0], "mock-timer-12345");
   });
 });

--- a/server/src/modules/classrooms/socket.js
+++ b/server/src/modules/classrooms/socket.js
@@ -88,9 +88,19 @@ export function getRoomState(roomId) {
   return roomStates.get(roomId);
 }
 
+let sweeperInterval = null;
+
+export function stopClassroomSweeper() {
+  if (sweeperInterval) {
+    clearInterval(sweeperInterval);
+    sweeperInterval = null;
+    logger.info("Classroom background sweeper stopped.");
+  }
+}
+
 export function initClassroomSockets(io) {
   // Start a periodic background sweeper to clean up empty classroom sessions across all instances
-  setInterval(async () => {
+  sweeperInterval = setInterval(async () => {
     try {
       const activeSessions = await ClassroomSession.find({ status: "active" });
 


### PR DESCRIPTION
## Overview

Fixes an active timer handle leak in the classroom module by ensuring the background sweeper interval is properly cleaned up during application shutdown.

Previously, the classroom socket manager created a periodic cleanup task using `setInterval()` but did not retain or clear the timer handle. As a result, the Node.js event loop continued running after shutdown signals or test completion, preventing graceful process termination.

This PR introduces a dedicated teardown mechanism and integrates it into the application's shutdown lifecycle.

---

## Related Issue

Closes #1450

---

## Type of Change

* [x] Bug Fix

---

## Problem

The classroom socket module initialized a long-running cleanup interval but never cleared it when:

* The server received shutdown signals (`SIGINT`, `SIGTERM`)
* Unit and integration tests completed
* The application restarted or terminated

This left an active timer handle in the Node.js event loop, causing the process to hang instead of exiting gracefully.

---

## Changes Made

### Classroom Sweeper Lifecycle Management

Updated:

```text
server/src/modules/classrooms/socket.js
```

Changes:

* Added a module-level `sweeperInterval` reference to track the active timer.
* Implemented and exported `stopClassroomSweeper()`.
* Added interval cleanup using `clearInterval()`.

### Graceful Shutdown Integration

Updated:

```text
server/index.js
```

Changes:

* Imported `stopClassroomSweeper`.
* Invoked the cleanup function during the graceful shutdown sequence.
* Ensured timer cleanup occurs alongside other resource shutdown operations.

### Test Coverage

Added tests validating:

* Background sweeper initialization.
* Proper interval cleanup through `stopClassroomSweeper()`.
* Correct timer handle lifecycle behavior.

---

## Files Updated

```text
server/index.js
server/src/modules/classrooms/socket.js
server/src/modules/classrooms/__tests__/sweeper.test.js
```

---

## Tests Added

* Added tests verifying `initClassroomSockets()` registers the cleanup interval.
* Added tests verifying `stopClassroomSweeper()` clears the active interval.
* Added tests covering sweeper lifecycle management.

---

## Result

The classroom background sweeper is now properly cleaned up during application shutdown. This eliminates the active timer handle leak, enables graceful process termination, and prevents test suites from hanging due to lingering interval timers.
