### PR TITLE
feat(notifications): implement bulk delete API and client integration

### DIFF
--- a/client/src/features/notifications/notificationsSlice.js
+++ b/client/src/features/notifications/notificationsSlice.js
@@ -113,6 +113,24 @@ export const clearAllNotifications = createAsyncThunk(
   }
 );
 
+/**
+ * Delete multiple notifications in bulk (with Optimistic UI updates)
+ */
+export const deleteNotificationsBulk = createAsyncThunk(
+  "notifications/deleteBulk",
+  async (ids, thunkAPI) => {
+    try {
+      const token = thunkAPI.getState()?.auth?.token;
+      if (!token) return thunkAPI.rejectWithValue("No auth token available");
+
+      await notificationService.deleteNotificationsBulk(ids, token);
+      return ids;
+    } catch (error) {
+      return thunkAPI.rejectWithValue(toErrorMessage(error, "Failed to delete notifications in bulk"));
+    }
+  }
+);
+
 const initialState = {
   items: [],
   unreadCount: 0,
@@ -287,6 +305,31 @@ const notificationsSlice = createSlice({
             state.unreadCount = snapshot.unreadCount;
             state.pagination = snapshot.pagination;
             state._rollbackSnapshot = null;
+          }
+          state.error = action.payload;
+        })
+
+      // Delete multiple notifications in bulk (Optimistic Update)
+      .addCase(deleteNotificationsBulk.pending, (state, action) => {
+          const ids = action.meta.arg;
+          const itemsToDelete = state.items.filter((item) => ids.includes(item._id));
+          
+          if (itemsToDelete.length > 0) {
+            state._rollbackBulkDeletedItems = itemsToDelete;
+            const unreadDeletedCount = itemsToDelete.filter((item) => !item.isRead).length;
+            state.unreadCount = Math.max(0, state.unreadCount - unreadDeletedCount);
+            state.items = state.items.filter((item) => !ids.includes(item._id));
+            state.pagination.total = Math.max(0, state.pagination.total - itemsToDelete.length);
+          }
+        })
+      .addCase(deleteNotificationsBulk.rejected, (state, action) => {
+          const deletedItems = state._rollbackBulkDeletedItems;
+          if (deletedItems && deletedItems.length > 0) {
+            state.items = [...state.items, ...deletedItems];
+            const unreadDeletedCount = deletedItems.filter((item) => !item.isRead).length;
+            state.unreadCount += unreadDeletedCount;
+            state.pagination.total += deletedItems.length;
+            state._rollbackBulkDeletedItems = null;
           }
           state.error = action.payload;
         });

--- a/client/src/modules/notifications/hooks/useNotifications.js
+++ b/client/src/modules/notifications/hooks/useNotifications.js
@@ -7,6 +7,7 @@ import {
   markAllAsRead,
   deleteNotificationById,
   clearAllNotifications,
+  deleteNotificationsBulk,
 } from "../../../features/notifications/notificationsSlice";
 
 /**
@@ -56,6 +57,14 @@ export const useNotifications = ({ page = 1, limit = 10, filter = "all", type } 
     dispatch(clearAllNotifications());
   }, [dispatch]);
 
+  // Delete multiple notifications in bulk
+  const handleDeleteNotificationsBulk = useCallback(
+    (notificationIds) => {
+      dispatch(deleteNotificationsBulk(notificationIds));
+    },
+    [dispatch],
+  );
+
   // Load more notifications (pagination)
   const handleLoadMore = useCallback(() => {
     const nextPage = pagination.page + 1;
@@ -75,6 +84,7 @@ export const useNotifications = ({ page = 1, limit = 10, filter = "all", type } 
     markAllAsRead: handleMarkAllAsRead,
     deleteNotification: handleDeleteNotification,
     deleteAllNotifications: handleDeleteAllNotifications,
+    deleteNotificationsBulk: handleDeleteNotificationsBulk,
     loadMore: handleLoadMore,
     hasMore: pagination.pages > 1 && pagination.page < pagination.pages,
   };

--- a/client/src/modules/notifications/pages/NotificationsPage.jsx
+++ b/client/src/modules/notifications/pages/NotificationsPage.jsx
@@ -95,6 +95,7 @@ const NotificationsPage = () => {
     markAllAsRead,
     deleteNotification,
     deleteAllNotifications,
+    deleteNotificationsBulk,
     loadMore,
     hasMore,
     socketStatus,
@@ -171,7 +172,7 @@ const NotificationsPage = () => {
         }?`,
       )
     ) {
-      selectedNotifications.forEach((id) => deleteNotification(id));
+      deleteNotificationsBulk(Array.from(selectedNotifications));
       setSelectedNotifications(new Set());
     }
   };

--- a/client/src/services/notificationService.js
+++ b/client/src/services/notificationService.js
@@ -88,3 +88,17 @@ export const deleteAllNotifications = async (token) => {
     token,
   });
 };
+
+/**
+ * Delete multiple notifications in a single request.
+ * @param {string[]} ids - Array of notification IDs to delete
+ * @param {string} token - The auth JWT token
+ * @returns {Promise<Object>} The bulk delete confirmation response
+ */
+export const deleteNotificationsBulk = async (ids, token) => {
+  return apiRequest("/api/notifications/bulk", {
+    method: "DELETE",
+    token,
+    body: { ids },
+  });
+};

--- a/server/src/modules/notifications/__tests__/controller.test.js
+++ b/server/src/modules/notifications/__tests__/controller.test.js
@@ -11,6 +11,7 @@ import {
   sanitizeNotificationMetadata,
   deleteNotificationById,
   deleteAllNotificationsForUser,
+  deleteNotificationsBulk,
 } from "../controller.js";
 import Notification from "../../../database/models/Notification.js";
 import AppError from "../../../utils/AppError.js";
@@ -468,6 +469,43 @@ describe("Notification Controller", () => {
         res.json.mock.calls[0].arguments[0].data.deletedCount,
         3,
       );
+    });
+  });
+
+  describe("deleteNotificationsBulk", () => {
+    it("should respond with 200 and deleted count when valid IDs list is provided", async () => {
+      mock.method(Notification, "deleteMany", () => ({ deletedCount: 2 }));
+
+      req.body = { ids: ["n1", "n2"] };
+      deleteNotificationsBulk(req, res, next);
+      await flush();
+
+      assert.equal(res.status.mock.calls[0].arguments[0], 200);
+      assert.equal(res.json.mock.calls[0].arguments[0].success, true);
+      assert.equal(
+        res.json.mock.calls[0].arguments[0].data.deletedCount,
+        2,
+      );
+    });
+
+    it("should throw AppError(400) when ids list is empty", async () => {
+      req.body = { ids: [] };
+      deleteNotificationsBulk(req, res, next);
+      await flush();
+
+      assert.equal(next.mock.calls.length, 1);
+      assert.ok(next.mock.calls[0].arguments[0] instanceof AppError);
+      assert.equal(next.mock.calls[0].arguments[0].statusCode, 400);
+    });
+
+    it("should throw AppError(400) when ids parameter is missing", async () => {
+      req.body = {};
+      deleteNotificationsBulk(req, res, next);
+      await flush();
+
+      assert.equal(next.mock.calls.length, 1);
+      assert.ok(next.mock.calls[0].arguments[0] instanceof AppError);
+      assert.equal(next.mock.calls[0].arguments[0].statusCode, 400);
     });
   });
 });

--- a/server/src/modules/notifications/controller.js
+++ b/server/src/modules/notifications/controller.js
@@ -9,6 +9,7 @@ import {
   deleteNotification,
   deleteAllNotifications,
   getUnreadNotificationCount,
+  deleteNotificationsBulk as deleteNotificationsBulkService,
 } from "./service.js";
 
 const decodeActionUrl = (value) => {
@@ -297,5 +298,27 @@ export const deleteAllNotificationsForUser = asyncHandler(async (req, res) => {
     success: true,
     data: { deletedCount: result.deletedCount },
     message: "All notifications deleted successfully",
+  });
+});
+
+/**
+ * @desc    Delete multiple notifications for user in bulk
+ * @route   DELETE /api/notifications/bulk
+ * @access  Private
+ */
+export const deleteNotificationsBulk = asyncHandler(async (req, res) => {
+  const { ids } = req.body;
+  const userId = req.user._id;
+
+  if (!ids || !Array.isArray(ids) || ids.length === 0) {
+    throw new AppError("Invalid or empty notification IDs list", 400);
+  }
+
+  const result = await deleteNotificationsBulkService(ids, userId.toString());
+
+  res.status(200).json({
+    success: true,
+    data: { deletedCount: result.deletedCount },
+    message: `${result.deletedCount} notifications deleted successfully`,
   });
 });

--- a/server/src/modules/notifications/routes.js
+++ b/server/src/modules/notifications/routes.js
@@ -9,6 +9,7 @@ import {
   markAllAsRead,
   deleteNotificationById,
   deleteAllNotificationsForUser,
+  deleteNotificationsBulk,
 } from "./controller.js";
 
 const router = express.Router();
@@ -23,6 +24,8 @@ router.get("/unread-count", getUnreadCount);
 router.post("/", createNotification);
 
 router.patch("/mark-all/read", markAllAsRead);
+
+router.delete("/bulk", deleteNotificationsBulk);
 
 router.get("/:id", getNotification);
 

--- a/server/src/modules/notifications/service.js
+++ b/server/src/modules/notifications/service.js
@@ -180,3 +180,17 @@ export const getUnreadNotificationCount = async (userId) => {
   const count = await Notification.countDocuments({ userId, isRead: false });
   return count;
 };
+
+/**
+ * Delete multiple notifications for a user in bulk
+ * @param {string[]} notificationIds - Array of Notification IDs
+ * @param {string} userId - User ID (for authorization)
+ * @returns {Promise<Object>} - Delete result containing deletedCount
+ */
+export const deleteNotificationsBulk = async (notificationIds, userId) => {
+  const result = await Notification.deleteMany({
+    _id: { $in: notificationIds },
+    userId: userId,
+  });
+  return result;
+};


### PR DESCRIPTION


## Summary

This change implements a unified Bulk Delete Notifications endpoint in the backend and integrates it with the Redux state and React UI on the client. It optimizes bulk checklist deletions, replacing multiple individual HTTP calls in a loop with a single API request.

## Type of Change

- [x] Feature

## Related Issue

Closes #1459 

## Changes Made

- **Backend**:
  - Implemented the `deleteNotificationsBulk` database method in [`server/src/modules/notifications/service.js`](file:///c:/Users/hp/SkillsSphere-AI/server/src/modules/notifications/service.js) to delete many records matching notification IDs and the user's ID.
  - Added the `deleteNotificationsBulk` handler in [`server/src/modules/notifications/controller.js`](file:///c:/Users/hp/SkillsSphere-AI/server/src/modules/notifications/controller.js) with validation checks.
  - Registered the `DELETE /api/notifications/bulk` route in [`server/src/modules/notifications/routes.js`](file:///c:/Users/hp/SkillsSphere-AI/server/src/modules/notifications/routes.js) before parameterized paths to prevent routing conflicts.
  - Added unit test coverage for successful and validation failure paths in [`server/src/modules/notifications/__tests__/controller.test.js`](file:///c:/Users/hp/SkillsSphere-AI/server/src/modules/notifications/__tests__/controller.test.js).
- **Frontend**:
  - Created the API wrapper `deleteNotificationsBulk` in [`client/src/services/notificationService.js`](file:///c:/Users/hp/SkillsSphere-AI/client/src/services/notificationService.js).
  - Configured the `deleteNotificationsBulk` async Redux thunk in [`client/src/features/notifications/notificationsSlice.js`](file:///c:/Users/hp/SkillsSphere-AI/client/src/features/notifications/notificationsSlice.js) with robust optimistic state updates and error rollback capabilities.
  - Exposed the bulk action through [`client/src/modules/notifications/hooks/useNotifications.js`](file:///c:/Users/hp/SkillsSphere-AI/client/src/modules/notifications/hooks/useNotifications.js).
  - Updated the selection delete click handler in [`client/src/modules/notifications/pages/NotificationsPage.jsx`](file:///c:/Users/hp/SkillsSphere-AI/client/src/modules/notifications/pages/NotificationsPage.jsx) to call the bulk action once instead of firing multiple individual delete calls inside a `.forEach` loop.

## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated


