### PR TITLE
fix: add rehype-sanitize to ReactMarkdown to prevent XSS

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.14.1",
     "recharts": "^3.8.1",
+    "rehype-sanitize": "^6.0.0",
     "simple-peer": "^9.11.1",
     "socket.io-client": "^4.8.3",
     "uuid": "^14.0.0",

--- a/client/src/modules/ai-assistant/components/MessageBubble.jsx
+++ b/client/src/modules/ai-assistant/components/MessageBubble.jsx
@@ -1,5 +1,6 @@
 import { Sparkles } from "lucide-react";
 import ReactMarkdown from "react-markdown";
+import rehypeSanitize from "rehype-sanitize";
 
 const MessageBubble = ({ sender, text }) => {
   const isUser = sender === "user";
@@ -33,6 +34,7 @@ const MessageBubble = ({ sender, text }) => {
         ) : (
           <div className="prose prose-sm dark:prose-invert prose-p:leading-relaxed prose-pre:bg-slate-800 prose-pre:text-slate-100 prose-a:text-violet-500 hover:prose-a:text-violet-600 max-w-none">
             <ReactMarkdown
+              rehypePlugins={[rehypeSanitize]}
               components={{
                 p: ({ node, ...props }) => <p className="m-0 mb-2 last:mb-0" {...props} />,
                 ul: ({ node, ...props }) => <ul className="m-0 pl-4 mb-2 last:mb-0 list-disc" {...props} />,


### PR DESCRIPTION
## Summary

Adds `rehype-sanitize` as a rehype plugin to the `ReactMarkdown` component in the AI assistant chat. Without it, malicious HTML embedded in AI responses (e.g. `<img onerror=...>`) could execute arbitrary scripts in the user's browser.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #1462

## Changes Made

- Installed `rehype-sanitize` package in `client/`
- Imported `rehypeSanitize` in `MessageBubble.jsx`
- Passed `rehypePlugins={[rehypeSanitize]}` to `<ReactMarkdown>`, stripping any unsafe HTML attributes/tags before rendering

## Validation

- [ ] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)