### PR TITLE
fix: add HTTP security headers via helmet (X-Frame-Options, HSTS, CSP, Permissions-Policy)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,6 @@
 import compression from "compression";
 import cors from "cors";
+import helmet from "helmet";
 import dotenv from "dotenv";
 import express from "express";
 import mongoose from "mongoose";
@@ -141,9 +142,32 @@ app.use(express.json({ limit: "1mb" }));
 app.use(requestLogger);
 
 // Security headers
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", "data:", "https:"],
+        connectSrc: ["'self'"],
+        fontSrc: ["'self'", "https:", "data:"],
+        objectSrc: ["'none'"],
+        upgradeInsecureRequests: [],
+      },
+    },
+    hsts: {
+      maxAge: 31536000,
+      includeSubDomains: true,
+      preload: true,
+    },
+    frameguard: { action: "deny" },
+    referrerPolicy: { policy: "no-referrer" },
+    permittedCrossDomainPolicies: false,
+  }),
+);
 app.use((req, res, next) => {
-  res.setHeader("Referrer-Policy", "no-referrer");
-  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
   next();
 });
 

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,7 @@
     "express": "^4.22.1",
     "express-rate-limit": "^8.5.2",
     "google-auth-library": "^10.6.2",
+    "helmet": "^8.2.0",
     "jsonwebtoken": "^9.0.3",
     "mammoth": "^1.12.0",
     "mongodb": "^7.2.0",


### PR DESCRIPTION
## Summary

Adds the `helmet` middleware to the Express server to set essential HTTP security headers that were previously missing. This closes the gap where responses lacked `X-Frame-Options`, `Strict-Transport-Security`, `Content-Security-Policy`, and `Permissions-Policy`.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #1463

## Changes Made

- Installed `helmet` in `server/`
- Replaced the hand-rolled `Referrer-Policy` / `X-Content-Type-Options` block with `helmet()` (which sets both plus many more)
- Configured CSP, HSTS (1-year + preload), `X-Frame-Options: DENY`, and `Permissions-Policy` restricting camera/microphone/geolocation

## Validation

- [ ] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)