### PR TITLE
fix: add aria-label and aria-expanded to AI chat toggle button

### DIFF
--- a/client/src/modules/ai-assistant/components/ChatWidget.jsx
+++ b/client/src/modules/ai-assistant/components/ChatWidget.jsx
@@ -9,6 +9,9 @@ const ChatWidget = () => {
     <>
       {/* Chat Panel */}
       <div
+        id="ai-chat-panel"
+        role="dialog"
+        aria-label="AI assistant chat"
         className={`fixed bottom-24 right-5 z-[1000] w-[calc(100vw-40px)] sm:w-[380px] h-[520px] transition-all duration-300 ease-out origin-bottom-right ${
           isOpen
             ? "scale-100 opacity-100 translate-y-0 pointer-events-auto"
@@ -21,6 +24,9 @@ const ChatWidget = () => {
       {/* Floating Action Button */}
       <button
         onClick={() => setIsOpen((prev) => !prev)}
+        aria-label={isOpen ? "Close AI assistant chat" : "Open AI assistant chat"}
+        aria-expanded={isOpen}
+        aria-controls="ai-chat-panel"
         className={`fixed bottom-5 right-5 z-[1000] w-14 h-14 rounded-full flex items-center justify-center shadow-lg transition-all duration-300 ${
           isOpen
             ? "bg-gray-200 dark:bg-slate-700 text-gray-600 dark:text-slate-300 rotate-0 hover:bg-gray-300 dark:hover:bg-slate-600"


### PR DESCRIPTION
## Summary

The AI assistant floating action button had no accessible label or expanded state, making it invisible to screen readers. This adds the required ARIA attributes so assistive technologies can identify and announce the button correctly.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #1464

## Changes Made

- Added `aria-label` (dynamic: "Open AI assistant chat" / "Close AI assistant chat") to the toggle button
- Added `aria-expanded={isOpen}` to reflect open/closed state
- Added `aria-controls="ai-chat-panel"` linking the button to the panel it controls
- Added `id="ai-chat-panel"`, `role="dialog"`, and `aria-label` to the chat panel div

## Validation

- [ ] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)