### PR TITLE
feat: enable Swagger/OpenAPI docs at /api-docs

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -19,7 +19,8 @@ import http from "http";
 import { Server } from "socket.io";
 import { logEvaluatorConfig } from "./src/config/evaluatorConfig.js";
 import redisClient, { connectRedis } from "./src/config/redis.js";
-// import swaggerSpec from "./src/config/swaggerConfig.js";
+import swaggerUi from "swagger-ui-express";
+import swaggerSpec from "./src/config/swaggerConfig.js";
 import connectDB, { isConnected } from "./src/database/db.js";
 import { protect, verifySocketToken } from "./src/middleware/authMiddleware.js";
 import globalErrorHandler from "./src/middleware/errorMiddleware.js";
@@ -195,7 +196,7 @@ app.get("/health", (req, res) => {
   });
 });
 
-// app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 
 


### PR DESCRIPTION
## Summary

Uncomments and wires up the pre-existing `swagger-ui-express` and `swagger-jsdoc` integration that was already installed but commented out. The interactive API docs are now served at `GET /api-docs`.

## Type of Change

- [x] Feature

## Related Issue

Closes #1466

## Changes Made

- Uncommented `import swaggerUi from "swagger-ui-express"` and `import swaggerSpec from "./src/config/swaggerConfig.js"` in `server/index.js`
- Uncommented `app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec))` to mount the Swagger UI

No new packages were installed — `swagger-jsdoc` and `swagger-ui-express` were already listed as dependencies.

## Validation

- [ ] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)

Visit `http://localhost:5000/api-docs` after starting the server to see the Swagger UI.