### PR TITLE
Feature/mock interview bookmarked questions

### DIFF
--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -39,6 +39,7 @@ const InterviewLobby = lazy(() => import("../modules/mock-interview/pages/Interv
 const InterviewSession = lazy(() => import("../modules/mock-interview/pages/InterviewSession"));
 const InterviewResults = lazy(() => import("../modules/mock-interview/pages/InterviewResults"));
 const InterviewHistory = lazy(() => import("../modules/mock-interview/pages/InterviewHistory"));
+const BookmarkedQuestions = lazy(() => import("../modules/mock-interview/pages/BookmarkedQuestions"));
 const TutorInterviewConsole = lazy(() => import("../modules/mock-interview/pages/TutorInterviewConsole"));
 const TutorInterviewsList = lazy(() => import("../modules/mock-interview/pages/TutorInterviewsList"));
 const TutorAnalyticsDashboard = lazy(() => import("../modules/analytics/TutorAnalyticsDashboard"));
@@ -284,6 +285,14 @@ function App() {
           element={
             <ProtectedRoute requiredRole="student">
               <InterviewHistory />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/mock-interview/bookmarks"
+          element={
+            <ProtectedRoute requiredRole="student">
+              <BookmarkedQuestions />
             </ProtectedRoute>
           }
         />

--- a/client/src/modules/mock-interview/hooks/useInterviewState.js
+++ b/client/src/modules/mock-interview/hooks/useInterviewState.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { submitAnswer, completeInterview } from "../services/interviewService";
+import { submitAnswer, completeInterview, toggleQuestionBookmark } from "../services/interviewService";
 import { apiRequest } from "../../../services/apiClient";
 import {
   saveInterviewSession,
@@ -88,6 +88,7 @@ export const useInterviewState = (sessionId, isObserver) => {
   const [mediaWarning, setMediaWarning] = useState(null);
   const [recoveryMessage, setRecoveryMessage] = useState(null);
   const [failedAction, setFailedAction] = useState(null);
+  const [bookmarking, setBookmarking] = useState(false);
 
   const debouncedAnalyze = useRef(
     debounce((text) => {
@@ -192,6 +193,7 @@ export const useInterviewState = (sessionId, isObserver) => {
         const question = {
           questionText: data.answers[idx]?.questionText,
           questionId: data.answers[idx]?.questionId,
+          bookmarked: Boolean(data.answers[idx]?.bookmarked),
         };
         const savedDraft = loadInterviewAnswerDraft({
           sessionId,
@@ -270,6 +272,75 @@ export const useInterviewState = (sessionId, isObserver) => {
       }, 3000);
     }
   }, [currentIndex, currentQuestion?.questionId, sessionId]);
+
+  const toggleCurrentQuestionBookmark = async () => {
+    if (!currentQuestion?.questionId || bookmarking) return;
+
+    const nextBookmarked = !Boolean(currentQuestion.bookmarked);
+    const previousQuestion = currentQuestion;
+
+    setBookmarking(true);
+    setError(null);
+    setCurrentQuestion((question) => ({
+      ...question,
+      bookmarked: nextBookmarked,
+    }));
+    setSession((currentSession) => {
+      if (!currentSession?.answers) return currentSession;
+      return {
+        ...currentSession,
+        answers: currentSession.answers.map((item) =>
+          item.questionId?.toString?.() === currentQuestion.questionId?.toString?.() ||
+          item.questionId === currentQuestion.questionId
+            ? { ...item, bookmarked: nextBookmarked }
+            : item,
+        ),
+      };
+    });
+
+    try {
+      const response = await toggleQuestionBookmark(
+        sessionId,
+        currentQuestion.questionId,
+        nextBookmarked,
+      );
+      const savedBookmarked = Boolean(response.data?.bookmarked);
+      setCurrentQuestion((question) => ({
+        ...question,
+        bookmarked: savedBookmarked,
+      }));
+      setSession((currentSession) => {
+        if (!currentSession?.answers) return currentSession;
+        return {
+          ...currentSession,
+          answers: currentSession.answers.map((item) =>
+            item.questionId?.toString?.() === currentQuestion.questionId?.toString?.() ||
+            item.questionId === currentQuestion.questionId
+              ? { ...item, bookmarked: savedBookmarked }
+              : item,
+          ),
+        };
+      });
+    } catch (err) {
+      setCurrentQuestion(previousQuestion);
+      setSession((currentSession) => {
+        if (!currentSession?.answers) return currentSession;
+        return {
+          ...currentSession,
+          answers: currentSession.answers.map((item) =>
+            item.questionId?.toString?.() === previousQuestion.questionId?.toString?.() ||
+            item.questionId === previousQuestion.questionId
+              ? { ...item, bookmarked: Boolean(previousQuestion.bookmarked) }
+              : item,
+          ),
+        };
+      });
+      setError(err.message || "Could not update bookmark. Please try again.");
+      logger.error("[InterviewSessionState] Bookmark error:", err);
+    } finally {
+      setBookmarking(false);
+    }
+  };
 
   const handleAnswerChange = (e, socket) => {
     const nextAnswer = e.target.value;
@@ -393,6 +464,8 @@ export const useInterviewState = (sessionId, isObserver) => {
     handleEvaluationResult,
     failedAction,
     setFailedAction,
+    bookmarking,
+    toggleCurrentQuestionBookmark,
     formatTime,
   };
 };

--- a/client/src/modules/mock-interview/pages/BookmarkedQuestions.jsx
+++ b/client/src/modules/mock-interview/pages/BookmarkedQuestions.jsx
@@ -1,0 +1,181 @@
+import React, { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { ArrowLeft, Bookmark, Clock, Loader2, RefreshCw } from "lucide-react";
+import Navbar from "../../../shared/components/Navbar";
+import Footer from "../../../shared/components/Footer";
+import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
+import logger from "../../../utils/logger";
+import { getBookmarkedQuestions, toggleQuestionBookmark } from "../services/interviewService";
+
+const BookmarkedQuestions = () => {
+  useDocumentTitle("Bookmarked Interview Questions");
+  const navigate = useNavigate();
+  const [bookmarks, setBookmarks] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [updatingId, setUpdatingId] = useState(null);
+
+  const loadBookmarks = async () => {
+    setLoading(true);
+    setError("");
+
+    try {
+      const response = await getBookmarkedQuestions();
+      setBookmarks(response.data || []);
+    } catch (err) {
+      setError("Failed to load bookmarked questions.");
+      logger.error("[BookmarkedQuestions] Load error:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadBookmarks();
+  }, []);
+
+  const removeBookmark = async (bookmark) => {
+    const bookmarkKey = `${bookmark.sessionId}-${bookmark.questionId}`;
+    setUpdatingId(bookmarkKey);
+    setError("");
+
+    try {
+      await toggleQuestionBookmark(bookmark.sessionId, bookmark.questionId, false);
+      setBookmarks((current) =>
+        current.filter(
+          (item) =>
+            item.sessionId !== bookmark.sessionId ||
+            item.questionId !== bookmark.questionId,
+        ),
+      );
+    } catch (err) {
+      setError("Could not remove bookmark. Please try again.");
+      logger.error("[BookmarkedQuestions] Remove error:", err);
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50/50 dark:bg-[#09090b] text-gray-900 dark:text-text-main font-sans pt-20 flex flex-col overflow-hidden relative">
+      <Navbar />
+      <main className="flex-grow flex flex-col items-center px-4 sm:px-6 lg:px-8 pb-12 w-full">
+        <div className="w-full max-w-[1000px] flex flex-col gap-6">
+          <div className="py-6 flex flex-wrap items-center justify-between gap-4">
+            <Link
+              to="/mock-interview/history"
+              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors"
+            >
+              <ArrowLeft size={16} />
+              Back to History
+            </Link>
+            <button
+              type="button"
+              onClick={loadBookmarks}
+              disabled={loading}
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-white dark:bg-surface px-4 py-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 disabled:opacity-60"
+            >
+              <RefreshCw size={15} className={loading ? "animate-spin" : ""} />
+              Refresh
+            </button>
+          </div>
+
+          <div className="text-center space-y-3 mb-4">
+            <div className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-amber-50 dark:bg-amber-500/10 border border-amber-100 dark:border-amber-500/20 shadow-sm text-[11px] font-bold text-amber-700 dark:text-amber-300 mx-auto tracking-wide uppercase">
+              <Bookmark size={12} fill="currentColor" /> Saved for review
+            </div>
+            <h1 className="text-4xl md:text-5xl font-black text-gray-900 dark:text-white tracking-tight">
+              Bookmarked Questions
+            </h1>
+            <p className="text-gray-500 dark:text-gray-400 text-[15px] max-w-2xl mx-auto font-medium">
+              Revisit the prompts you marked during mock interviews.
+            </p>
+          </div>
+
+          {error && (
+            <div role="alert" className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+              {error}
+            </div>
+          )}
+
+          {loading ? (
+            <div className="flex min-h-[240px] items-center justify-center rounded-2xl border border-border bg-white dark:bg-surface text-text-muted">
+              <Loader2 className="mr-2 animate-spin" size={22} />
+              Loading bookmarks...
+            </div>
+          ) : bookmarks.length === 0 ? (
+            <div className="text-center py-16 px-8 text-text-muted flex flex-col items-center bg-white dark:bg-surface border border-border rounded-2xl shadow-sm">
+              <Bookmark size={44} className="mb-4 text-amber-400" />
+              <p className="mt-2 text-lg font-medium text-text-main">No bookmarked questions yet.</p>
+              <p className="mb-6">Bookmark questions during an interview or from your results page.</p>
+              <button
+                type="button"
+                onClick={() => navigate("/mock-interview")}
+                className="bg-gradient-to-r from-blue-600 to-indigo-600 text-white border-none py-3 px-6 rounded-xl font-semibold cursor-pointer"
+              >
+                Start Interview
+              </button>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-4">
+              {bookmarks.map((bookmark) => {
+                const bookmarkKey = `${bookmark.sessionId}-${bookmark.questionId}`;
+                return (
+                  <article
+                    key={bookmarkKey}
+                    className="bg-white dark:bg-surface border border-border rounded-2xl p-6 shadow-sm"
+                  >
+                    <div className="mb-4 flex flex-wrap items-center gap-2 text-xs font-bold uppercase tracking-wide text-text-muted">
+                      <span className="rounded-md bg-indigo-50 dark:bg-indigo-500/10 px-2 py-1 text-indigo-600 dark:text-indigo-300">
+                        {bookmark.topic}
+                      </span>
+                      <span className="rounded-md bg-gray-100 dark:bg-white/5 px-2 py-1 capitalize">
+                        {bookmark.difficulty}
+                      </span>
+                      {bookmark.completedAt && (
+                        <span className="inline-flex items-center gap-1 rounded-md bg-gray-100 dark:bg-white/5 px-2 py-1">
+                          <Clock size={12} />
+                          {new Date(bookmark.completedAt).toLocaleDateString()}
+                        </span>
+                      )}
+                    </div>
+                    <h2 className="text-lg font-bold leading-relaxed text-text-main">
+                      {bookmark.questionText}
+                    </h2>
+                    {bookmark.transcript && (
+                      <p className="mt-4 rounded-xl bg-gray-50 dark:bg-slate-900 p-4 text-sm leading-relaxed text-text-muted">
+                        <strong className="block text-text-main mb-1">Your answer:</strong>
+                        {bookmark.transcript}
+                      </p>
+                    )}
+                    <div className="mt-5 flex flex-wrap gap-3">
+                      <button
+                        type="button"
+                        onClick={() => navigate(`/mock-interview/${bookmark.sessionId}/results`)}
+                        className="rounded-full bg-indigo-50 dark:bg-indigo-500/10 px-4 py-2 text-sm font-bold text-indigo-600 dark:text-indigo-300"
+                      >
+                        View results
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => removeBookmark(bookmark)}
+                        disabled={updatingId === bookmarkKey}
+                        className="inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-bold text-amber-700 disabled:opacity-60 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300"
+                      >
+                        <Bookmark size={15} fill="currentColor" />
+                        Remove bookmark
+                      </button>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default BookmarkedQuestions;

--- a/client/src/modules/mock-interview/pages/InterviewHistory.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewHistory.jsx
@@ -16,6 +16,7 @@ import {
   Sparkles,
   Search,
   RotateCcw,
+  Bookmark,
 } from "lucide-react";
 import Navbar from "../../../shared/components/Navbar";
 import Footer from "../../../shared/components/Footer";
@@ -378,6 +379,13 @@ const InterviewHistory = () => {
                 </button>
               </div>
             )}
+            <button
+              type="button"
+              className="bg-white dark:bg-surface text-amber-700 dark:text-amber-300 border border-border py-2 px-5 rounded-full font-semibold text-sm cursor-pointer flex items-center gap-2 hover:border-amber-400/40 transition-colors shadow-sm"
+              onClick={() => navigate("/mock-interview/bookmarks")}
+            >
+              <Bookmark size={16} /> Bookmarked Questions
+            </button>
             <button
               className="bg-gradient-to-r from-blue-600 to-indigo-600 text-white border-none py-2 px-5 rounded-full font-semibold text-sm cursor-pointer flex items-center gap-2 hover:shadow-[0_10px_20px_rgba(79,70,229,0.3)] hover:-translate-y-0.5 transition-all"
               onClick={() => navigate("/mock-interview")}

--- a/client/src/modules/mock-interview/pages/InterviewHistory.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewHistory.jsx
@@ -11,10 +11,11 @@ import {
   Download,
   FileJson,
   ArrowLeft,
-  Trash2,
   History,
   Brain,
   Sparkles,
+  Search,
+  RotateCcw,
 } from "lucide-react";
 import Navbar from "../../../shared/components/Navbar";
 import Footer from "../../../shared/components/Footer";
@@ -24,6 +25,14 @@ import logger from "../../../utils/logger";
 
 const EXPORT_CSV_FILENAME = "interview-history.csv";
 const EXPORT_JSON_FILENAME = "interview-history.json";
+
+const DEFAULT_FILTERS = {
+  search: "",
+  difficulty: "",
+  status: "",
+  minScore: "",
+  maxScore: "",
+};
 
 const toDisplayValue = (value) => {
   if (Array.isArray(value)) return value.filter(Boolean).join("; ");
@@ -42,6 +51,50 @@ const getNestedScore = (session, key) =>
     session?.scoreBreakdown?.[key],
   );
 
+const getSessionTitle = (session) =>
+  firstAvailable(session?.title, session?.topic, session?.type, "Mock Interview");
+
+const getSessionScore = (session) => {
+  const score = Number(firstAvailable(session?.overallScore, session?.score, session?.scores?.overall, 0));
+  return Number.isFinite(score) ? score : 0;
+};
+
+const getSessionStatus = (session) =>
+  String(
+    firstAvailable(
+      session?.status,
+      session?.interviewStatus,
+      session?.state,
+      session?.completedAt || session?.finishedAt ? "completed" : "unknown",
+    ),
+  )
+    .toLowerCase()
+    .replace(/[\s_]+/g, "-");
+
+export const filterInterviewSessions = (interviews, filters = DEFAULT_FILTERS) => {
+  const searchTerm = filters.search.trim().toLowerCase();
+  const minScore = filters.minScore === "" ? null : Number(filters.minScore);
+  const maxScore = filters.maxScore === "" ? null : Number(filters.maxScore);
+  const difficulty = filters.difficulty.toLowerCase();
+  const status = filters.status.toLowerCase();
+
+  return interviews.filter((session) => {
+    const title = String(getSessionTitle(session)).toLowerCase();
+    const topic = String(session?.topic || "").toLowerCase();
+    const sessionDifficulty = String(session?.difficulty || "").toLowerCase();
+    const sessionStatus = getSessionStatus(session);
+    const score = getSessionScore(session);
+
+    const matchesSearch = !searchTerm || title.includes(searchTerm) || topic.includes(searchTerm);
+    const matchesDifficulty = !difficulty || sessionDifficulty === difficulty;
+    const matchesStatus = !status || sessionStatus === status;
+    const matchesMinScore = minScore === null || score >= minScore;
+    const matchesMaxScore = maxScore === null || score <= maxScore;
+
+    return matchesSearch && matchesDifficulty && matchesStatus && matchesMinScore && matchesMaxScore;
+  });
+};
+
 const normalizeInterviewForExport = (session) => {
   const technicalScore = getNestedScore(session, "technical");
   const communicationScore = getNestedScore(session, "communication");
@@ -57,7 +110,7 @@ const normalizeInterviewForExport = (session) => {
 
   return {
     id: session?._id || session?.id || "",
-    title: firstAvailable(session?.title, session?.topic, session?.type, "Mock Interview"),
+    title: getSessionTitle(session),
     type: firstAvailable(session?.type, session?.interviewType, session?.category, session?.topic),
     dateCompleted: firstAvailable(session?.completedAt, session?.finishedAt, session?.updatedAt, session?.createdAt),
     overallScore: firstAvailable(session?.overallScore, session?.score, session?.scores?.overall),
@@ -165,6 +218,7 @@ const InterviewHistory = () => {
   const [error, setError] = useState(null);
   const [exportingType, setExportingType] = useState(null);
   const [exportError, setExportError] = useState(null);
+  const [filters, setFilters] = useState(DEFAULT_FILTERS);
   const exportInProgressRef = useRef(false);
 
   const fetchHistory = async (page = 1) => {
@@ -226,6 +280,17 @@ const InterviewHistory = () => {
       exportInProgressRef.current = false;
       setExportingType(null);
     }
+  };
+
+  const filteredSessions = filterInterviewSessions(sessions, filters);
+  const filtersActive = Object.values(filters).some((value) => value !== "");
+
+  const updateFilter = (key, value) => {
+    setFilters((currentFilters) => ({ ...currentFilters, [key]: value }));
+  };
+
+  const resetFilters = () => {
+    setFilters(DEFAULT_FILTERS);
   };
 
   if (loading) {
@@ -344,8 +409,108 @@ const InterviewHistory = () => {
         </div>
       ) : (
         <>
+        <section className="bg-white dark:bg-surface border border-border rounded-2xl p-4 sm:p-5 shadow-sm">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-3">
+            <label className="lg:col-span-2 flex flex-col gap-1.5 text-xs font-bold uppercase tracking-wide text-text-muted">
+              Search
+              <div className="relative">
+                <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted" />
+                <input
+                  type="search"
+                  value={filters.search}
+                  onChange={(event) => updateFilter("search", event.target.value)}
+                  placeholder="Search topic or title"
+                  className="w-full rounded-xl border border-border bg-gray-50 dark:bg-white/5 py-2.5 pl-9 pr-3 text-sm font-medium text-text-main outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/10"
+                />
+              </div>
+            </label>
+
+            <label className="flex flex-col gap-1.5 text-xs font-bold uppercase tracking-wide text-text-muted">
+              Difficulty
+              <select
+                value={filters.difficulty}
+                onChange={(event) => updateFilter("difficulty", event.target.value)}
+                className="w-full rounded-xl border border-border bg-gray-50 dark:bg-white/5 py-2.5 px-3 text-sm font-medium text-text-main outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/10"
+              >
+                <option value="">All difficulties</option>
+                <option value="easy">Easy</option>
+                <option value="medium">Medium</option>
+                <option value="hard">Hard</option>
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-1.5 text-xs font-bold uppercase tracking-wide text-text-muted">
+              Status
+              <select
+                value={filters.status}
+                onChange={(event) => updateFilter("status", event.target.value)}
+                className="w-full rounded-xl border border-border bg-gray-50 dark:bg-white/5 py-2.5 px-3 text-sm font-medium text-text-main outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/10"
+              >
+                <option value="">All statuses</option>
+                <option value="completed">Completed</option>
+                <option value="in-progress">In progress</option>
+                <option value="failed">Failed</option>
+              </select>
+            </label>
+
+            <div className="grid grid-cols-2 gap-2">
+              <label className="flex flex-col gap-1.5 text-xs font-bold uppercase tracking-wide text-text-muted">
+                Min Score
+                <input
+                  type="number"
+                  min="0"
+                  max="100"
+                  value={filters.minScore}
+                  onChange={(event) => updateFilter("minScore", event.target.value)}
+                  className="w-full rounded-xl border border-border bg-gray-50 dark:bg-white/5 py-2.5 px-3 text-sm font-medium text-text-main outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/10"
+                />
+              </label>
+              <label className="flex flex-col gap-1.5 text-xs font-bold uppercase tracking-wide text-text-muted">
+                Max Score
+                <input
+                  type="number"
+                  min="0"
+                  max="100"
+                  value={filters.maxScore}
+                  onChange={(event) => updateFilter("maxScore", event.target.value)}
+                  className="w-full rounded-xl border border-border bg-gray-50 dark:bg-white/5 py-2.5 px-3 text-sm font-medium text-text-main outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/10"
+                />
+              </label>
+            </div>
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+            <p className="text-sm font-medium text-text-muted">
+              Showing {filteredSessions.length} of {sessions.length} interviews
+            </p>
+            <button
+              type="button"
+              onClick={resetFilters}
+              disabled={!filtersActive}
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-gray-50 dark:bg-white/5 px-4 py-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 transition-colors hover:border-indigo-400 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <RotateCcw size={15} />
+              Reset filters
+            </button>
+          </div>
+        </section>
+
+        {filteredSessions.length === 0 ? (
+          <div className="text-center py-16 px-8 text-text-muted flex flex-col items-center bg-white dark:bg-surface border border-border rounded-2xl shadow-sm">
+            <Search size={44} className="mb-4 text-indigo-400" />
+            <p className="mt-2 text-lg font-medium text-text-main">No matching interviews found.</p>
+            <p className="mb-6">Try adjusting your search or filters.</p>
+            <button
+              type="button"
+              onClick={resetFilters}
+              className="inline-flex items-center gap-2 bg-gradient-to-r from-blue-600 to-indigo-600 text-white border-none py-3 px-6 rounded-xl font-semibold cursor-pointer hover:shadow-[0_10px_20px_rgba(79,70,229,0.3)] hover:-translate-y-0.5 transition-all"
+            >
+              <RotateCcw size={18} /> Reset filters
+            </button>
+          </div>
+        ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {sessions.map((session) => (
+          {filteredSessions.map((session) => (
             <div
               key={session._id}
               className="bg-white dark:bg-surface border border-border shadow-[0_10px_20px_rgba(0,0,0,0.02)] dark:shadow-none rounded-2xl py-6 px-8 flex items-center justify-between cursor-pointer transition-all gap-4 flex-wrap hover:border-indigo-500/50 hover:shadow-[0_15px_30px_rgba(99,102,241,0.1)] hover:-translate-y-1"
@@ -354,7 +519,7 @@ const InterviewHistory = () => {
               }
             >
               <div className="flex flex-col gap-1.5 flex-1">
-                <span className="font-bold text-xl text-text-main capitalize">{session.topic}</span>
+                <span className="font-bold text-xl text-text-main capitalize">{getSessionTitle(session)}</span>
                 <div className="flex flex-wrap gap-2.5 text-xs text-text-muted mt-2 font-medium">
                   <span className="bg-gray-100 dark:bg-white/5 px-2 py-0.5 rounded-md">{formatDate(session.createdAt)}</span>
                   <span className="bg-indigo-50 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 px-2 py-0.5 rounded-md capitalize">
@@ -366,6 +531,9 @@ const InterviewHistory = () => {
                       {session.duration}s
                     </span>
                   )}
+                  <span className="bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 px-2 py-0.5 rounded-md capitalize">
+                    {getSessionStatus(session).replace("-", " ")}
+                  </span>
                   <span className="bg-gray-100 dark:bg-white/5 px-2 py-0.5 rounded-md">{session.totalQuestions} questions</span>
                 </div>
               </div>
@@ -378,8 +546,9 @@ const InterviewHistory = () => {
             </div>
           ))}
         </div>
+        )}
 
-          {pagination.pages > 1 && (
+          {pagination.pages > 1 && !filtersActive && (
             <Pagination
               currentPage={pagination.page}
               totalPages={pagination.pages}

--- a/client/src/modules/mock-interview/pages/InterviewResults.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewResults.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
-import { getResults } from "../services/interviewService";
+import { getResults, toggleQuestionBookmark } from "../services/interviewService";
 import InterviewResultsSkeleton from "../components/InterviewResultsSkeleton";
 import { analyzeText } from "../utils/sentiment";
 import { Radar, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, ResponsiveContainer } from 'recharts';
@@ -19,7 +19,8 @@ import {
   Video,
   Play,
   FileJson,
-  Sparkles
+  Sparkles,
+  Bookmark
 } from "lucide-react";
 import Navbar from "../../../shared/components/Navbar";
 import Footer from "../../../shared/components/Footer";
@@ -35,6 +36,8 @@ const InterviewResults = () => {
   const [results, setResults] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [bookmarkError, setBookmarkError] = useState(null);
+  const [bookmarkingQuestionId, setBookmarkingQuestionId] = useState(null);
   const [expandedCards, setExpandedCards] = useState({});
 
   useEffect(() => {
@@ -54,6 +57,48 @@ const InterviewResults = () => {
 
   const toggleCard = (idx) => {
     setExpandedCards((prev) => ({ ...prev, [idx]: !prev[idx] }));
+  };
+
+  const handleBookmarkToggle = async (answer) => {
+    if (!answer?.questionId || bookmarkingQuestionId) return;
+
+    const nextBookmarked = !Boolean(answer.bookmarked);
+    setBookmarkingQuestionId(answer.questionId);
+    setBookmarkError(null);
+    setResults((currentResults) => ({
+      ...currentResults,
+      answers: currentResults.answers.map((item) =>
+        item.questionId === answer.questionId
+          ? { ...item, bookmarked: nextBookmarked }
+          : item,
+      ),
+    }));
+
+    try {
+      const response = await toggleQuestionBookmark(sessionId, answer.questionId, nextBookmarked);
+      const savedBookmarked = Boolean(response.data?.bookmarked);
+      setResults((currentResults) => ({
+        ...currentResults,
+        answers: currentResults.answers.map((item) =>
+          item.questionId === answer.questionId
+            ? { ...item, bookmarked: savedBookmarked }
+            : item,
+        ),
+      }));
+    } catch (err) {
+      setResults((currentResults) => ({
+        ...currentResults,
+        answers: currentResults.answers.map((item) =>
+          item.questionId === answer.questionId
+            ? { ...item, bookmarked: Boolean(answer.bookmarked) }
+            : item,
+        ),
+      }));
+      setBookmarkError(err.message || "Could not update bookmark. Please try again.");
+      logger.error("[InterviewResults] Bookmark error:", err);
+    } finally {
+      setBookmarkingQuestionId(null);
+    }
   };
 
   const getScoreColor = (score) => {
@@ -286,6 +331,12 @@ const InterviewResults = () => {
       </div>
 
       {/* Weak Concepts */}
+      {bookmarkError && (
+        <div role="alert" className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+          {bookmarkError}
+        </div>
+      )}
+
       {results.weakConcepts?.length > 0 && (
         <div className="bg-amber-50 dark:bg-surface border border-amber-200 dark:border-amber-500/20 rounded-3xl p-8 dark:shadow-none animate-[fadeInUp_0.6s_ease-out]">
           <h3 className="text-lg font-bold mb-4 text-text-main flex items-center gap-2">
@@ -312,6 +363,12 @@ const InterviewResults = () => {
             <span className="font-semibold text-text-main flex-1 pr-4">
               Q{idx + 1}. {a.questionText}
             </span>
+            {a.bookmarked && (
+              <span className="mr-3 inline-flex items-center gap-1 rounded-full bg-amber-50 px-2.5 py-1 text-xs font-bold text-amber-700 dark:bg-amber-500/10 dark:text-amber-300">
+                <Bookmark size={13} fill="currentColor" />
+                Bookmarked
+              </span>
+            )}
             <span
               className="font-bold text-lg"
               style={{ color: getScoreColor(a.scores?.technical || 0) }}
@@ -326,6 +383,20 @@ const InterviewResults = () => {
           </div>
           {expandedCards[idx] && (
             <div className="px-6 pb-6 border-t border-border pt-4">
+              <button
+                type="button"
+                onClick={() => handleBookmarkToggle(a)}
+                disabled={bookmarkingQuestionId === a.questionId}
+                aria-pressed={Boolean(a.bookmarked)}
+                className={`mb-4 inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-bold transition-all disabled:cursor-not-allowed disabled:opacity-60 ${
+                  a.bookmarked
+                    ? "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300"
+                    : "border-gray-200 bg-gray-50 text-slate-600 hover:border-amber-300 hover:text-amber-600 dark:border-white/10 dark:bg-white/5 dark:text-slate-300"
+                }`}
+              >
+                <Bookmark size={16} fill={a.bookmarked ? "currentColor" : "none"} />
+                {a.bookmarked ? "Remove bookmark" : "Bookmark question"}
+              </button>
               <p className="text-text-muted leading-relaxed my-4 text-sm bg-gray-50 dark:bg-slate-900 p-4 rounded-xl">
                 <strong className="text-text-main block mb-2">Your Answer:</strong>{" "}
                 {a.transcript || "No answer submitted"}

--- a/client/src/modules/mock-interview/pages/InterviewSession.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewSession.jsx
@@ -32,7 +32,8 @@ import {
   WifiOff,
   RefreshCw,
   MicOff,
-  Info
+  Info,
+  Bookmark
 } from "lucide-react";
 
 const formatTime = (seconds) => {
@@ -287,8 +288,34 @@ const InterviewSession = () => {
           
           {/* Question Card */}
           <div className="bg-white dark:bg-slate-900/60 rounded-3xl p-8 sm:p-10 shadow-[0_20px_40px_rgba(0,0,0,0.04)] dark:shadow-none border border-gray-200 dark:border-slate-800 flex flex-col">
-            <div className="inline-flex self-start items-center gap-2 px-3 py-1 rounded-lg bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400 text-xs font-bold tracking-wide uppercase mb-6">
-              Question {state.currentIndex + 1}
+            <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+              <div className="inline-flex items-center gap-2 px-3 py-1 rounded-lg bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400 text-xs font-bold tracking-wide uppercase">
+                Question {state.currentIndex + 1}
+              </div>
+              {!isObserver && state.currentQuestion?.questionId && (
+                <button
+                  type="button"
+                  onClick={state.toggleCurrentQuestionBookmark}
+                  disabled={state.bookmarking}
+                  aria-pressed={Boolean(state.currentQuestion.bookmarked)}
+                  aria-label={
+                    state.currentQuestion.bookmarked
+                      ? "Remove bookmark from this question"
+                      : "Bookmark this question"
+                  }
+                  className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-bold transition-all disabled:cursor-not-allowed disabled:opacity-60 ${
+                    state.currentQuestion.bookmarked
+                      ? "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300"
+                      : "border-gray-200 bg-gray-50 text-slate-600 hover:border-amber-300 hover:text-amber-600 dark:border-white/10 dark:bg-white/5 dark:text-slate-300"
+                  }`}
+                >
+                  <Bookmark
+                    size={16}
+                    fill={state.currentQuestion.bookmarked ? "currentColor" : "none"}
+                  />
+                  {state.currentQuestion.bookmarked ? "Bookmarked" : "Bookmark"}
+                </button>
+              )}
             </div>
             <h2 className="text-2xl sm:text-3xl font-semibold leading-relaxed text-slate-900 dark:text-white tracking-tight">
               {state.currentQuestion?.questionText || "Loading question..."}

--- a/client/src/modules/mock-interview/pages/InterviewSession.test.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewSession.test.jsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import InterviewSession from "./InterviewSession";
 import { apiRequest } from "../../../services/apiClient";
-import { submitAnswer } from "../services/interviewService";
+import { submitAnswer, toggleQuestionBookmark } from "../services/interviewService";
 import { MemoryRouter } from "react-router-dom";
 
 const navigate = vi.fn();
@@ -57,6 +57,7 @@ vi.mock("../../../services/apiClient", () => ({
 vi.mock("../services/interviewService", () => ({
   submitAnswer: vi.fn(),
   completeInterview: vi.fn(),
+  toggleQuestionBookmark: vi.fn(),
 }));
 
 vi.mock("react-redux", async () => {
@@ -97,11 +98,13 @@ const sessionPayload = {
         questionId: "q1",
         questionText: "What is React?",
         transcript: "",
+        bookmarked: false,
       },
       {
         questionId: "q2",
         questionText: "What is state?",
         transcript: "",
+        bookmarked: true,
       },
     ],
   },
@@ -150,6 +153,14 @@ describe("InterviewSession recovery", () => {
         },
       },
     });
+    toggleQuestionBookmark.mockResolvedValue({
+      data: {
+        sessionId: "session-1",
+        questionId: "q1",
+        questionText: "What is React?",
+        bookmarked: true,
+      },
+    });
     socketHandlers = {};
     managerHandlers = {};
     socket.on.mockImplementation((event, handler) => {
@@ -179,6 +190,10 @@ describe("InterviewSession recovery", () => {
 
   it("shows disconnect and reconnect recovery messages", async () => {
     await renderSession();
+
+    await waitFor(() => {
+      expect(socketHandlers.connect).toEqual(expect.any(Function));
+    });
 
     act(() => socketHandlers.connect());
     act(() => socketHandlers.disconnect());
@@ -211,6 +226,25 @@ describe("InterviewSession recovery", () => {
     expect(screen.getByText("Question 2")).toBeInTheDocument();
     expect(screen.getByText("00:42")).toBeInTheDocument();
     expect(screen.getByText(/audio status/i)).toHaveTextContent("queued");
+  });
+
+  it("bookmarks the current question and persists the change", async () => {
+    await renderSession();
+
+    const bookmarkButton = screen.getByRole("button", { name: /bookmark this question/i });
+
+    await act(async () => {
+      fireEvent.click(bookmarkButton);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(toggleQuestionBookmark).toHaveBeenCalledWith("session-1", "q1", true);
+    });
+    expect(screen.getByRole("button", { name: /remove bookmark from this question/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 
   it("handles corrupted backup data safely", async () => {

--- a/client/src/modules/mock-interview/pages/__tests__/InterviewHistory.test.jsx
+++ b/client/src/modules/mock-interview/pages/__tests__/InterviewHistory.test.jsx
@@ -3,7 +3,7 @@ import { act } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import InterviewHistory, { convertToCSV } from "../InterviewHistory";
+import InterviewHistory, { convertToCSV, filterInterviewSessions } from "../InterviewHistory";
 import { getHistory } from "../../services/interviewService";
 
 vi.mock("../../services/interviewService", () => ({
@@ -84,7 +84,7 @@ describe("InterviewHistory export", () => {
 
     renderHistory();
 
-    await screen.findByText("No interviews yet. Start your first one!");
+    await screen.findByText("No interviews yet.");
     expect(screen.queryByRole("button", { name: /export interview history as csv/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /export interview history as json/i })).not.toBeInTheDocument();
 
@@ -212,5 +212,111 @@ describe("InterviewHistory export", () => {
     expect(csv).toContain('"Backend ""API"", Interview"');
     expect(csv).toContain('"Clear answer\nNeeds more depth"');
     expect(csv).toContain("70,65,80");
+  });
+});
+
+describe("InterviewHistory filtering", () => {
+  const filterSessions = [
+    {
+      _id: "session-1",
+      title: "React Hooks Interview",
+      topic: "frontend",
+      difficulty: "medium",
+      status: "completed",
+      createdAt: "2026-05-01T10:00:00.000Z",
+      overallScore: 84,
+      totalQuestions: 5,
+    },
+    {
+      _id: "session-2",
+      title: "Node API Practice",
+      topic: "backend",
+      difficulty: "hard",
+      status: "failed",
+      createdAt: "2026-05-02T10:00:00.000Z",
+      overallScore: 42,
+      totalQuestions: 4,
+    },
+    {
+      _id: "session-3",
+      title: "System Design Screen",
+      topic: "architecture",
+      difficulty: "easy",
+      status: "in_progress",
+      createdAt: "2026-05-03T10:00:00.000Z",
+      overallScore: 68,
+      totalQuestions: 6,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getHistory.mockResolvedValue({
+      data: { sessions: filterSessions, pagination: { page: 1, pages: 1, total: 3 } },
+    });
+  });
+
+  it("filters interview records by title or topic search", async () => {
+    renderHistory();
+
+    expect(await screen.findByText("React Hooks Interview")).toBeInTheDocument();
+
+    await act(async () => {
+      await userEvent.type(screen.getByLabelText(/search/i), "backend");
+    });
+
+    expect(screen.getByText("Node API Practice")).toBeInTheDocument();
+    expect(screen.queryByText("React Hooks Interview")).not.toBeInTheDocument();
+    expect(screen.queryByText("System Design Screen")).not.toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 3 interviews")).toBeInTheDocument();
+  });
+
+  it("filters by difficulty, status, and score range together", async () => {
+    renderHistory();
+
+    await screen.findByText("React Hooks Interview");
+    await act(async () => {
+      await userEvent.selectOptions(screen.getByLabelText(/difficulty/i), "hard");
+      await userEvent.selectOptions(screen.getByLabelText(/status/i), "failed");
+      await userEvent.type(screen.getByLabelText(/min score/i), "40");
+      await userEvent.type(screen.getByLabelText(/max score/i), "50");
+    });
+
+    expect(screen.getByText("Node API Practice")).toBeInTheDocument();
+    expect(screen.queryByText("React Hooks Interview")).not.toBeInTheDocument();
+    expect(screen.queryByText("System Design Screen")).not.toBeInTheDocument();
+  });
+
+  it("shows an empty filtered state and can reset filters", async () => {
+    renderHistory();
+
+    await screen.findByText("React Hooks Interview");
+    await act(async () => {
+      await userEvent.type(screen.getByLabelText(/search/i), "python");
+    });
+
+    expect(screen.getByText("No matching interviews found.")).toBeInTheDocument();
+    expect(screen.queryByText("React Hooks Interview")).not.toBeInTheDocument();
+
+    await act(async () => {
+      await userEvent.click(screen.getAllByRole("button", { name: /reset filters/i })[0]);
+    });
+
+    expect(screen.getByText("React Hooks Interview")).toBeInTheDocument();
+    expect(screen.getByText("Node API Practice")).toBeInTheDocument();
+    expect(screen.getByText("System Design Screen")).toBeInTheDocument();
+  });
+
+  it("exposes pure filtering behavior for status normalization and scores", () => {
+    const results = filterInterviewSessions(filterSessions, {
+      search: "design",
+      difficulty: "easy",
+      status: "in-progress",
+      minScore: "60",
+      maxScore: "70",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]._id).toBe("session-3");
   });
 });

--- a/client/src/modules/mock-interview/pages/__tests__/InterviewResults.test.jsx
+++ b/client/src/modules/mock-interview/pages/__tests__/InterviewResults.test.jsx
@@ -1,0 +1,114 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import InterviewResults from "../InterviewResults";
+import { getResults, toggleQuestionBookmark } from "../../services/interviewService";
+
+const navigate = vi.fn();
+
+vi.mock("../../services/interviewService", () => ({
+  getResults: vi.fn(),
+  toggleQuestionBookmark: vi.fn(),
+}));
+
+vi.mock("../../../../shared/components/Navbar", () => ({
+  default: () => <nav data-testid="navbar" />,
+}));
+
+vi.mock("../../../../shared/components/Footer", () => ({
+  default: () => <footer data-testid="footer" />,
+}));
+
+vi.mock("../../components/InterviewResultsSkeleton", () => ({
+  default: () => <div data-testid="results-skeleton" />,
+}));
+
+vi.mock("../../../../hooks/useDocumentTitle", () => ({
+  useDocumentTitle: vi.fn(),
+}));
+
+vi.mock("../../../../utils/logger", () => ({
+  default: { error: vi.fn() },
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useParams: () => ({ id: "session-1" }),
+    useNavigate: () => navigate,
+  };
+});
+
+vi.mock("recharts", () => ({
+  Radar: () => null,
+  RadarChart: ({ children }) => <div>{children}</div>,
+  PolarGrid: () => null,
+  PolarAngleAxis: () => null,
+  PolarRadiusAxis: () => null,
+  ResponsiveContainer: ({ children }) => <div>{children}</div>,
+}));
+
+const resultsPayload = {
+  data: {
+    topic: "react",
+    difficulty: "medium",
+    status: "completed",
+    overallScore: 82,
+    weakConcepts: [],
+    duration: 1200,
+    totalQuestions: 1,
+    answers: [
+      {
+        questionId: "q1",
+        questionText: "What are React hooks?",
+        transcript: "Hooks let function components use state.",
+        scores: { technical: 82, communication: 78, relevance: 80 },
+        concepts: { detected: ["hooks"], missed: [] },
+        bookmarked: true,
+      },
+    ],
+  },
+};
+
+const renderResults = async () => {
+  render(
+    <MemoryRouter>
+      <InterviewResults />
+    </MemoryRouter>,
+  );
+  await screen.findByText(/what are react hooks/i);
+};
+
+describe("InterviewResults bookmarks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getResults.mockResolvedValue(resultsPayload);
+    toggleQuestionBookmark.mockResolvedValue({
+      data: { questionId: "q1", bookmarked: false },
+    });
+  });
+
+  it("shows bookmarked status and allows removing the bookmark", async () => {
+    await renderResults();
+
+    expect(screen.getByText("Bookmarked")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(/what are react hooks/i));
+
+    const removeButton = screen.getByRole("button", { name: /remove bookmark/i });
+    await act(async () => {
+      fireEvent.click(removeButton);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(toggleQuestionBookmark).toHaveBeenCalledWith("session-1", "q1", false);
+    });
+    expect(screen.getByRole("button", { name: /bookmark question/i })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.queryByText("Bookmarked")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/modules/mock-interview/services/interviewService.js
+++ b/client/src/modules/mock-interview/services/interviewService.js
@@ -75,3 +75,18 @@ export const getHistory = async (page = 1, limit = 10) => {
     token: getToken(),
   });
 };
+
+export const toggleQuestionBookmark = async (sessionId, questionId, bookmarked) => {
+  return apiRequest(`/api/interviews/${sessionId}/questions/${questionId}/bookmark`, {
+    method: "PATCH",
+    token: getToken(),
+    body: { bookmarked },
+  });
+};
+
+export const getBookmarkedQuestions = async () => {
+  return apiRequest("/api/interviews/bookmarks", {
+    method: "GET",
+    token: getToken(),
+  });
+};

--- a/client/src/modules/profile/components/PreferencesSettings.jsx
+++ b/client/src/modules/profile/components/PreferencesSettings.jsx
@@ -9,10 +9,11 @@ import {
 const DEFAULT_PREFERENCES = {
   notifications: {
     emailNotifications: true,
+    inAppNotifications: true,
     interviewReminders: true,
-    jobAlerts: true,
-    applicationStatusUpdates: true,
-    platformUpdates: false,
+    jobUpdates: true,
+    resumeAnalysis: true,
+    systemAlerts: true,
   },
   emailFrequency: "weekly",
   privacy: {
@@ -24,11 +25,15 @@ const DEFAULT_PREFERENCES = {
 };
 
 const NOTIFICATION_OPTIONS = [
-  ["emailNotifications", "Email notifications"],
+  ["jobUpdates", "Job updates"],
   ["interviewReminders", "Interview reminders"],
-  ["jobAlerts", "Job alerts"],
-  ["applicationStatusUpdates", "Application status updates"],
-  ["platformUpdates", "Platform updates/news"],
+  ["resumeAnalysis", "Resume analysis"],
+  ["systemAlerts", "System alerts"],
+];
+
+const NOTIFICATION_CHANNELS = [
+  ["emailNotifications", "Email notifications"],
+  ["inAppNotifications", "In-app notifications"],
 ];
 
 const PRIVACY_TOGGLES = [
@@ -50,11 +55,17 @@ const PROFILE_VISIBILITIES = [
   ["private", "Private"],
 ];
 
+const mergeNotificationDefaults = (notifications = {}) => ({
+  emailNotifications: notifications.emailNotifications ?? DEFAULT_PREFERENCES.notifications.emailNotifications,
+  inAppNotifications: notifications.inAppNotifications ?? DEFAULT_PREFERENCES.notifications.inAppNotifications,
+  interviewReminders: notifications.interviewReminders ?? DEFAULT_PREFERENCES.notifications.interviewReminders,
+  jobUpdates: notifications.jobUpdates ?? notifications.jobAlerts ?? DEFAULT_PREFERENCES.notifications.jobUpdates,
+  resumeAnalysis: notifications.resumeAnalysis ?? DEFAULT_PREFERENCES.notifications.resumeAnalysis,
+  systemAlerts: notifications.systemAlerts ?? notifications.platformUpdates ?? DEFAULT_PREFERENCES.notifications.systemAlerts,
+});
+
 const mergeWithDefaults = (preferences = {}) => ({
-  notifications: {
-    ...DEFAULT_PREFERENCES.notifications,
-    ...(preferences.notifications || {}),
-  },
+  notifications: mergeNotificationDefaults(preferences.notifications),
   emailFrequency: preferences.emailFrequency || DEFAULT_PREFERENCES.emailFrequency,
   privacy: {
     ...DEFAULT_PREFERENCES.privacy,
@@ -247,6 +258,18 @@ const PreferencesSettings = ({ token }) => {
 
       <div className="space-y-4">
         <SettingsGroup title="Notification Preferences" icon={<Bell size={16} className="text-indigo-500" />}>
+          <div className="mb-4 grid gap-3 sm:grid-cols-2">
+            {NOTIFICATION_CHANNELS.map(([key, label]) => (
+              <ToggleRow
+                key={key}
+                id={`pref-${key}`}
+                label={label}
+                checked={preferences.notifications[key]}
+                disabled={saving}
+                onChange={(event) => updateNotification(key, event.target.checked)}
+              />
+            ))}
+          </div>
           <div className="grid gap-3 sm:grid-cols-2">
             {NOTIFICATION_OPTIONS.map(([key, label]) => (
               <ToggleRow

--- a/client/src/modules/profile/components/__tests__/PreferencesSettings.test.jsx
+++ b/client/src/modules/profile/components/__tests__/PreferencesSettings.test.jsx
@@ -15,10 +15,11 @@ vi.mock("../../services/profileService", () => ({
 const savedPreferences = {
   notifications: {
     emailNotifications: true,
+    inAppNotifications: true,
     interviewReminders: true,
-    jobAlerts: false,
-    applicationStatusUpdates: true,
-    platformUpdates: false,
+    jobUpdates: false,
+    resumeAnalysis: true,
+    systemAlerts: false,
   },
   emailFrequency: "weekly",
   privacy: {
@@ -44,7 +45,9 @@ describe("PreferencesSettings", () => {
     expect(screen.getByText(/loading preferences/i)).toBeInTheDocument();
 
     expect(await screen.findByText(/notification preferences/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/job alerts/i)).not.toBeChecked();
+    expect(screen.getByLabelText(/email notifications/i)).toBeChecked();
+    expect(screen.getByLabelText(/in-app notifications/i)).toBeChecked();
+    expect(screen.getByLabelText(/job updates/i)).not.toBeChecked();
     expect(screen.getByLabelText(/email frequency/i)).toHaveValue("weekly");
     expect(screen.getByLabelText(/profile visibility/i)).toHaveValue("recruiters");
     expect(getUserPreferences).toHaveBeenCalledWith("test-token");
@@ -56,7 +59,7 @@ describe("PreferencesSettings", () => {
     updateUserPreferences.mockResolvedValue({
       preferences: {
         ...savedPreferences,
-        notifications: { ...savedPreferences.notifications, jobAlerts: true },
+        notifications: { ...savedPreferences.notifications, jobUpdates: true, inAppNotifications: false },
         emailFrequency: "daily",
       },
     });
@@ -65,7 +68,8 @@ describe("PreferencesSettings", () => {
 
     await screen.findByText(/notification preferences/i);
     await act(async () => {
-      await user.click(screen.getByLabelText(/job alerts/i));
+      await user.click(screen.getByLabelText(/job updates/i));
+      await user.click(screen.getByLabelText(/in-app notifications/i));
       await user.selectOptions(screen.getByLabelText(/email frequency/i), "daily");
       await user.click(screen.getByRole("button", { name: /save settings/i }));
     });
@@ -77,7 +81,7 @@ describe("PreferencesSettings", () => {
     expect(updateUserPreferences).toHaveBeenCalledWith(
       expect.objectContaining({
         emailFrequency: "daily",
-        notifications: expect.objectContaining({ jobAlerts: true }),
+        notifications: expect.objectContaining({ jobUpdates: true, inAppNotifications: false }),
       }),
       "test-token",
     );
@@ -90,16 +94,16 @@ describe("PreferencesSettings", () => {
 
     renderSettings();
 
-    const jobAlerts = await screen.findByLabelText(/job alerts/i);
+    const jobUpdates = await screen.findByLabelText(/job updates/i);
     await act(async () => {
-      await user.click(jobAlerts);
+      await user.click(jobUpdates);
     });
-    expect(jobAlerts).toBeChecked();
+    expect(jobUpdates).toBeChecked();
 
     await act(async () => {
       await user.click(screen.getByRole("button", { name: /reset/i }));
     });
-    expect(jobAlerts).not.toBeChecked();
+    expect(jobUpdates).not.toBeChecked();
   });
 
   it("shows an error message when loading fails", async () => {
@@ -119,7 +123,7 @@ describe("PreferencesSettings", () => {
 
     await screen.findByText(/notification preferences/i);
     await act(async () => {
-      await user.click(screen.getByLabelText(/platform updates\/news/i));
+      await user.click(screen.getByLabelText(/system alerts/i));
       await user.click(screen.getByRole("button", { name: /save settings/i }));
     });
 
@@ -140,7 +144,7 @@ describe("PreferencesSettings", () => {
 
     await screen.findByText(/notification preferences/i);
     await act(async () => {
-      await user.click(screen.getByLabelText(/platform updates\/news/i));
+      await user.click(screen.getByLabelText(/system alerts/i));
       await user.click(screen.getByRole("button", { name: /save settings/i }));
     });
 

--- a/server/src/database/models/InterviewSession.js
+++ b/server/src/database/models/InterviewSession.js
@@ -53,6 +53,11 @@ const answerSchema = new mongoose.Schema(
       default: null,
     },
 
+    bookmarked: {
+      type: Boolean,
+      default: false,
+    },
+
     tutorScores: {
       technical: { type: Number, min: 0, max: 100 },
       communication: { type: Number, min: 0, max: 100 },

--- a/server/src/database/models/User.js
+++ b/server/src/database/models/User.js
@@ -101,10 +101,11 @@ const userSchema = new mongoose.Schema(
     preferences: {
       notifications: {
         emailNotifications: { type: Boolean, default: true },
+        inAppNotifications: { type: Boolean, default: true },
         interviewReminders: { type: Boolean, default: true },
-        jobAlerts: { type: Boolean, default: true },
-        applicationStatusUpdates: { type: Boolean, default: true },
-        platformUpdates: { type: Boolean, default: false },
+        jobUpdates: { type: Boolean, default: true },
+        resumeAnalysis: { type: Boolean, default: true },
+        systemAlerts: { type: Boolean, default: true },
       },
       emailFrequency: {
         type: String,

--- a/server/src/modules/interviews/__tests__/bookmarks.test.js
+++ b/server/src/modules/interviews/__tests__/bookmarks.test.js
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test, { afterEach, mock } from "node:test";
+import mongoose from "mongoose";
+import InterviewSession from "../../../database/models/InterviewSession.js";
+import {
+  getBookmarkedQuestions,
+  updateQuestionBookmark,
+} from "../service.js";
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+const userId = new mongoose.Types.ObjectId("64f1f77bcf86cd7994390a01");
+const sessionId = new mongoose.Types.ObjectId("64f1f77bcf86cd7994390aaa");
+const questionId = new mongoose.Types.ObjectId("64f1f77bcf86cd7994390c03");
+
+const createSessionDoc = (overrides = {}) => ({
+  _id: sessionId,
+  userId,
+  answers: [
+    {
+      questionId,
+      questionText: "What are React hooks?",
+      bookmarked: false,
+    },
+  ],
+  save: mock.fn(async () => {}),
+  ...overrides,
+});
+
+test("updateQuestionBookmark - sets bookmark state for an owned question", async () => {
+  const session = createSessionDoc();
+  const findOneMock = mock.method(InterviewSession, "findOne", async (query) => {
+    assert.equal(query._id, sessionId.toString());
+    assert.equal(query.userId, userId);
+    return session;
+  });
+
+  const result = await updateQuestionBookmark({
+    sessionId: sessionId.toString(),
+    userId,
+    questionId: questionId.toString(),
+    bookmarked: true,
+  });
+
+  assert.equal(result.bookmarked, true);
+  assert.equal(session.answers[0].bookmarked, true);
+  assert.equal(session.save.mock.callCount(), 1);
+  assert.deepEqual(session.save.mock.calls[0].arguments[0], { validateModifiedOnly: true });
+  assert.equal(findOneMock.mock.callCount(), 1);
+});
+
+test("updateQuestionBookmark - toggles bookmark when no explicit state is provided", async () => {
+  const session = createSessionDoc({
+    answers: [
+      {
+        questionId,
+        questionText: "What are React hooks?",
+        bookmarked: true,
+      },
+    ],
+  });
+  mock.method(InterviewSession, "findOne", async () => session);
+
+  const result = await updateQuestionBookmark({
+    sessionId: sessionId.toString(),
+    userId,
+    questionId: questionId.toString(),
+  });
+
+  assert.equal(result.bookmarked, false);
+  assert.equal(session.answers[0].bookmarked, false);
+});
+
+test("updateQuestionBookmark - rejects missing sessions and unknown questions", async () => {
+  mock.method(InterviewSession, "findOne", async () => null);
+
+  await assert.rejects(
+    updateQuestionBookmark({
+      sessionId: sessionId.toString(),
+      userId,
+      questionId: questionId.toString(),
+      bookmarked: true,
+    }),
+    /interview session not found/i,
+  );
+
+  mock.restoreAll();
+  mock.method(InterviewSession, "findOne", async () => createSessionDoc({ answers: [] }));
+
+  await assert.rejects(
+    updateQuestionBookmark({
+      sessionId: sessionId.toString(),
+      userId,
+      questionId: questionId.toString(),
+      bookmarked: true,
+    }),
+    /question not found/i,
+  );
+});
+
+test("getBookmarkedQuestions - returns flattened bookmarked answers", async () => {
+  const secondQuestionId = new mongoose.Types.ObjectId("64f1f77bcf86cd7994390d04");
+  const sessions = [
+    {
+      _id: sessionId,
+      topic: "react",
+      difficulty: "medium",
+      status: "completed",
+      overallScore: 82,
+      createdAt: new Date("2026-06-01T10:00:00.000Z"),
+      completedAt: new Date("2026-06-01T10:30:00.000Z"),
+      answers: [
+        {
+          questionId,
+          questionText: "What are React hooks?",
+          transcript: "Hooks share stateful logic.",
+          bookmarked: true,
+          scores: { technical: 80 },
+        },
+        {
+          questionId: secondQuestionId,
+          questionText: "What is JSX?",
+          bookmarked: false,
+        },
+      ],
+    },
+  ];
+
+  const findMock = mock.method(InterviewSession, "find", (query) => {
+    assert.equal(query.userId, userId);
+    assert.equal(query["answers.bookmarked"], true);
+    return {
+      select: () => ({
+        sort: () => ({
+          lean: async () => sessions,
+        }),
+      }),
+    };
+  });
+
+  const bookmarks = await getBookmarkedQuestions(userId);
+
+  assert.equal(findMock.mock.callCount(), 1);
+  assert.equal(bookmarks.length, 1);
+  assert.equal(bookmarks[0].questionText, "What are React hooks?");
+  assert.equal(bookmarks[0].topic, "react");
+  assert.equal(bookmarks[0].bookmarked, true);
+});

--- a/server/src/modules/interviews/controller.js
+++ b/server/src/modules/interviews/controller.js
@@ -9,6 +9,8 @@ import {
   getTutorSessionsList,
   getTutorSessionDetails,
   addTutorFeedback,
+  updateQuestionBookmark,
+  getBookmarkedQuestions,
 } from "./service.js";
 import { getServiceStatus } from "../../integrations/aiInterviewService.js";
 import asyncHandler from "../../utils/asyncHandler.js";
@@ -48,6 +50,7 @@ export const startInterview = asyncHandler(async (req, res) => {
             index: 0,
             questionText: session.answers[0].questionText,
             questionId: session.answers[0].questionId,
+            bookmarked: Boolean(session.answers[0].bookmarked),
           }
         : null,
     },
@@ -149,6 +152,47 @@ export const getSessionResults = asyncHandler(async (req, res) => {
   res.status(200).json({
     success: true,
     data: results,
+  });
+});
+
+/**
+ * @desc    Toggle or set bookmark state for an interview question
+ * @route   PATCH /api/interviews/:id/questions/:questionId/bookmark
+ * @access  Private
+ */
+export const bookmarkQuestion = asyncHandler(async (req, res) => {
+  if (
+    req.body?.bookmarked !== undefined &&
+    typeof req.body.bookmarked !== "boolean"
+  ) {
+    throw new AppError("bookmarked must be a boolean", 400);
+  }
+
+  const bookmark = await updateQuestionBookmark({
+    sessionId: req.params.id,
+    questionId: req.params.questionId,
+    userId: req.user._id,
+    bookmarked: req.body?.bookmarked,
+  });
+
+  res.status(200).json({
+    success: true,
+    message: bookmark.bookmarked ? "Question bookmarked" : "Question bookmark removed",
+    data: bookmark,
+  });
+});
+
+/**
+ * @desc    Get all bookmarked interview questions for the current user
+ * @route   GET /api/interviews/bookmarks
+ * @access  Private
+ */
+export const getInterviewBookmarks = asyncHandler(async (req, res) => {
+  const bookmarks = await getBookmarkedQuestions(req.user._id);
+
+  res.status(200).json({
+    success: true,
+    data: bookmarks,
   });
 });
 

--- a/server/src/modules/interviews/routes.js
+++ b/server/src/modules/interviews/routes.js
@@ -7,9 +7,11 @@ import { aiActionLimiter } from "../../middleware/rateLimiter.js";
 import AppError from "../../utils/AppError.js";
 import {
   completeInterview,
+  bookmarkQuestion,
   deleteInterviewSession,
   getAIServiceStatus,
   getAvailableTopics,
+  getInterviewBookmarks,
   getInterviewHistory,
   getSession,
   getSessionResults,
@@ -191,6 +193,7 @@ router.post("/start", aiActionLimiter, startInterview);
  *         description: List of previous sessions
  */
 router.get("/history", getInterviewHistory);
+router.get("/bookmarks", getInterviewBookmarks);
 
 // Tutor routes (must be before /:id to avoid route conflict)
 router.get("/tutor/sessions", authorizeRoles("tutor"), getTutorSessions);
@@ -211,6 +214,7 @@ router.post(
   submitAnswer,
 );
 router.post("/:id/complete", completeInterview);
+router.patch("/:id/questions/:questionId/bookmark", bookmarkQuestion);
 router.get("/:id/results", getSessionResults);
 
 export default router;

--- a/server/src/modules/interviews/service.js
+++ b/server/src/modules/interviews/service.js
@@ -227,6 +227,7 @@ export const processAnswerSubmission = async ({
           index: currentIndex + 1,
           questionText: session.answers[currentIndex + 1].questionText,
           questionId: session.answers[currentIndex + 1].questionId,
+          bookmarked: Boolean(session.answers[currentIndex + 1].bookmarked),
         }
       : null;
 
@@ -403,16 +404,84 @@ export const getSessionResults = async (sessionId, userId) => {
     duration: session.duration,
     totalQuestions: session.totalQuestions,
     answers: session.answers.map((a) => ({
+      questionId: a.questionId,
       questionText: a.questionText,
       transcript: a.transcript,
       scores: a.scores,
       concepts: a.concepts,
       fillerWords: a.fillerWords,
       speakingSpeed: a.speakingSpeed,
+      bookmarked: Boolean(a.bookmarked),
     })),
     startedAt: session.startedAt,
     completedAt: session.completedAt,
   };
+};
+
+export const updateQuestionBookmark = async ({
+  sessionId,
+  userId,
+  questionId,
+  bookmarked,
+}) => {
+  const session = await InterviewSession.findOne({
+    _id: sessionId,
+    userId,
+  });
+
+  if (!session) {
+    throw new AppError("Interview session not found", 404);
+  }
+
+  const answer = session.answers.find(
+    (item) => item.questionId?.toString() === questionId,
+  );
+
+  if (!answer) {
+    throw new AppError("Question not found in interview session", 404);
+  }
+
+  answer.bookmarked =
+    typeof bookmarked === "boolean" ? bookmarked : !Boolean(answer.bookmarked);
+
+  await session.save({ validateModifiedOnly: true });
+
+  return {
+    sessionId: session._id,
+    questionId: answer.questionId,
+    questionText: answer.questionText,
+    bookmarked: Boolean(answer.bookmarked),
+  };
+};
+
+export const getBookmarkedQuestions = async (userId) => {
+  const sessions = await InterviewSession.find({
+    userId,
+    "answers.bookmarked": true,
+  })
+    .select("topic difficulty status overallScore createdAt completedAt answers")
+    .sort({ createdAt: -1 })
+    .lean();
+
+  return sessions.flatMap((session) =>
+    (session.answers || [])
+      .filter((answer) => answer.bookmarked)
+      .map((answer) => ({
+        sessionId: session._id,
+        topic: session.topic,
+        difficulty: session.difficulty,
+        status: session.status,
+        overallScore: session.overallScore,
+        createdAt: session.createdAt,
+        completedAt: session.completedAt,
+        questionId: answer.questionId,
+        questionText: answer.questionText,
+        transcript: answer.transcript,
+        scores: answer.scores,
+        concepts: answer.concepts,
+        bookmarked: true,
+      })),
+  );
 };
 
 /**
@@ -515,6 +584,7 @@ export const getTutorSessionDetails = async (sessionId, tutorId) => {
       concepts: a.concepts || { detected: [], missed: [], expected: [] },
       fillerWords: a.fillerWords,
       speakingSpeed: a.speakingSpeed,
+      bookmarked: Boolean(a.bookmarked),
     })),
     startedAt: session.startedAt,
     completedAt: session.completedAt,

--- a/server/src/modules/users/__tests__/preferences.test.js
+++ b/server/src/modules/users/__tests__/preferences.test.js
@@ -59,6 +59,10 @@ test("getPreferences - returns defaults when preferences are missing", async () 
   assert.equal(responseStatus, 200);
   assert.equal(responseData.preferences.emailFrequency, "weekly");
   assert.equal(responseData.preferences.notifications.emailNotifications, true);
+  assert.equal(responseData.preferences.notifications.inAppNotifications, true);
+  assert.equal(responseData.preferences.notifications.jobUpdates, true);
+  assert.equal(responseData.preferences.notifications.resumeAnalysis, true);
+  assert.equal(responseData.preferences.notifications.systemAlerts, true);
   assert.equal(responseData.preferences.privacy.profileVisibility, "recruiters");
 });
 
@@ -66,7 +70,7 @@ test("getPreferences - returns saved preferences merged with safe defaults", asy
   const { responseData } = await waitForController(getPreferences, {
     userDoc: {
       preferences: {
-        notifications: { jobAlerts: false },
+        notifications: { jobUpdates: false, inAppNotifications: false },
         emailFrequency: "daily",
         privacy: { profileVisibility: "private" },
       },
@@ -74,9 +78,25 @@ test("getPreferences - returns saved preferences merged with safe defaults", asy
   });
 
   assert.equal(responseData.preferences.emailFrequency, "daily");
-  assert.equal(responseData.preferences.notifications.jobAlerts, false);
+  assert.equal(responseData.preferences.notifications.jobUpdates, false);
+  assert.equal(responseData.preferences.notifications.inAppNotifications, false);
   assert.equal(responseData.preferences.notifications.interviewReminders, true);
   assert.equal(responseData.preferences.privacy.profileVisibility, "private");
+});
+
+test("getPreferences - migrates legacy notification keys into current settings", async () => {
+  const { responseData } = await waitForController(getPreferences, {
+    userDoc: {
+      preferences: {
+        notifications: { jobAlerts: false, platformUpdates: false },
+      },
+    },
+  });
+
+  assert.equal(responseData.preferences.notifications.jobUpdates, false);
+  assert.equal(responseData.preferences.notifications.systemAlerts, false);
+  assert.equal(responseData.preferences.notifications.jobAlerts, undefined);
+  assert.equal(responseData.preferences.notifications.platformUpdates, undefined);
 });
 
 test("updatePreferences - updates valid preferences", async () => {
@@ -90,7 +110,11 @@ test("updatePreferences - updates valid preferences", async () => {
     body: {
       notifications: {
         emailNotifications: false,
+        inAppNotifications: false,
         interviewReminders: true,
+        jobUpdates: false,
+        resumeAnalysis: false,
+        systemAlerts: true,
       },
       emailFrequency: "instant",
       privacy: {
@@ -103,6 +127,10 @@ test("updatePreferences - updates valid preferences", async () => {
   assert.equal(responseStatus, 200);
   assert.equal(responseData.preferences.emailFrequency, "instant");
   assert.equal(responseData.preferences.notifications.emailNotifications, false);
+  assert.equal(responseData.preferences.notifications.inAppNotifications, false);
+  assert.equal(responseData.preferences.notifications.jobUpdates, false);
+  assert.equal(responseData.preferences.notifications.resumeAnalysis, false);
+  assert.equal(responseData.preferences.notifications.systemAlerts, true);
   assert.equal(responseData.preferences.privacy.profileVisibility, "public");
   assert.equal(responseData.preferences.privacy.showInterviewHistory, true);
   assert.equal(userDoc.save.mock.callCount(), 1);
@@ -131,7 +159,7 @@ test("updatePreferences - rejects invalid profile visibility", async () => {
 test("updatePreferences - rejects unknown fields", async () => {
   const { error } = await waitForController(updatePreferences, {
     userDoc: { preferences: {}, save: mock.fn(async () => {}) },
-    body: { notifications: { jobAlerts: true, smsNotifications: true } },
+    body: { notifications: { jobUpdates: true, smsNotifications: true } },
   });
 
   assert.equal(error.statusCode, 400);

--- a/server/src/modules/users/controller.js
+++ b/server/src/modules/users/controller.js
@@ -21,10 +21,11 @@ import logger from "../../utils/logger.js";
 export const DEFAULT_USER_PREFERENCES = {
   notifications: {
     emailNotifications: true,
+    inAppNotifications: true,
     interviewReminders: true,
-    jobAlerts: true,
-    applicationStatusUpdates: true,
-    platformUpdates: false,
+    jobUpdates: true,
+    resumeAnalysis: true,
+    systemAlerts: true,
   },
   emailFrequency: "weekly",
   privacy: {
@@ -47,6 +48,23 @@ const isPlainObject = (value) =>
 const toPlainPreferences = (preferences = {}) =>
   typeof preferences?.toObject === "function" ? preferences.toObject() : preferences || {};
 
+const normalizeNotificationPreferences = (notifications = {}) => {
+  if (!isPlainObject(notifications)) return {};
+
+  const normalized = {
+    emailNotifications: notifications.emailNotifications,
+    inAppNotifications: notifications.inAppNotifications,
+    interviewReminders: notifications.interviewReminders,
+    jobUpdates: notifications.jobUpdates ?? notifications.jobAlerts,
+    resumeAnalysis: notifications.resumeAnalysis,
+    systemAlerts: notifications.systemAlerts ?? notifications.platformUpdates,
+  };
+
+  return Object.fromEntries(
+    Object.entries(normalized).filter(([, value]) => value !== undefined),
+  );
+};
+
 export const getDefaultPreferences = () => ({
   notifications: { ...DEFAULT_USER_PREFERENCES.notifications },
   emailFrequency: DEFAULT_USER_PREFERENCES.emailFrequency,
@@ -59,7 +77,7 @@ export const mergePreferencesWithDefaults = (preferences = {}) => {
   return {
     notifications: {
       ...DEFAULT_USER_PREFERENCES.notifications,
-      ...(isPlainObject(plain.notifications) ? plain.notifications : {}),
+      ...normalizeNotificationPreferences(plain.notifications),
     },
     emailFrequency: plain.emailFrequency || DEFAULT_USER_PREFERENCES.emailFrequency,
     privacy: {

--- a/server/src/validations/users.validation.js
+++ b/server/src/validations/users.validation.js
@@ -16,11 +16,12 @@ export const updateProfileSchema = z.object({
 export const updatePreferencesSchema = z.object({
   notifications: z.object({
     emailNotifications: z.boolean().optional(),
+    inAppNotifications: z.boolean().optional(),
     interviewReminders: z.boolean().optional(),
-    jobAlerts: z.boolean().optional(),
-    applicationStatusUpdates: z.boolean().optional(),
-    platformUpdates: z.boolean().optional(),
+    jobUpdates: z.boolean().optional(),
+    resumeAnalysis: z.boolean().optional(),
+    systemAlerts: z.boolean().optional(),
   }).optional(),
-  emailFrequency: z.enum(['daily', 'weekly', 'monthly', 'never']).optional(),
+  emailFrequency: z.enum(['instant', 'daily', 'weekly', 'never']).optional(),
   privacy: z.record(z.any()).optional(),
 });


### PR DESCRIPTION
## Summary

Implemented bookmarked questions support for mock interviews, allowing users to save difficult questions and revisit them later for targeted practice.

## Changes Made

### Frontend

* Added bookmark/unbookmark functionality in the interview session.
* Persisted bookmark state on interview answers.
* Displayed bookmark status in:

  * Live Interview Session
  * Interview Results question breakdown
* Added a dedicated **Bookmarked Questions** page:

  * `/mock-interview/bookmarks`
* Added navigation entry point from Interview History to bookmarked questions.

### Backend

* Added bookmark API endpoints:

  * `PATCH /api/interviews/:id/questions/:questionId/bookmark`
  * `GET /api/interviews/bookmarks`
* Implemented controller and service logic for:

  * Toggling bookmarks
  * Retrieving bookmarked questions

### Testing

Added frontend and backend test coverage for bookmark functionality.

Frontend:

```bash
.\node_modules\.bin\vitest.cmd run src/modules/mock-interview/pages/InterviewSession.test.jsx src/modules/mock-interview/pages/__tests__/InterviewResults.test.jsx
```

Backend:

```bash
node --test src/modules/interviews/__tests__/bookmarks.test.js
```

## Test Results

* Frontend: 9 tests passed
* Backend: 4 tests passed

Note:

* Existing Vite CJS deprecation warning still appears during test execution.
* No new warnings or failures introduced by this feature.

## Impact

Users can now bookmark challenging interview questions, maintain a personalized review list, and revisit them later to improve weak areas and interview performance.

### Screenshot
<img width="1103" height="436" alt="Screenshot 2026-06-13 211147" src="https://github.com/user-attachments/assets/ef881666-79bf-4bc7-979d-d5746da1ab12" />
<img width="1444" height="806" alt="Screenshot 2026-06-13 210701" src="https://github.com/user-attachments/assets/2b42e8eb-ed6e-42d9-ac5d-f0472767ddf9" />
