### PR TITLE
fix(notifications): validate ObjectId format in bulk delete endpoint

### DIFF
--- a/server/src/modules/notifications/__tests__/controller.test.js
+++ b/server/src/modules/notifications/__tests__/controller.test.js
@@ -476,7 +476,7 @@ describe("Notification Controller", () => {
     it("should respond with 200 and deleted count when valid IDs list is provided", async () => {
       mock.method(Notification, "deleteMany", () => ({ deletedCount: 2 }));
 
-      req.body = { ids: ["n1", "n2"] };
+      req.body = { ids: ["507f1f77bcf86cd799439011", "507f1f77bcf86cd799439012"] };
       deleteNotificationsBulk(req, res, next);
       await flush();
 
@@ -500,6 +500,26 @@ describe("Notification Controller", () => {
 
     it("should throw AppError(400) when ids parameter is missing", async () => {
       req.body = {};
+      deleteNotificationsBulk(req, res, next);
+      await flush();
+
+      assert.equal(next.mock.calls.length, 1);
+      assert.ok(next.mock.calls[0].arguments[0] instanceof AppError);
+      assert.equal(next.mock.calls[0].arguments[0].statusCode, 400);
+    });
+
+    it("should throw AppError(400) when ids contains an invalid ObjectId", async () => {
+      req.body = { ids: ["not-a-valid-objectid"] };
+      deleteNotificationsBulk(req, res, next);
+      await flush();
+
+      assert.equal(next.mock.calls.length, 1);
+      assert.ok(next.mock.calls[0].arguments[0] instanceof AppError);
+      assert.equal(next.mock.calls[0].arguments[0].statusCode, 400);
+    });
+
+    it("should throw AppError(400) when ids is a mix of valid and invalid ObjectIds", async () => {
+      req.body = { ids: ["507f1f77bcf86cd799439011", "invalid-id"] };
       deleteNotificationsBulk(req, res, next);
       await flush();
 

--- a/server/src/modules/notifications/controller.js
+++ b/server/src/modules/notifications/controller.js
@@ -1,5 +1,6 @@
 import asyncHandler from "../../utils/asyncHandler.js";
 import AppError from "../../utils/AppError.js";
+import mongoose from "mongoose";
 import {
   createNotification as createNotificationService,
   getUserNotifications,
@@ -312,6 +313,11 @@ export const deleteNotificationsBulk = asyncHandler(async (req, res) => {
 
   if (!ids || !Array.isArray(ids) || ids.length === 0) {
     throw new AppError("Invalid or empty notification IDs list", 400);
+  }
+
+  const invalidIds = ids.filter((id) => !mongoose.Types.ObjectId.isValid(id));
+  if (invalidIds.length > 0) {
+    throw new AppError("Invalid notification ID format", 400);
   }
 
   const result = await deleteNotificationsBulkService(ids, userId.toString());


### PR DESCRIPTION
## Description
Fixes #1472

Adds validation for the `ids` array in `DELETE /api/notifications/bulk` to ensure every element is a valid MongoDB ObjectId before being passed to the `$in` query. Previously, malformed IDs caused an unhandled Mongoose `CastError`, surfacing as a 500 instead of a clean 400 response.

## Changes
- `server/src/modules/notifications/controller.js`: added `mongoose.Types.ObjectId.isValid()` check on each element of `ids`, throwing `AppError(400, "Invalid notification ID format")` if any element is invalid.
- `server/src/modules/notifications/__tests__/controller.test.js`: 
  - updated the existing "valid IDs" test to use real ObjectId-format strings
  - added a test for a fully invalid ID
  - added a test for a mixed valid/invalid IDs list

## Testing
All existing and new tests pass for the `deleteNotificationsBulk` controller.

## Related Issue
Closes #1472