### PR TITLE
fix(notifications): prevent rollback data loss on overlapping markAllAsRead requests

### DIFF
--- a/client/src/features/notifications/notificationsSlice.js
+++ b/client/src/features/notifications/notificationsSlice.js
@@ -240,11 +240,16 @@ const notificationsSlice = createSlice({
 
       // Mark all notifications as read (Optimistic Update)
       .addCase(markAllAsRead.pending, (state) => {
-        state._rollbackUnreadIds = state.items
-          .filter((item) => !item.isRead)
-          .map((item) => item._id);
+        if (!state._rollbackUnreadIds) {
+          state._rollbackUnreadIds = state.items
+            .filter((item) => !item.isRead)
+            .map((item) => item._id);
+        }
         state.items = state.items.map((item) => ({ ...item, isRead: true }));
         state.unreadCount = 0;
+      })
+      .addCase(markAllAsRead.fulfilled, (state) => {
+        state._rollbackUnreadIds = null;
       })
       .addCase(markAllAsRead.rejected, (state, action) => {
         const unreadIds = state._rollbackUnreadIds;

--- a/client/src/features/notifications/notificationsSlice.test.js
+++ b/client/src/features/notifications/notificationsSlice.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import reducer, {
   addLiveNotification,
   getNotifications,
+  markAllAsRead,
   setSocketStatus,
 } from "./notificationsSlice";
 
@@ -79,5 +80,53 @@ describe("notificationsSlice", () => {
     const nextState = reducer(undefined, setSocketStatus("reconnecting"));
 
     expect(nextState.socketStatus).toBe("reconnecting");
+  });
+
+  it("preserves rollback data across overlapping markAllAsRead requests", () => {
+    const previousState = {
+      items: [
+        notification({ _id: "n1", isRead: false }),
+        notification({ _id: "n2", isRead: false }),
+      ],
+      unreadCount: 2,
+      loading: false,
+      socketStatus: "connected",
+      pagination: { page: 1, limit: 10, total: 2, pages: 1 },
+      error: null,
+    };
+
+    // First markAllAsRead dispatch
+    const afterFirstPending = reducer(previousState, markAllAsRead.pending("request-1"));
+    expect(afterFirstPending._rollbackUnreadIds).toEqual(["n1", "n2"]);
+    expect(afterFirstPending.unreadCount).toBe(0);
+
+    // Second markAllAsRead dispatch before the first resolves
+    const afterSecondPending = reducer(afterFirstPending, markAllAsRead.pending("request-2"));
+    // Rollback data from request 1 must not be overwritten with an empty array
+    expect(afterSecondPending._rollbackUnreadIds).toEqual(["n1", "n2"]);
+
+    // First request fails - rollback should restore both items as unread
+    const afterRejected = reducer(
+      afterSecondPending,
+      markAllAsRead.rejected(null, "request-1", undefined, "Server error"),
+    );
+    expect(afterRejected.items.every((item) => item.isRead === false)).toBe(true);
+    expect(afterRejected.unreadCount).toBe(2);
+    expect(afterRejected._rollbackUnreadIds).toBe(null);
+  });
+
+  it("clears rollback tracking when markAllAsRead succeeds", () => {
+    const previousState = {
+      items: [notification({ _id: "n1", isRead: false })],
+      unreadCount: 1,
+      loading: false,
+      socketStatus: "connected",
+      pagination: { page: 1, limit: 10, total: 1, pages: 1 },
+      error: null,
+      _rollbackUnreadIds: ["n1"],
+    };
+
+    const nextState = reducer(previousState, markAllAsRead.fulfilled(null, "request-1"));
+    expect(nextState._rollbackUnreadIds).toBe(null);
   });
 });


### PR DESCRIPTION
## Description
Fixes #1482

Fixes a race condition in the `markAllAsRead` optimistic update where overlapping/rapid dispatches could overwrite the `_rollbackUnreadIds` snapshot with an empty array, causing a subsequent failed request to be unable to restore the unread state correctly.

## Changes
- `client/src/features/notifications/notificationsSlice.js`:
  - `markAllAsRead.pending` now only sets `_rollbackUnreadIds` if it isn't already set, preserving the original snapshot across overlapping requests.
  - Added a `markAllAsRead.fulfilled` case to clear `_rollbackUnreadIds` on success.
- `client/src/features/notifications/notificationsSlice.test.js`:
  - Added a test simulating overlapping `markAllAsRead` dispatches followed by a rejection, verifying rollback restores correctly.
  - Added a test verifying `_rollbackUnreadIds` is cleared on success.

## Related Issue
Closes #1482