### PR TITLE
fix(auth): prevent account enumeration via OTP rate-limit and verification status responses

### DIFF
--- a/server/src/modules/auth/__tests__/passwordReset.service.test.js
+++ b/server/src/modules/auth/__tests__/passwordReset.service.test.js
@@ -1,0 +1,83 @@
+import { describe, it, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import { forgotPasswordRequest, resendUserOTP } from "../service.js";
+import User from "../../../database/models/User.js";
+
+const GENERIC_RESET_MESSAGE = "If an account exists with this email, a reset code has been sent.";
+const GENERIC_VERIFY_MESSAGE = "If an account exists with this email, a verification code has been sent.";
+
+const createMockUser = (overrides = {}) => ({
+  email: overrides.email || "user@example.com",
+  isVerified: overrides.isVerified ?? false,
+  resetPasswordExpires: overrides.resetPasswordExpires,
+  verificationTokenExpires: overrides.verificationTokenExpires,
+  otpAttempts: overrides.otpAttempts ?? 0,
+  resetPasswordToken: overrides.resetPasswordToken,
+  verificationToken: overrides.verificationToken,
+  save: async function () { return this; },
+});
+
+describe("forgotPasswordRequest enumeration safety", () => {
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  it("returns generic response for a non-existent email", async () => {
+    mock.method(User, "findOne", async () => null);
+
+    const result = await forgotPasswordRequest("nobody@example.com");
+
+    assert.equal(result.success, true);
+    assert.equal(result.message, GENERIC_RESET_MESSAGE);
+  });
+
+  it("returns the same generic response when a recent reset request is already pending", async () => {
+    const user = createMockUser({
+      resetPasswordExpires: new Date(Date.now() + 4.5 * 60 * 1000), // issued < 1 min ago
+    });
+    mock.method(User, "findOne", async () => user);
+
+    const result = await forgotPasswordRequest(user.email);
+
+    assert.equal(result.success, true);
+    assert.equal(result.message, GENERIC_RESET_MESSAGE);
+  });
+});
+
+describe("resendUserOTP enumeration safety", () => {
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  it("returns generic response for a non-existent email", async () => {
+    mock.method(User, "findOne", async () => null);
+
+    const result = await resendUserOTP("nobody@example.com");
+
+    assert.equal(result.success, true);
+    assert.equal(result.message, GENERIC_VERIFY_MESSAGE);
+  });
+
+  it("returns the same generic response when the account is already verified", async () => {
+    const user = createMockUser({ isVerified: true });
+    mock.method(User, "findOne", async () => user);
+
+    const result = await resendUserOTP(user.email);
+
+    assert.equal(result.success, true);
+    assert.equal(result.message, GENERIC_VERIFY_MESSAGE);
+  });
+
+  it("returns the same generic response when a recent verification OTP is already pending", async () => {
+    const user = createMockUser({
+      isVerified: false,
+      verificationTokenExpires: new Date(Date.now() + 4.5 * 60 * 1000),
+    });
+    mock.method(User, "findOne", async () => user);
+
+    const result = await resendUserOTP(user.email);
+
+    assert.equal(result.success, true);
+    assert.equal(result.message, GENERIC_VERIFY_MESSAGE);
+  });
+});

--- a/server/src/modules/auth/service.js
+++ b/server/src/modules/auth/service.js
@@ -141,14 +141,20 @@ if (user.isVerified) {
 
 // 🔑 Forgot password
 export const forgotPasswordRequest = async (email) => {
+  const GENERIC_RESPONSE = {
+    success: true,
+    message: "If an account exists with this email, a reset code has been sent.",
+  };
+
   const user = await User.findOne({ email });
 
   if (!user) {
-    return { success: true, message: "If an account exists with this email, a reset code has been sent." };
+    return GENERIC_RESPONSE;
   }
 
   if (user.resetPasswordExpires && user.resetPasswordExpires.getTime() > Date.now() + (OTP_EXPIRY_MINUTES - 1) * 60 * 1000) {
-    throw new AppError("Please wait a minute before requesting another reset code", 429);
+    // Avoid leaking account existence via a distinct rate-limit response.
+    return GENERIC_RESPONSE;
   }
 
   const otp = generateOTP();
@@ -166,7 +172,7 @@ export const forgotPasswordRequest = async (email) => {
     throw new AppError("Failed to send reset code. Please try again.", 500);
   }
 
-  return { success: true, message: "If an account exists with this email, a reset code has been sent." };
+  return GENERIC_RESPONSE;
 };
 
 // 🔄 Reset password
@@ -213,18 +219,25 @@ export const resetUserPassword = async (email, otp, newPassword) => {
 
 // 🔁 Resend OTP
 export const resendUserOTP = async (email) => {
+  const GENERIC_RESPONSE = {
+    success: true,
+    message: "If an account exists with this email, a verification code has been sent.",
+  };
+
   const user = await User.findOne({ email });
 
   if (!user) {
-    return { success: true, message: "If an account exists with this email, a verification code has been sent." };
+    return GENERIC_RESPONSE;
   }
 
   if (user.isVerified) {
-    throw new AppError("User is already verified", 400);
+    // Avoid leaking account existence/verification status via a distinct response.
+    return GENERIC_RESPONSE;
   }
 
   if (user.verificationTokenExpires && user.verificationTokenExpires.getTime() > Date.now() + (OTP_EXPIRY_MINUTES - 1) * 60 * 1000) {
-    throw new AppError("Please wait a minute before requesting another verification code", 429);
+    // Avoid leaking account existence via a distinct rate-limit response.
+    return GENERIC_RESPONSE;
   }
 
   const otp = generateOTP();
@@ -242,7 +255,7 @@ export const resendUserOTP = async (email) => {
     throw new AppError("Failed to resend verification code. Please try again.", 500);
   }
 
-  return { success: true, message: "If an account exists with this email, a verification code has been sent." };
+  return GENERIC_RESPONSE;
 };
 
 export const loginUser = async (email, password) => {


### PR DESCRIPTION
## Description
Fixes #1484

`forgotPasswordRequest` and `resendUserOTP` already return a generic response when no account exists for the given email, to prevent user enumeration. However, when an account does exist and a rate-limit condition was hit (or, for `resendUserOTP`, the account is already verified), these functions threw distinct error responses (429 / 400) instead of returning the same generic response — creating a side channel that allows distinguishing registered emails from unregistered ones.

## Changes
- `server/src/modules/auth/service.js`:
  - `forgotPasswordRequest`: the rate-limit branch now returns the same generic success response instead of throwing `429`.
  - `resendUserOTP`: both the "already verified" (`400`) and rate-limit (`429`) branches now return the same generic success response.
  - Extracted `GENERIC_RESPONSE` constants for clarity and to guarantee identical response shape across all non-actionable code paths.
- `server/src/modules/auth/__tests__/passwordReset.service.test.js` (new):
  - Tests that `forgotPasswordRequest` returns the same generic response for non-existent emails and for accounts with a pending reset request.
  - Tests that `resendUserOTP` returns the same generic response for non-existent emails, already-verified accounts, and accounts with a pending verification OTP.

## Related Issue
Closes #1484