### PR TITLE
fix: send full conversation history to backend in ChatBox

### DIFF
--- a/client/src/modules/ai-assistant/components/ChatBox.jsx
+++ b/client/src/modules/ai-assistant/components/ChatBox.jsx
@@ -31,10 +31,9 @@ const ChatBox = ({ onClose }) => {
 
   const sendMessageToBackend = async (history) => {
     try {
-      const message = history[history.length - 1]?.text;
       const data = await apiRequest("/api/chat", {
         method: "POST",
-        body: { message },
+        body: { messages: history },
         token: getToken(),
       });
       return data.reply;


### PR DESCRIPTION
## Summary

The AI assistant `ChatBox` was discarding all conversation history on every request, sending only the last user message. This fix passes the full `messages` array to `/api/chat`, enabling multi-turn conversations. The backend already supported this path — it was just never reached.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #1488

## Changes Made

- In `sendMessageToBackend`, replace `body: { message }` (last message text only) with `body: { messages: history }` (full conversation array)
- Remove the now-unused `message` variable extraction

## Validation

- [ ] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)

No UI change — behavioural fix only. The backend already handles the `messages` array format and filters out `"Thinking..."` indicators, so the full conversation context is now forwarded correctly on every turn.