### PR TITLE
fix: add aiActionLimiter to /api/chat endpoint

### DIFF
--- a/server/src/modules/ai-assistant/routes.js
+++ b/server/src/modules/ai-assistant/routes.js
@@ -1,9 +1,10 @@
 import express from "express";
 import { protect } from "../../middleware/authMiddleware.js";
+import { aiActionLimiter } from "../../middleware/rateLimiter.js";
 import { generateChatResponse } from "./controller.js";
 
 const router = express.Router();
 
-router.post("/", protect, generateChatResponse);
+router.post("/", protect, aiActionLimiter, generateChatResponse);
 
 export default router;


### PR DESCRIPTION
## Summary

The `/api/chat` route calls the Gemini API on every request but was only guarded by the global rate limiter (400 req/15 min for students — effectively ~1,600 Gemini calls/hour). Every other AI endpoint in the codebase applies `aiActionLimiter` (20 calls/hour). This adds the missing middleware to close that gap.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #1489

## Changes Made

- Import `aiActionLimiter` from `../../middleware/rateLimiter.js` in the ai-assistant routes file
- Add `aiActionLimiter` between `protect` and `generateChatResponse` on the `POST /` route

## Validation

- [x] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)

N/A — backend-only change.