### PR TITLE
fix: debounce applicant search and guard against stale responses

### DIFF
--- a/client/src/modules/recruiter-jobs/pages/RecruiterApplicantsPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/RecruiterApplicantsPage.jsx
@@ -243,6 +243,7 @@ const RecruiterApplicantsPage = () => {
   
   // Filtering and Sorting States
   const [searchTerm, setSearchTerm] = useState('');
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [sortBy, setSortBy] = useState('matchScore');
   const [minScore, setMinScore] = useState(0);
@@ -264,17 +265,22 @@ const RecruiterApplicantsPage = () => {
   const [totalPages, setTotalPages] = useState(1);
   const [totalCount, setTotalCount] = useState(0);
 
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearchTerm(searchTerm), 400);
+    return () => clearTimeout(timer);
+  }, [searchTerm]);
+
   const handleExportPDF = () => {
     setIsExportDropdownOpen(false);
     exportToPDF("applicants-container", `Candidate_List_${job?.title?.replace(/[^a-z0-9]/gi, '_') || 'Job'}.pdf`);
   };
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (ignoreRef = { current: false }) => {
     setLoading(true);
     setError(null);
     try {
       const filtersObj = {
-        q: searchTerm || undefined,
+        q: debouncedSearchTerm || undefined,
         status: statusFilter,
         sortBy,
         minScore: minScore > 0 ? minScore : undefined,
@@ -294,19 +300,25 @@ const RecruiterApplicantsPage = () => {
         getJobPostingById(jobId, token),
         getJobApplications(jobId, token, filtersObj)
       ]);
-      setJob(jobData.job);
-      setApplicants(appsData.applications || []);
-      setTotalPages(appsData.totalPages || 1);
-      setTotalCount(appsData.totalCount || 0);
+      if (!ignoreRef.current) {
+        setJob(jobData.job);
+        setApplicants(appsData.applications || []);
+        setTotalPages(appsData.totalPages || 1);
+        setTotalCount(appsData.totalCount || 0);
+      }
     } catch (err) {
-      setError(err.message || "Failed to load applicant data.");
+      if (!ignoreRef.current) {
+        setError(err.message || "Failed to load applicant data.");
+      }
     } finally {
-      setLoading(false);
+      if (!ignoreRef.current) {
+        setLoading(false);
+      }
     }
   }, [
-    jobId, 
-    token, 
-    searchTerm,
+    jobId,
+    token,
+    debouncedSearchTerm,
     statusFilter, 
     sortBy, 
     minScore, 
@@ -322,7 +334,9 @@ const RecruiterApplicantsPage = () => {
   ]);
 
   useEffect(() => {
-    fetchData();
+    const ignoreRef = { current: false };
+    fetchData(ignoreRef);
+    return () => { ignoreRef.current = true; };
   }, [fetchData]);
 
   const handleUpdateStatus = async (status, comment) => {


### PR DESCRIPTION
## Summary

The applicant search input in `RecruiterApplicantsPage` was firing one API request per keystroke with no debounce and no protection against out-of-order responses. Typing "react developer" rapidly triggered 14 sequential Gemini/backend calls; a slow early response could overwrite the correct result for the final query.

This fix adds a 400ms debounce on `searchTerm` and an `ignoreRef` stale-response guard on `fetchData`, matching the pattern already used in `EditJobPostingPage.jsx` and `RecruiterJobsPage.jsx`.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #1490

## Changes Made

- Add `debouncedSearchTerm` state, updated 400ms after `searchTerm` changes via a `useEffect` + `setTimeout` cleanup
- Replace `searchTerm` with `debouncedSearchTerm` in `fetchData`'s `useCallback` dependency array so the API only fires after the user pauses
- Add `ignoreRef = { current: false }` parameter to `fetchData`; all `setState` calls are gated on `!ignoreRef.current`
- Update the `useEffect` that drives `fetchData` to create and pass an `ignoreRef`, setting `ignoreRef.current = true` in the cleanup to discard stale responses
- Direct calls to `fetchData()` (e.g., from `handleUpdateStatus`) use the default `{ current: false }` ref and are unaffected

## Validation

- [x] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)

No visual change — behavioural fix. Verifiable via DevTools Network tab: typing quickly now produces a single request ~400ms after the last keystroke instead of one per character.