### PR TITLE
fix: replace window.confirm in ClassroomRoom with proper leave dialogs

### DIFF
--- a/client/src/modules/classrooms/pages/ClassroomRoom.jsx
+++ b/client/src/modules/classrooms/pages/ClassroomRoom.jsx
@@ -26,6 +26,7 @@ import { endClassroomSession } from "../services/classroomService";
 
 import { SOCKET_URL } from "../../../config/env";
 import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
+import ConfirmDialog from "../../../shared/components/ConfirmDialog";
 import { useToast } from "../../../shared/components/toast/ToastProvider";
 import logger from "../../../utils/logger";
 
@@ -46,6 +47,10 @@ export default function ClassroomRoom() {
 
   const [initialCode, setInitialCode] = useState("");
   const [initialWhiteboard, setInitialWhiteboard] = useState([]);
+
+  // Leave dialog state
+  const [leaveDialogOpen, setLeaveDialogOpen] = useState(false);
+  const [leavingSession, setLeavingSession] = useState(false);
 
   // Controls state
   const [isMuted, setIsMuted] = useState(false);
@@ -462,26 +467,25 @@ export default function ClassroomRoom() {
     setChatInput("");
   };
 
-  const handleLeave = async () => {
-    if (user?.role === "tutor") {
-      const choice = window.confirm("Tutors: Click OK to END the session for everyone, or Cancel to just Leave.");
-      if (choice) {
-        try {
-          await endClassroomSession(roomId, token);
-          toast.success("Session ended successfully.");
-          navigate("/classrooms");
-        } catch (err) {
-          logger.error("Failed to end session", err);
-          toast.error("Failed to end session.");
-        }
-      } else {
-        navigate("/classrooms");
-      }
-    } else {
-      if (window.confirm("Are you sure you want to leave the classroom?")) {
-        navigate("/classrooms");
-      }
+  const handleLeave = () => {
+    setLeaveDialogOpen(true);
+  };
+
+  const handleEndSession = async () => {
+    setLeavingSession(true);
+    try {
+      await endClassroomSession(roomId, token);
+      toast.success("Session ended successfully.");
+      navigate("/classrooms");
+    } catch (err) {
+      logger.error("Failed to end session", err);
+      toast.error("Failed to end session.");
+      setLeavingSession(false);
     }
+  };
+
+  const handleLeaveOnly = () => {
+    navigate("/classrooms");
   };
 
   const copyRoomId = () => {
@@ -490,6 +494,7 @@ export default function ClassroomRoom() {
   };
 
   return (
+    <>
     <div className="h-screen bg-white dark:bg-[#0B0F19] text-slate-900 dark:text-white flex flex-col font-sans">
       {/* Top Header */}
       <div className="h-16 flex items-center justify-between px-6 border-b border-gray-200 dark:border-slate-800 bg-white/50 dark:bg-slate-900/50 backdrop-blur-md z-20">
@@ -779,5 +784,53 @@ export default function ClassroomRoom() {
         </div>
       </div>
     </div>
+
+    {/* Leave / End session dialog — tutor has 3 choices, student has 2 */}
+    {user?.role === "tutor" ? (
+      leaveDialogOpen && (
+        <div className="fixed inset-0 z-[1100] flex items-center justify-center p-4">
+          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => !leavingSession && setLeaveDialogOpen(false)} />
+          <div className="relative w-full max-w-md bg-slate-900 border border-white/10 rounded-2xl shadow-2xl p-6 space-y-4">
+            <h2 className="text-lg font-bold text-white">Leave classroom?</h2>
+            <p className="text-sm text-slate-300">Choose what happens when you leave this session.</p>
+            <div className="flex flex-col gap-3 pt-2">
+              <button
+                onClick={handleEndSession}
+                disabled={leavingSession}
+                className="w-full py-2.5 rounded-xl bg-red-600 hover:bg-red-500 disabled:opacity-50 text-white text-sm font-semibold transition-colors"
+              >
+                {leavingSession ? "Ending…" : "End session for everyone"}
+              </button>
+              <button
+                onClick={handleLeaveOnly}
+                disabled={leavingSession}
+                className="w-full py-2.5 rounded-xl bg-slate-700 hover:bg-slate-600 disabled:opacity-50 text-white text-sm font-semibold transition-colors"
+              >
+                Leave without ending
+              </button>
+              <button
+                onClick={() => setLeaveDialogOpen(false)}
+                disabled={leavingSession}
+                className="w-full py-2.5 rounded-xl border border-white/10 hover:bg-white/5 disabled:opacity-50 text-slate-300 text-sm font-semibold transition-colors"
+              >
+                Stay in session
+              </button>
+            </div>
+          </div>
+        </div>
+      )
+    ) : (
+      <ConfirmDialog
+        isOpen={leaveDialogOpen}
+        title="Leave classroom?"
+        message="Are you sure you want to leave this classroom session?"
+        confirmText="Leave"
+        cancelText="Stay"
+        variant="warning"
+        onConfirm={handleLeaveOnly}
+        onCancel={() => setLeaveDialogOpen(false)}
+      />
+    )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Tutors pressing **Cancel** on the `window.confirm` leave dialog were being navigated out of the classroom instead of staying. `window.confirm` only has two outcomes (OK / Cancel), but tutors need three distinct actions: End Session, Leave without ending, and Stay. Cancel was silently mapped to "leave", with no way to dismiss and remain in the room.

Replace `window.confirm` with dedicated React dialogs:
- **Tutors**: inline modal with three clearly-labelled buttons (End Session / Leave / Stay)
- **Students**: reuses the existing `ConfirmDialog` component (Leave / Stay)

## Type of Change

- [x] Bug fix

## Related Issue

Closes #1491

## Changes Made

- Import `ConfirmDialog` from `../../../shared/components/ConfirmDialog`
- Add `leaveDialogOpen` and `leavingSession` state variables
- Replace `handleLeave` with a simple state setter; extract `handleEndSession` (calls API, navigates) and `handleLeaveOnly` (navigates directly)
- Render a tutor-specific three-button modal and a student `ConfirmDialog` in the JSX, wrapped in a Fragment so they sit alongside the page root div
- Closing the dialog (Stay) sets `leaveDialogOpen = false` — tutor remains in session

## Validation

- [x] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)

No screenshot attached — behaviour change only. Reproducible: log in as tutor → join classroom → click Leave → confirm that "Stay in session" dismisses the dialog without navigating.