### PR TITLE
refactor: centralise auth token key in shared authToken utility

### DIFF
--- a/client/src/features/auth/authSlice.js
+++ b/client/src/features/auth/authSlice.js
@@ -1,7 +1,6 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import * as authService from "../../services/authService";
-
-const TOKEN_KEY = "skillssphere.auth.token";
+import { TOKEN_KEY } from "../../utils/authToken";
 const USER_KEY = "skillssphere.auth.user";
 const PENDING_EMAIL_KEY = "skillssphere.auth.pendingEmail";
 
@@ -264,8 +263,8 @@ const authSlice = createSlice({
       state.user = action.payload;
       
       // Update storage as well
-      const storage = window.localStorage.getItem("skillssphere.auth.token") 
-        ? window.localStorage 
+      const storage = window.localStorage.getItem(TOKEN_KEY)
+        ? window.localStorage
         : window.sessionStorage;
       
       try {

--- a/client/src/modules/ai-assistant/components/ChatBox.jsx
+++ b/client/src/modules/ai-assistant/components/ChatBox.jsx
@@ -4,9 +4,7 @@ import { X, Send, Sparkles } from "lucide-react";
 import MessageBubble from "./MessageBubble";
 import { apiRequest } from "../../../services/apiClient";
 
-const TOKEN_KEY = "skillssphere.auth.token";
-const getToken = () => localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY);
-
+import { getToken } from "../../../utils/authToken";
 import logger from "../../../utils/logger";
 
 const ChatBox = ({ onClose }) => {

--- a/client/src/modules/dashboard/services/dashboardService.js
+++ b/client/src/modules/dashboard/services/dashboardService.js
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { apiRequest, normalizeApiError } from "../../../services/apiClient";
-
-const TOKEN_KEY = "skillssphere.auth.token";
+import { TOKEN_KEY } from "../../../utils/authToken";
 const USER_KEY = "skillssphere.auth.user";
 const CACHE_TTL_MS = 60 * 1000;
 const REQUEST_TIMEOUT_MS = 10 * 1000;

--- a/client/src/modules/mock-interview/hooks/useInterviewSocket.js
+++ b/client/src/modules/mock-interview/hooks/useInterviewSocket.js
@@ -2,9 +2,8 @@ import { useState, useEffect, useRef } from "react";
 import { io } from "socket.io-client";
 import { SOCKET_URL } from "../../../config/env";
 import { loadInterviewSession } from "../../../utils/interviewSessionStorage";
+import { getToken } from "../../../utils/authToken";
 import logger from "../../../utils/logger";
-
-const TOKEN_KEY = "skillssphere.auth.token";
 
 export const useInterviewSocket = ({
   sessionId,
@@ -33,7 +32,7 @@ export const useInterviewSocket = ({
 
   useEffect(() => {
     if (!session || !user) return;
-    const token = localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY);
+    const token = getToken();
     
     const newSocket = io(SOCKET_URL, {
       auth: { token },

--- a/client/src/modules/mock-interview/hooks/useInterviewState.js
+++ b/client/src/modules/mock-interview/hooks/useInterviewState.js
@@ -11,9 +11,9 @@ import {
   clearInterviewAnswerDraft,
 } from "../../../utils/interviewSessionStorage";
 import { analyzeText, debounce } from "../utils/sentiment";
+import { getToken } from "../../../utils/authToken";
 import logger from "../../../utils/logger";
 
-const TOKEN_KEY = "skillssphere.auth.token";
 const REQUEST_TIMEOUT_MS = 20000;
 const MAX_RETRY_ATTEMPTS = 3;
 
@@ -160,8 +160,7 @@ export const useInterviewState = (sessionId, isObserver) => {
 
     const fetchSession = async () => {
       try {
-        const token =
-          localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY);
+        const token = getToken();
         setRequestStatus("Loading interview session...");
         const res = await retryRecoverable(
           () =>

--- a/client/src/modules/mock-interview/services/interviewService.js
+++ b/client/src/modules/mock-interview/services/interviewService.js
@@ -1,9 +1,5 @@
 import { apiRequest } from "../../../services/apiClient";
-
-const TOKEN_KEY = "skillssphere.auth.token";
-
-const getToken = () =>
-  localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY);
+import { getToken } from "../../../utils/authToken";
 
 /**
  * Fetch available interview topics with question counts and difficulty levels.

--- a/client/src/modules/resume-analyzer/services/resumeService.js
+++ b/client/src/modules/resume-analyzer/services/resumeService.js
@@ -1,10 +1,6 @@
 import { apiRequest } from "../../../services/apiClient";
-
+import { getToken } from "../../../utils/authToken";
 import logger from "../../../utils/logger";
-
-const TOKEN_KEY = "skillssphere.auth.token";
-const getToken = () =>
-  localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY);
 
 /**
  * Fetch the student's latest stored resume analysis from the database.

--- a/client/src/modules/roadmap/components/RoadmapCollaborationPanel.jsx
+++ b/client/src/modules/roadmap/components/RoadmapCollaborationPanel.jsx
@@ -4,10 +4,8 @@ import { Send, X, MessageSquare, Clock, Loader2 } from "lucide-react";
 import { getRoadmapComments, postRoadmapComment } from "../services/roadmapService";
 import { SOCKET_URL } from "../../../config/env";
 import { useToast } from "../../../shared/components";
+import { getToken } from "../../../utils/authToken";
 import logger from "../../../utils/logger";
-
-const TOKEN_KEY = "skillssphere.auth.token";
-const getToken = () => localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY);
 
 export default function RoadmapCollaborationPanel({
   roadmapId,

--- a/client/src/modules/roadmap/services/roadmapService.js
+++ b/client/src/modules/roadmap/services/roadmapService.js
@@ -1,7 +1,5 @@
 import { apiRequest } from "../../../services/apiClient";
-
-const TOKEN_KEY = "skillssphere.auth.token";
-const getToken = () => localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY);
+import { getToken } from "../../../utils/authToken";
 
 export const getMyRoadmap = async () => {
   return await apiRequest("/api/roadmap/me", {

--- a/client/src/utils/authToken.js
+++ b/client/src/utils/authToken.js
@@ -1,0 +1,4 @@
+export const TOKEN_KEY = "skillssphere.auth.token";
+
+export const getToken = () =>
+  localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY) || null;

--- a/client/src/utils/protectedAssetUrl.js
+++ b/client/src/utils/protectedAssetUrl.js
@@ -1,7 +1,6 @@
-const TOKEN_KEY = "skillssphere.auth.token";
+import { getToken } from "./authToken";
 
-export const getAuthToken = () =>
-  localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY) || "";
+export const getAuthToken = () => getToken() || "";
 
 export const resolveProtectedFilePath = (url) => {
   if (!url || typeof url !== "string") return null;


### PR DESCRIPTION
## Summary

The string `"skillssphere.auth.token"` and the `getToken()` helper were copy-pasted independently into 10 separate files across the client. A future storage key rename required hunting and updating every file with no compile-time guarantee of completeness. This PR introduces a single shared utility and replaces all local definitions with imports.

## Type of Change

- [x] Refactor

## Related Issue

Closes #1492

## Changes Made

- Create `client/src/utils/authToken.js` exporting `TOKEN_KEY` and `getToken()`
- Replace local `const TOKEN_KEY = "skillssphere.auth.token"` in all 10 files with imports
- Files using a custom token-reading wrapper (`dashboardService`, `authSlice`) import `TOKEN_KEY` only; files with simple token reads import `getToken()` directly
- Replace the one stray inline string literal in `authSlice.js:267` with `TOKEN_KEY`
- `protectedAssetUrl.js`'s `getAuthToken()` delegates to `getToken() || ""` to preserve its empty-string fallback contract

## Validation

- [x] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)

N/A — no runtime behaviour change. Verified with `grep -rn '"skillssphere.auth.token"' client/src/` — only the new shared file and one test `localStorage.setItem` call remain.