### PR TITLE
fix: support bare domains in company website validation

### DIFF
--- a/server/src/modules/users/__tests__/controller.profile.test.js
+++ b/server/src/modules/users/__tests__/controller.profile.test.js
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test, { afterEach, mock } from "node:test";
+import mongoose from "mongoose";
+import User from "../../../database/models/User.js";
+import { updateProfile } from "../controller.js";
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+const invokeUpdateProfile = async ({ body, role = "recruiter" }) => {
+  const userId = new mongoose.Types.ObjectId();
+  let updatePayload;
+
+  mock.method(User, "findByIdAndUpdate", (_id, update) => {
+    updatePayload = update;
+
+    return {
+      select: async () => ({
+        _id,
+        role,
+        accessLevel: "pending",
+        name: update.$set?.name,
+        companyWebsite: update.$set?.companyWebsite,
+        ...update.$set,
+      }),
+    };
+  });
+
+  const req = {
+    body,
+    user: { _id: userId, role },
+  };
+
+  const result = await new Promise((resolve, reject) => {
+    const res = {
+      statusCode: null,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(data) {
+        resolve({ statusCode: this.statusCode, data, updatePayload });
+      },
+    };
+
+    updateProfile(req, res, reject);
+  });
+
+  return result;
+};
+
+test("updateProfile stores bare company website domains with https prefix", async () => {
+  const { statusCode, data, updatePayload } = await invokeUpdateProfile({
+    body: {
+      name: "Recruiter User",
+      companyWebsite: "example.com",
+    },
+  });
+
+  assert.equal(statusCode, 200);
+  assert.equal(data.success, true);
+  assert.equal(updatePayload.$set.companyWebsite, "https://example.com");
+});
+
+test("updateProfile stores www company website domains with https prefix", async () => {
+  const { statusCode, updatePayload } = await invokeUpdateProfile({
+    body: {
+      name: "Recruiter User",
+      companyWebsite: "www.example.com",
+    },
+  });
+
+  assert.equal(statusCode, 200);
+  assert.equal(updatePayload.$set.companyWebsite, "https://www.example.com");
+});
+
+test("updateProfile keeps full https company website URLs unchanged", async () => {
+  const { statusCode, updatePayload } = await invokeUpdateProfile({
+    body: {
+      name: "Recruiter User",
+      companyWebsite: "https://example.com",
+    },
+  });
+
+  assert.equal(statusCode, 200);
+  assert.equal(updatePayload.$set.companyWebsite, "https://example.com");
+});

--- a/server/src/validations/__tests__/usersValidation.test.js
+++ b/server/src/validations/__tests__/usersValidation.test.js
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { updateProfileSchema } from "../users.validation.js";
+
+test("updateProfileSchema accepts bare company website domains", () => {
+  const result = updateProfileSchema.safeParse({
+    name: "Recruiter User",
+    companyWebsite: "example.com",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.companyWebsite, "example.com");
+});
+
+test("updateProfileSchema accepts www company website domains", () => {
+  const result = updateProfileSchema.safeParse({
+    name: "Recruiter User",
+    companyWebsite: "www.example.com",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.companyWebsite, "www.example.com");
+});
+
+test("updateProfileSchema accepts full https company website URLs", () => {
+  const result = updateProfileSchema.safeParse({
+    name: "Recruiter User",
+    companyWebsite: "https://example.com",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.companyWebsite, "https://example.com");
+});
+
+test("updateProfileSchema rejects invalid company website strings", () => {
+  const result = updateProfileSchema.safeParse({
+    name: "Recruiter User",
+    companyWebsite: "not a website",
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "companyWebsite");
+  assert.equal(result.error.issues[0].message, "Invalid URL");
+});
+
+test("updateProfileSchema keeps empty company website values valid for clearing profile data", () => {
+  const result = updateProfileSchema.safeParse({
+    name: "Recruiter User",
+    companyWebsite: "",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.companyWebsite, "");
+});

--- a/server/src/validations/users.validation.js
+++ b/server/src/validations/users.validation.js
@@ -1,10 +1,50 @@
 import { z } from 'zod';
 
+const hasValidDomainHostname = (hostname) => {
+  const normalizedHostname = hostname.toLowerCase();
+
+  if (
+    normalizedHostname === "localhost" ||
+    normalizedHostname.includes("..") ||
+    !normalizedHostname.includes(".")
+  ) {
+    return false;
+  }
+
+  return /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/.test(
+    normalizedHostname,
+  );
+};
+
+const isValidCompanyWebsite = (value) => {
+  const trimmedValue = value.trim();
+  if (!trimmedValue) return true;
+
+  try {
+    const parsedUrl = new URL(
+      /^https?:\/\//i.test(trimmedValue) ? trimmedValue : `https://${trimmedValue}`,
+    );
+
+    return (
+      ["http:", "https:"].includes(parsedUrl.protocol) &&
+      hasValidDomainHostname(parsedUrl.hostname)
+    );
+  } catch {
+    return false;
+  }
+};
+
+const companyWebsiteSchema = z
+  .string()
+  .trim()
+  .refine(isValidCompanyWebsite, "Invalid URL")
+  .optional();
+
 export const updateProfileSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters').optional(),
   role: z.string().optional(),
   company: z.string().optional(),
-  companyWebsite: z.string().url('Invalid URL').optional(),
+  companyWebsite: companyWebsiteSchema,
   linkedinUrl: z.string().optional(),
   credentialUrl: z.string().optional(),
   bio: z.string().optional(),


### PR DESCRIPTION
## Summary

Fixed the company website validation mismatch between the frontend, backend validation, and controller normalization logic.

## Changes Made

### Validation Updates

* Updated `companyWebsite` validation to accept:

  * `example.com`
  * `www.example.com`
  * `https://example.com`
  * Empty string (`""`) for clearing existing profile data

* Continued rejecting invalid website values such as:

  * `not a website`
  * malformed URLs

### Existing Behavior Preserved

* Controller normalization still automatically converts bare domains to:

  * `https://example.com`

### Tests Added

* Added validation coverage in:

  * `usersValidation.test.js`
* Added profile update coverage in:

  * `controller.profile.test.js`

### Verification

Executed and passed:

```powershell
node --test server\src\validations\__tests__\usersValidation.test.js

node --test server\src\modules\users\__tests__\controller.profile.test.js

node --test server\src\modules\users\__tests__\preferences.test.js server\src\modules\users\__tests__\controller.avatar.test.js server\src\modules\users\__tests__\controller.delete.test.js server\src\modules\users\__tests__\controller.profile.test.js

node --test server\src\validations\__tests__\authValidation.test.js server\src\validations\__tests__\usersValidation.test.js
```

All tests passed successfully.

## Result

Users can now enter company websites in a more user-friendly format while maintaining proper backend validation and URL normalization.
