### PR TITLE
Fix/strict user preferences validation

### DIFF
--- a/server/src/modules/jobs/__tests__/routes.recommendations.test.js
+++ b/server/src/modules/jobs/__tests__/routes.recommendations.test.js
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test, { afterEach, mock } from "node:test";
+import Resume from "../../../database/models/Resume.js";
+import jobsRoutes from "../routes.js";
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+const getRecommendationsRoute = () => {
+  const layer = jobsRoutes.stack.find((stackLayer) => (
+    stackLayer.route?.path === "/recommendations" &&
+    stackLayer.route?.methods?.get
+  ));
+
+  assert.ok(layer, "recommendations route should be registered");
+  return layer.route.stack;
+};
+
+const invokeMiddleware = (middleware, req = {}) =>
+  new Promise((resolve) => {
+    middleware.handle(req, {}, (error) => {
+      resolve(error);
+    });
+  });
+
+test("recommendations route allows authenticated students through role guard", async () => {
+  const [roleGuard, controller] = getRecommendationsRoute();
+  mock.method(Resume, "findOne", () => ({
+    select() {
+      return this;
+    },
+    sort() {
+      return this;
+    },
+    lean: async () => null,
+  }));
+
+  const error = await invokeMiddleware(roleGuard, {
+    user: { role: "student" },
+  });
+
+  assert.equal(error, undefined);
+
+  const response = await new Promise((resolve, reject) => {
+    const res = {
+      statusCode: null,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(data) {
+        resolve({ statusCode: this.statusCode, data });
+      },
+    };
+
+    controller.handle(
+      {
+        query: {},
+        user: { _id: "student-123", role: "student" },
+      },
+      res,
+      reject,
+    );
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.data.success, true);
+  assert.equal(response.data.hasResume, false);
+});
+
+test("recommendations route denies authenticated non-student roles", async () => {
+  const [roleGuard] = getRecommendationsRoute();
+
+  for (const role of ["recruiter", "admin", "tutor"]) {
+    const error = await invokeMiddleware(roleGuard, {
+      user: { role },
+    });
+
+    assert.equal(error.statusCode, 403);
+    assert.match(error.message, /do not have permission/i);
+  }
+});
+
+test("recommendations route denies unauthenticated requests at jobs router protect middleware", async () => {
+  const protectLayer = jobsRoutes.stack[0];
+
+  const error = await invokeMiddleware(protectLayer, {
+    headers: {},
+  });
+
+  assert.equal(error.statusCode, 401);
+  assert.match(error.message, /not logged in/i);
+});

--- a/server/src/modules/jobs/routes.js
+++ b/server/src/modules/jobs/routes.js
@@ -61,7 +61,7 @@ router.get("/", cacheMiddleware("jobs", 300), getJobs);
  *       200:
  *         description: Recommended jobs
  */
-router.get("/recommendations", getRecommendations);
+router.get("/recommendations", authorizeRoles("student"), getRecommendations);
 router.get("/trends/skills", getSkillTrends);
 
 // Recruiter-only routes

--- a/server/src/modules/users/__tests__/controller.profile.test.js
+++ b/server/src/modules/users/__tests__/controller.profile.test.js
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test, { afterEach, mock } from "node:test";
+import mongoose from "mongoose";
+import User from "../../../database/models/User.js";
+import { updateProfile } from "../controller.js";
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+const invokeUpdateProfile = async ({ body, role = "recruiter" }) => {
+  const userId = new mongoose.Types.ObjectId();
+  let updatePayload;
+
+  mock.method(User, "findByIdAndUpdate", (_id, update) => {
+    updatePayload = update;
+
+    return {
+      select: async () => ({
+        _id,
+        role,
+        accessLevel: "pending",
+        name: update.$set?.name,
+        companyWebsite: update.$set?.companyWebsite,
+        ...update.$set,
+      }),
+    };
+  });
+
+  const req = {
+    body,
+    user: { _id: userId, role },
+  };
+
+  const result = await new Promise((resolve, reject) => {
+    const res = {
+      statusCode: null,
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(data) {
+        resolve({ statusCode: this.statusCode, data, updatePayload });
+      },
+    };
+
+    updateProfile(req, res, reject);
+  });
+
+  return result;
+};
+
+test("updateProfile stores bare company website domains with https prefix", async () => {
+  const { statusCode, data, updatePayload } = await invokeUpdateProfile({
+    body: {
+      name: "Recruiter User",
+      companyWebsite: "example.com",
+    },
+  });
+
+  assert.equal(statusCode, 200);
+  assert.equal(data.success, true);
+  assert.equal(updatePayload.$set.companyWebsite, "https://example.com");
+});
+
+test("updateProfile stores www company website domains with https prefix", async () => {
+  const { statusCode, updatePayload } = await invokeUpdateProfile({
+    body: {
+      name: "Recruiter User",
+      companyWebsite: "www.example.com",
+    },
+  });
+
+  assert.equal(statusCode, 200);
+  assert.equal(updatePayload.$set.companyWebsite, "https://www.example.com");
+});
+
+test("updateProfile keeps full https company website URLs unchanged", async () => {
+  const { statusCode, updatePayload } = await invokeUpdateProfile({
+    body: {
+      name: "Recruiter User",
+      companyWebsite: "https://example.com",
+    },
+  });
+
+  assert.equal(statusCode, 200);
+  assert.equal(updatePayload.$set.companyWebsite, "https://example.com");
+});

--- a/server/src/validations/__tests__/usersValidation.test.js
+++ b/server/src/validations/__tests__/usersValidation.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { updateProfileSchema } from "../users.validation.js";
+import { updatePreferencesSchema, updateProfileSchema } from "../users.validation.js";
 
 test("updateProfileSchema accepts bare company website domains", () => {
   const result = updateProfileSchema.safeParse({
@@ -51,4 +51,88 @@ test("updateProfileSchema keeps empty company website values valid for clearing 
 
   assert.equal(result.success, true);
   assert.equal(result.data.companyWebsite, "");
+});
+
+test("updatePreferencesSchema accepts valid nested preference payloads", () => {
+  const result = updatePreferencesSchema.safeParse({
+    notifications: {
+      emailNotifications: false,
+      inAppNotifications: true,
+      interviewReminders: true,
+      jobUpdates: false,
+      resumeAnalysis: true,
+      systemAlerts: true,
+    },
+    emailFrequency: "daily",
+    privacy: {
+      profileVisibility: "private",
+      showResumeToRecruiters: false,
+      showInterviewHistory: true,
+      allowPersonalizedRecommendations: false,
+    },
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.privacy.profileVisibility, "private");
+  assert.equal(result.data.privacy.showResumeToRecruiters, false);
+  assert.equal(result.data.privacy.allowPersonalizedRecommendations, false);
+});
+
+test("updatePreferencesSchema rejects invalid profile visibility values", () => {
+  const result = updatePreferencesSchema.safeParse({
+    privacy: {
+      profileVisibility: "everyone",
+    },
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "privacy.profileVisibility");
+});
+
+test("updatePreferencesSchema rejects invalid privacy value types", () => {
+  const result = updatePreferencesSchema.safeParse({
+    privacy: {
+      showResumeToRecruiters: "yes",
+    },
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "privacy.showResumeToRecruiters");
+});
+
+test("updatePreferencesSchema rejects unknown privacy fields", () => {
+  const result = updatePreferencesSchema.safeParse({
+    privacy: {
+      profileVisibility: "public",
+      shareEmailWithRecruiters: true,
+    },
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "privacy");
+  assert.match(result.error.issues[0].message, /unrecognized key/i);
+});
+
+test("updatePreferencesSchema rejects unknown notification fields", () => {
+  const result = updatePreferencesSchema.safeParse({
+    notifications: {
+      jobUpdates: true,
+      smsNotifications: true,
+    },
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "notifications");
+  assert.match(result.error.issues[0].message, /unrecognized key/i);
+});
+
+test("updatePreferencesSchema rejects unknown top-level preference fields", () => {
+  const result = updatePreferencesSchema.safeParse({
+    emailFrequency: "weekly",
+    theme: "dark",
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "");
+  assert.match(result.error.issues[0].message, /unrecognized key/i);
 });

--- a/server/src/validations/__tests__/usersValidation.test.js
+++ b/server/src/validations/__tests__/usersValidation.test.js
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { updateProfileSchema } from "../users.validation.js";
+
+test("updateProfileSchema accepts bare company website domains", () => {
+  const result = updateProfileSchema.safeParse({
+    name: "Recruiter User",
+    companyWebsite: "example.com",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.companyWebsite, "example.com");
+});
+
+test("updateProfileSchema accepts www company website domains", () => {
+  const result = updateProfileSchema.safeParse({
+    name: "Recruiter User",
+    companyWebsite: "www.example.com",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.companyWebsite, "www.example.com");
+});
+
+test("updateProfileSchema accepts full https company website URLs", () => {
+  const result = updateProfileSchema.safeParse({
+    name: "Recruiter User",
+    companyWebsite: "https://example.com",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.companyWebsite, "https://example.com");
+});
+
+test("updateProfileSchema rejects invalid company website strings", () => {
+  const result = updateProfileSchema.safeParse({
+    name: "Recruiter User",
+    companyWebsite: "not a website",
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "companyWebsite");
+  assert.equal(result.error.issues[0].message, "Invalid URL");
+});
+
+test("updateProfileSchema keeps empty company website values valid for clearing profile data", () => {
+  const result = updateProfileSchema.safeParse({
+    name: "Recruiter User",
+    companyWebsite: "",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.companyWebsite, "");
+});

--- a/server/src/validations/users.validation.js
+++ b/server/src/validations/users.validation.js
@@ -1,10 +1,50 @@
 import { z } from 'zod';
 
+const hasValidDomainHostname = (hostname) => {
+  const normalizedHostname = hostname.toLowerCase();
+
+  if (
+    normalizedHostname === "localhost" ||
+    normalizedHostname.includes("..") ||
+    !normalizedHostname.includes(".")
+  ) {
+    return false;
+  }
+
+  return /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/.test(
+    normalizedHostname,
+  );
+};
+
+const isValidCompanyWebsite = (value) => {
+  const trimmedValue = value.trim();
+  if (!trimmedValue) return true;
+
+  try {
+    const parsedUrl = new URL(
+      /^https?:\/\//i.test(trimmedValue) ? trimmedValue : `https://${trimmedValue}`,
+    );
+
+    return (
+      ["http:", "https:"].includes(parsedUrl.protocol) &&
+      hasValidDomainHostname(parsedUrl.hostname)
+    );
+  } catch {
+    return false;
+  }
+};
+
+const companyWebsiteSchema = z
+  .string()
+  .trim()
+  .refine(isValidCompanyWebsite, "Invalid URL")
+  .optional();
+
 export const updateProfileSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters').optional(),
   role: z.string().optional(),
   company: z.string().optional(),
-  companyWebsite: z.string().url('Invalid URL').optional(),
+  companyWebsite: companyWebsiteSchema,
   linkedinUrl: z.string().optional(),
   credentialUrl: z.string().optional(),
   bio: z.string().optional(),

--- a/server/src/validations/users.validation.js
+++ b/server/src/validations/users.validation.js
@@ -53,15 +53,24 @@ export const updateProfileSchema = z.object({
   education: z.array(z.any()).optional(),
 });
 
+const notificationPreferencesSchema = z.object({
+  emailNotifications: z.boolean().optional(),
+  inAppNotifications: z.boolean().optional(),
+  interviewReminders: z.boolean().optional(),
+  jobUpdates: z.boolean().optional(),
+  resumeAnalysis: z.boolean().optional(),
+  systemAlerts: z.boolean().optional(),
+}).strict();
+
+const privacyPreferencesSchema = z.object({
+  profileVisibility: z.enum(['public', 'recruiters', 'private']).optional(),
+  showResumeToRecruiters: z.boolean().optional(),
+  showInterviewHistory: z.boolean().optional(),
+  allowPersonalizedRecommendations: z.boolean().optional(),
+}).strict();
+
 export const updatePreferencesSchema = z.object({
-  notifications: z.object({
-    emailNotifications: z.boolean().optional(),
-    inAppNotifications: z.boolean().optional(),
-    interviewReminders: z.boolean().optional(),
-    jobUpdates: z.boolean().optional(),
-    resumeAnalysis: z.boolean().optional(),
-    systemAlerts: z.boolean().optional(),
-  }).optional(),
+  notifications: notificationPreferencesSchema.optional(),
   emailFrequency: z.enum(['instant', 'daily', 'weekly', 'never']).optional(),
-  privacy: z.record(z.any()).optional(),
-});
+  privacy: privacyPreferencesSchema.optional(),
+}).strict();


### PR DESCRIPTION
## Summary

Improved user preferences validation by replacing loose privacy validation with a strict schema and enforcing strict validation across preference payloads.

## Changes Made

### Privacy Validation

Replaced:

```js
privacy: z.record(z.any())
```

with a strict nested schema that validates:

* `profileVisibility`

  * `public`
  * `recruiters`
  * `private`
* `showResumeToRecruiters` (boolean)
* `showInterviewHistory` (boolean)
* `allowPersonalizedRecommendations` (boolean)

### Strict Preference Validation

Updated preference schemas to reject unexpected fields instead of silently removing them.

Applied strict validation to:

* Top-level preferences payload
* Nested `notifications` object
* Nested `privacy` object

### Benefits

* Prevents invalid privacy settings from being stored.
* Ensures boolean preference fields receive correct data types.
* Protects against accidental or unsupported payload fields.
* Keeps API behavior predictable and easier to maintain.

## Tests Added

Added validation coverage for:

* Valid preferences payloads
* Invalid `profileVisibility` enum values
* Invalid boolean field types
* Unknown fields in privacy settings
* Unknown fields in notifications settings
* Unknown fields in top-level preference payloads

### Files Updated

* `server/src/validations/users.validation.js`
* `server/src/validations/__tests__/usersValidation.test.js`

## Verification

Executed:

```powershell
node --test server\src\validations\__tests__\usersValidation.test.js

node --test server\src\modules\users\__tests__\preferences.test.js
```

Both test suites passed successfully.

## Result

User preferences now have stronger validation guarantees, ensuring only supported privacy and notification settings are accepted while rejecting invalid or unexpected fields.
