### PR TITLE
fix: resolve backend test failures and CSV export leaks

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "nodemon index.js",
     "start": "node index.js",
-    "test": "node --test",
+    "test": "node --experimental-test-module-mocks --test",
     "lint": "eslint . --ext js,cjs --report-unused-disable-directives --max-warnings 0",
     "depcruise": "depcruise src --config .dependency-cruiser.js",
     "depcruise:validate": "depcruise src --config .dependency-cruiser.js --output-type err-long",

--- a/server/src/config/__tests__/validateEnv.test.js
+++ b/server/src/config/__tests__/validateEnv.test.js
@@ -13,6 +13,7 @@ import {
 const validBaseEnv = {
   NODE_ENV: "production",
   JWT_SECRET: "Str0ngProductionSecretValueForJwt!",
+  OAUTH_STATE_SECRET: "Str0ngOAuthStateSecretValue32Chars!",
   GOOGLE_CLIENT_ID: "1234567890-test.apps.googleusercontent.com",
   GOOGLE_CLIENT_SECRET: "google-oauth-client-secret",
   GOOGLE_CALLBACK_URL: "https://api.skillssphere.ai/api/auth/google/callback",

--- a/server/src/modules/auth/__tests__/oauthRedirect.test.js
+++ b/server/src/modules/auth/__tests__/oauthRedirect.test.js
@@ -10,6 +10,8 @@ import {
   normalizeOAuthRedirectPath,
 } from "../controller.js";
 
+process.env.OAUTH_STATE_SECRET = "Str0ngOAuthStateSecretValue32Chars!";
+
 const encodeState = (stateObj) =>
   encodeURIComponent(
     Buffer.from(JSON.stringify(stateObj), "utf8").toString("base64"),

--- a/server/src/modules/dashboard/__tests__/pagination.test.js
+++ b/server/src/modules/dashboard/__tests__/pagination.test.js
@@ -1,5 +1,6 @@
 import test, { mock, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import logger from "../../../utils/logger.js";
 import AnalysisHistory from "../../../database/models/AnalysisHistory.js";
 import CoverLetter from "../../../database/models/CoverLetter.js";
 import Resume from "../../../database/models/Resume.js";

--- a/server/src/modules/jobs/__tests__/controller.test.js
+++ b/server/src/modules/jobs/__tests__/controller.test.js
@@ -225,10 +225,10 @@ describe("Job Controller", () => {
 
   describe("exportApplicationsToCSV", () => {
     it("should export applications as CSV and set correct headers", async () => {
-      req.params.id = "job123";
+      req.params.id = "507f1f77bcf86cd799439011";
       
       const mockJob = {
-        _id: "job123",
+        _id: "507f1f77bcf86cd799439011",
         recruiter: { toString: () => "user123" }
       };
       
@@ -253,7 +253,6 @@ describe("Job Controller", () => {
         limit() { return this; },
         lean() { return this; }
       };
-      // We don't use lean anymore in the updated service, we let the promise resolve:
       mockQuery.then = function(resolve) { resolve(mockApplications); };
       
       mock.method(JobApplication, "find", () => mockQuery);
@@ -266,8 +265,10 @@ describe("Job Controller", () => {
       const testPromise = new Promise((resolve) => { resolveTest = resolve; });
       
       res.setHeader = mock.fn((name, value) => { headers[name] = value; });
-      res.send = mock.fn((content) => {
-        sentContent = content;
+      res.write = mock.fn((content) => {
+        sentContent += content;
+      });
+      res.end = mock.fn(() => {
         resolveTest();
       });
       next = mock.fn((err) => {
@@ -280,7 +281,7 @@ describe("Job Controller", () => {
 
       assert.equal(res.status.mock.calls[0].arguments[0], 200);
       assert.equal(headers["Content-Type"], "text/csv");
-      assert.ok(headers["Content-Disposition"].includes("job-job123-applicants.csv"));
+      assert.ok(headers["Content-Disposition"].includes("job-507f1f77bcf86cd799439011-applicants.csv"));
       
       const lines = sentContent.split("\n");
       assert.equal(lines[0], "Candidate Name,Candidate Email,Match Score,Match Category,Status,Apply Date,Resume Link,Cover Note");
@@ -291,10 +292,10 @@ describe("Job Controller", () => {
     });
 
     it("should throw 403 error if recruiter is not owner of the job", async () => {
-      req.params.id = "job123";
+      req.params.id = "507f1f77bcf86cd799439011";
       
       const mockJob = {
-        _id: "job123",
+        _id: "507f1f77bcf86cd799439011",
         recruiter: { toString: () => "differentUser" }
       };
       
@@ -313,6 +314,65 @@ describe("Job Controller", () => {
       assert.equal(next.mock.calls.length, 1);
       assert.ok(error instanceof AppError);
       assert.equal(error.statusCode, 403);
+    });
+
+    it("should throw 400 error if job ID format is invalid", async () => {
+      req.params.id = "invalid-id-format";
+
+      let resolveTest;
+      const testPromise = new Promise((resolve) => { resolveTest = resolve; });
+
+      next = mock.fn((err) => {
+        resolveTest(err);
+      });
+
+      await exportApplicationsToCSV(req, res, next);
+      const error = await testPromise;
+
+      assert.equal(next.mock.calls.length, 1);
+      assert.ok(error instanceof AppError);
+      assert.equal(error.statusCode, 400);
+      assert.ok(error.message.includes("Invalid job ID format"));
+    });
+
+    it("should throw 400 error if status filter query parameter is invalid", async () => {
+      req.params.id = "507f1f77bcf86cd799439011";
+      req.query.status = "invalid-status-value";
+
+      let resolveTest;
+      const testPromise = new Promise((resolve) => { resolveTest = resolve; });
+
+      next = mock.fn((err) => {
+        resolveTest(err);
+      });
+
+      await exportApplicationsToCSV(req, res, next);
+      const error = await testPromise;
+
+      assert.equal(next.mock.calls.length, 1);
+      assert.ok(error instanceof AppError);
+      assert.equal(error.statusCode, 400);
+      assert.ok(error.message.includes("Invalid status filter"));
+    });
+
+    it("should throw 400 error if sortBy query parameter is invalid", async () => {
+      req.params.id = "507f1f77bcf86cd799439011";
+      req.query.sortBy = "invalid-sort-value";
+
+      let resolveTest;
+      const testPromise = new Promise((resolve) => { resolveTest = resolve; });
+
+      next = mock.fn((err) => {
+        resolveTest(err);
+      });
+
+      await exportApplicationsToCSV(req, res, next);
+      const error = await testPromise;
+
+      assert.equal(next.mock.calls.length, 1);
+      assert.ok(error instanceof AppError);
+      assert.equal(error.statusCode, 400);
+      assert.ok(error.message.includes("Invalid sort option"));
     });
   });
 });

--- a/server/src/modules/jobs/controller.js
+++ b/server/src/modules/jobs/controller.js
@@ -20,6 +20,8 @@ import AppError from "../../utils/AppError.js";
 import asyncHandler from "../../utils/asyncHandler.js";
 import { invalidateCacheByPrefix } from "../../utils/cacheHelpers.js";
 import redisClient from "../../config/redis.js";
+import mongoose from "mongoose";
+import logger from "../../utils/logger.js";
 
 /**
  * Sanitizes a string to prevent CSV Injection (Formula Injection).
@@ -343,6 +345,35 @@ export const getRankedCandidates = asyncHandler(async (req, res) => {
 export const exportApplicationsToCSV = asyncHandler(async (req, res) => {
   const { status, sortBy } = req.query || {};
 
+  // Validate job ID format
+  if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+    throw new AppError("Invalid job ID format", 400);
+  }
+
+  // Validate status filter if provided
+  const allowedStatuses = ["pending", "reviewed", "shortlisted", "rejected", "withdrawn"];
+  if (status && !allowedStatuses.includes(status.trim().toLowerCase())) {
+    throw new AppError(`Invalid status filter. Allowed values: ${allowedStatuses.join(", ")}`, 400);
+  }
+
+  // Validate sort options if provided
+  const allowedSortOptions = ["matchScore", "newest", "oldest"];
+  if (sortBy && !allowedSortOptions.includes(sortBy.trim())) {
+    throw new AppError(`Invalid sort option. Allowed values: ${allowedSortOptions.join(", ")}`, 400);
+  }
+
+  const job = await JobPosting.findById(req.params.id);
+  if (!job) {
+    throw new AppError("Job posting not found", 404);
+  }
+
+  if (job.recruiter.toString() !== req.user._id.toString()) {
+    throw new AppError("You do not have permission to view these applications", 403);
+  }
+
+  logger.info(`Recruiter ${req.user._id} initiated CSV export for job ${req.params.id} (status: ${status || "all"}, sortBy: ${sortBy || "matchScore"})`);
+
+  res.status(200);
   res.setHeader("Content-Type", "text/csv");
   res.setHeader(
     "Content-Disposition",


### PR DESCRIPTION
## Summary

This PR resolves multiple backend test failures and refactors the recruiter CSV export controller. It introduces robust input validation (ObjectIds, query params) on the export endpoint, corrects missing environment setup mock variables in OAuth tests, fixes a logger reference error, and enables native Node module mocks in the test runner.

## Type of Change

- [x] Bug fix

- [x] Chore


## Changes Made

- **Jobs Module**: Added MongoDB ObjectId check, `status` filter check, and `sortBy` query parameter validation in `exportApplicationsToCSV` ([controller.js](file:///c:/Users/hp/SkillsSphere-AI/server/src/modules/jobs/controller.js)) prior to setting headers or starting the paginated response stream. Added accompanying Winston logs.
- **Jobs Tests**: Added 3 new unit tests for the export validations (invalid ID, invalid status, invalid sort option) and updated response stream mocking.
- **Auth & Env Tests**: Added `OAUTH_STATE_SECRET` to the mock config in [validateEnv.test.js](file:///c:/Users/hp/SkillsSphere-AI/server/src/config/__tests__/validateEnv.test.js) and injected the secret into `process.env` in [oauthRedirect.test.js](file:///c:/Users/hp/SkillsSphere-AI/server/src/modules/auth/__tests__/oauthRedirect.test.js).
- **Dashboard Tests**: Imported the missing `logger` module inside [pagination.test.js](file:///c:/Users/hp/SkillsSphere-AI/server/src/modules/dashboard/__tests__/pagination.test.js) to resolve a ReferenceError.
- **Package Config**: Appended the `--experimental-test-module-mocks` flag to the `npm run test` script in [package.json](file:///c:/Users/hp/SkillsSphere-AI/server/package.json) to support ESM imports mocking.

## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated

