### PR TITLE
docs: sync markdown specifications with active codebase implementation

### DIFF
--- a/docs/features/authentication-module.md
+++ b/docs/features/authentication-module.md
@@ -40,31 +40,32 @@ sequenceDiagram
     participant DB as MongoDB
 
     User->>FE: Clicks "Continue with Google"
-    FE->>BE: GET /api/auth/google/url
+    FE->>BE: GET /api/auth/google/url?action=signup&role=student
 
-    Note over BE: Generate CSRF State Token
-    BE->>BE: crypto.randomBytes(32)
-    BE->>BE: Set 'oauth_state' HttpOnly Cookie
+    Note over BE: Generate CSRF State Token with Payload
+    BE->>BE: Encode and encrypt { action: 'signup', role: 'student', csrfToken } into 'state'
+    BE->>BE: Set 'oauth_state' HttpOnly Cookie with raw csrfToken
     BE-->>FE: Return Google Auth URL
 
     FE->>IdP: Redirect User to Google
     User->>IdP: Grants Permission
-    IdP->>BE: Redirect to /api/auth/google/callback?code=XYZ&state=ABC
+    IdP->>BE: Redirect to /api/auth/google/callback?code=XYZ&state=ENCRYPTED_PAYLOAD
 
-    Note over BE: Strict State Validation
-    BE->>BE: Compare req.query.state === req.cookies.oauth_state
+    Note over BE: Strict State Validation & Decryption
+    BE->>BE: Decrypt 'state' parameter -> verifyAndDecodeOAuthState(state)
+    BE->>BE: Compare decrypted payload CSRF against req.cookies.oauth_state
 
     BE->>IdP: Exchange 'code' for Access Token
     IdP-->>BE: Returns IdP Access Token
     BE->>IdP: Fetch User Profile (Email, Name, Avatar)
 
-    BE->>DB: Upsert User by Email
+    BE->>DB: Upsert User by Email (assigning requested role if signup)
     Note over BE: Token Generation
     BE->>BE: Sign short-lived Access Token (JWT)
     BE->>BE: Sign long-lived Refresh Token (JWT)
 
     BE->>BE: Set 'accessToken' & 'refreshToken' HttpOnly Cookies
-    BE-->>FE: Redirect to /dashboard
+    BE-->>FE: Redirect to /dashboard with frontend callback URI
 ```
 
 ### Component Hierarchy & Service Boundaries
@@ -184,12 +185,15 @@ TTL: 900 (15 minutes)
 
 ### REST Endpoints
 
+### Strict Zod Validation Middlewares
+All incoming requests are intercepted by `validateBody(schema)` which leverages strict Zod schemas (`auth.validation.js`). This automatically sanitizes inputs and strips unknown keys, mitigating NoSQL injection risks before the controller executes.
+
 | Method | Endpoint | Auth Level | Purpose | Payload | Response |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| `POST` | `/api/auth/otp/send` | Public | Generates a 6-digit OTP and emails it via SendGrid. | `{ email: "user@example.com" }` | `{ success: true, message: "OTP Sent" }` |
-| `POST` | `/api/auth/otp/verify` | Public | Validates the OTP. If valid, issues HttpOnly cookies. | `{ email: "user@example.com", otp: "123456" }` | `{ user: {...} }` (Cookies attached via headers) |
-| `GET` | `/api/auth/google/url` | Public | Generates the secure OAuth redirect URL. | `None` | `{ url: "https://accounts.google.com/..." }` |
-| `GET` | `/api/auth/google/callback` | Public | Consumes the OAuth code and state. | `?code=XYZ&state=ABC` | Redirects to frontend with Cookies. |
+| `POST` | `/api/auth/otp/send` | Public | Generates a 6-digit OTP and emails it via SendGrid. | `{ email: "user@example.com" }` (Zod validated) | `{ success: true, message: "OTP Sent" }` |
+| `POST` | `/api/auth/otp/verify` | Public | Validates the OTP. If valid, issues HttpOnly cookies. | `{ email: "user@example.com", otp: "123456" }` (Zod validated) | `{ user: {...} }` (Cookies attached via headers) |
+| `GET` | `/api/auth/google/url` | Public | Generates the secure OAuth redirect URL with encoded state. | `?action=signup&role=student` | `{ url: "https://accounts.google.com/..." }` |
+| `GET` | `/api/auth/google/callback` | Public | Consumes the OAuth code and encrypted state. | `?code=XYZ&state=ENCRYPTED` | Redirects to frontend with Cookies. |
 | `POST` | `/api/auth/refresh` | Public | Issues a new Access Token if the Refresh cookie is valid. | `None` | `{ success: true }` |
 | `POST` | `/api/auth/logout` | Auth | Clears all cookies and increments `refreshTokenVersion` in DB. | `None` | `{ success: true }` |
 | `GET` | `/api/auth/me` | Auth | Validates the current Access Token and returns the user payload. | `None` | `{ user: {...} }` |

--- a/docs/features/recruiter-module.md
+++ b/docs/features/recruiter-module.md
@@ -186,13 +186,15 @@ export const KANBAN_COLUMNS = {
 
 ### REST Endpoints Topography
 
+All mutation endpoints explicitly route through `validateBody(schema)` using shared Zod schemas (e.g., `jobPostingSchema`) to strip undefined properties and rigorously enforce data integrity before hitting the controller.
+
 | HTTP Method | API Endpoint | Responsibility | Security Level | Payload | Response Signature |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | `GET` | `/api/recruiter/jobs` | Recruiter | Lists all jobs created by the authenticated recruiter. | `None` | `[{ _id, title, status, metrics }]` |
-| `POST` | `/api/recruiter/jobs` | Recruiter | Creates a new job requisition. | `{ title, company, description, skills, salary }` | `{ success: true, jobId }` |
-| `PATCH` | `/api/recruiter/jobs/:id` | Recruiter | Updates an existing job (e.g., closing a filled role). | `{ status: 'closed' }` | `{ success: true }` |
+| `POST` | `/api/recruiter/jobs` | Recruiter | Creates a new job requisition. | `{ title, company, description, skills, salary }` (Zod validated) | `{ success: true, jobId }` |
+| `PATCH` | `/api/recruiter/jobs/:id` | Recruiter | Updates an existing job (e.g., closing a filled role). | `{ status: 'closed' }` (Zod validated) | `{ success: true }` |
 | `GET` | `/api/recruiter/jobs/:jobId/applicants` | Recruiter | Fetches all applications for the Kanban board. | `None` | `[{ application, candidatePreview }]` |
-| `PATCH` | `/api/recruiter/applications/:id/status` | Recruiter | Moves a candidate between Kanban columns. | `{ status: "interviewing", note: "Optional feedback" }` | `{ success: true, timeline: [...] }` |
+| `PATCH` | `/api/recruiter/applications/:id/status` | Recruiter | Moves a candidate between Kanban columns. | `{ status: "interviewing", note: "Optional feedback" }` (Zod validated) | `{ success: true, timeline: [...] }` |
 | `GET` | `/api/recruiter/analytics` | Recruiter | Aggregates AI/ATS match scores across all jobs. | `None` | `{ matchCategoryDistribution, totalApplicants }` |
 
 ### Websocket Notification Layer (Optional Extension)

--- a/docs/workflows/classrooms-workflow.md
+++ b/docs/workflows/classrooms-workflow.md
@@ -20,7 +20,7 @@ Traditional remote learning often suffers from tool fragmentation—students and
 - Implements native Picture-in-Picture (PiP) support for persistent media visibility across different workspaces.
 
 **What the Module Deliberately Avoids:**
-- **Centralized Media Routing (SFU/MCU)**: To maintain a zero-cost infrastructure footprint for media, all video/audio streams are routed strictly P2P. This enforces a soft cap on room sizes (optimally 5-8 participants) before client-side CPU/bandwidth bottlenecks occur.
+- **Centralized Media Routing (SFU/MCU)**: To maintain a zero-cost infrastructure footprint for media, all video/audio streams are routed strictly P2P. Recent infrastructure upgrades now support larger room capacities, enforcing a cap on room sizes (optimally 30 participants, max 100) before client-side CPU/bandwidth bottlenecks occur.
 - **Persistent Media Storage**: The platform does not record or persist video/audio streams. All media data is inherently ephemeral.
 
 ---
@@ -116,43 +116,55 @@ const mongoose = require('mongoose');
 const classroomSessionSchema = new mongoose.Schema({
   roomId: { 
     type: String, 
-    required: true, 
+    required: [true, "Room ID is required"], 
     unique: true,
     index: true 
   },
-  hostId: { 
-    type: mongoose.Schema.Types.ObjectId, 
-    ref: 'User', 
-    required: true,
-    index: true
-  },
   title: { 
     type: String, 
-    default: 'Live Session' 
+    required: [true, "Session title is required"], 
+    trim: true,
+    maxlength: [100, "Session title cannot exceed 100 characters"]
+  },
+  subject: {
+    type: String,
+    trim: true,
+    maxlength: [100, "Subject cannot exceed 100 characters"],
+    default: "",
+  },
+  host: { 
+    type: mongoose.Schema.Types.ObjectId, 
+    ref: 'User', 
+    required: [true, "Host reference is required"],
+    index: true
   },
   status: { 
     type: String, 
-    enum: ['active', 'ended', 'aborted'], 
-    default: 'active' 
+    enum: ['active', 'ended'], 
+    default: 'active',
+    index: true
   },
-  participants: [{
-    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
-    joinedAt: { type: Date, default: Date.now },
-    leftAt: { type: Date }
+  maxParticipants: {
+    type: Number,
+    default: 30,
+    min: [2, "A session must allow at least 2 participants"],
+    max: [100, "A session cannot exceed 100 participants"]
+  },
+  chatHistory: [{
+    sender: { type: Object },
+    message: { type: String },
+    timestamp: { type: String }
   }],
-  settings: {
-    maxParticipants: { type: Number, default: 10 },
-    allowScreenShare: { type: Boolean, default: true },
-    requireApproval: { type: Boolean, default: false }
-  },
-  startedAt: { type: Date, default: Date.now },
-  endedAt: { type: Date }
-}, { 
-  timestamps: true 
-});
-
-// Compound index for querying active sessions by host
-classroomSessionSchema.index({ hostId: 1, status: 1 });
+  codeSnapshot: { type: String, default: "" },
+  whiteboardSnapshot: { type: Array, default: [] },
+  participants: [{
+    socketId: { type: String, required: true },
+    user: { type: Object, required: true },
+    joinedAt: { type: Date, default: Date.now }
+  }],
+  endedAt: { type: Date, default: null },
+  emptySince: { type: Date, default: null }
+}, { timestamps: true });
 
 module.exports = mongoose.model('ClassroomSession', classroomSessionSchema);
 ```


### PR DESCRIPTION
This PR resolves the severe documentation drift by auditing and synchronizing the core Markdown specifications to exactly match the active codebase state. I updated authentication-module.md to accurately reflect the encrypted state payloads used to verify OAuth flows and noted the use of validateBody Zod middlewares across all REST endpoints. I also updated recruiter-module.md to reflect Zod payload requirements for requisition mutations, and corrected classrooms-workflow.md to document the true ClassroomSession schema limits (defaulting to 30 participants, capping at 100). These updates ensure new contributors have a perfectly accurate, single source of truth when building upon the Auth, Recruiter, and Classroom modules.

Closes #1509 