### PR TITLE
docs: add missing blank line before fenced code block in Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ SkillSphere AI aims to simplify the path from learning to hiring by giving users
 To simplify setup, you can now run the entire project using root-level scripts.
 
 ### Install all dependencies
+
 ```bash
 ### Install all dependencies
 


### PR DESCRIPTION
README.md line 140 was failing `MD031/blanks-around-fences` — the bash fence block opened immediately after `### Install all dependencies` with no blank line separating them.

Added a single blank line before the opening fence. All other markdown files are clean.

**Root cause**: Introduced in the `docs: comprehensively update documentation` commit (c1b915a). The Quick Start section heading and its code block were written without the required surrounding whitespace.