### PR TITLE
feat: Add Mock Interview performance report PDF export

### DIFF
--- a/client/src/modules/mock-interview/pages/InterviewResults.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewResults.jsx
@@ -20,10 +20,12 @@ import {
   Play,
   FileJson,
   Sparkles,
-  Bookmark
+  Bookmark,
+  Download
 } from "lucide-react";
 import Navbar from "../../../shared/components/Navbar";
 import Footer from "../../../shared/components/Footer";
+import { exportToPDF } from "../../../utils/exportUtils";
 
 import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
 import logger from "../../../utils/logger";
@@ -105,6 +107,17 @@ const InterviewResults = () => {
     if (score >= 75) return "#10b981";
     if (score >= 50) return "#f59e0b";
     return "#ef4444";
+  };
+
+  const handleExportPDF = async () => {
+    try {
+      const filename = `Interview_Report_${results?.topic?.replace(/[^a-z0-9]/gi, '_') || 'Session'}.pdf`;
+      await exportToPDF("mock-interview-pdf-target", filename, {
+        html2canvas: { scale: 2, useCORS: true, backgroundColor: '#09090b' }
+      });
+    } catch (err) {
+      logger.error("[InterviewResults] PDF export failed:", err);
+    }
   };
 
   if (loading) {
@@ -441,6 +454,12 @@ const InterviewResults = () => {
         </button>
         <button
           className="bg-white dark:bg-surface text-indigo-600 dark:text-indigo-400 border border-border shadow-[0_5px_15px_rgba(0,0,0,0.02)] py-3 px-8 rounded-full font-bold cursor-pointer flex items-center gap-2 hover:border-indigo-500/30 transition-all hover:-translate-y-0.5"
+          onClick={handleExportPDF}
+        >
+          <Download size={18} /> Export Report (PDF)
+        </button>
+        <button
+          className="bg-white dark:bg-surface text-indigo-600 dark:text-indigo-400 border border-border shadow-[0_5px_15px_rgba(0,0,0,0.02)] py-3 px-8 rounded-full font-bold cursor-pointer flex items-center gap-2 hover:border-indigo-500/30 transition-all hover:-translate-y-0.5"
           onClick={() => navigate("/mock-interview/history")}
         >
           <Clock size={18} /> View History
@@ -451,6 +470,115 @@ const InterviewResults = () => {
         >
           <ArrowLeft size={18} /> Back to Dashboard
         </button>
+      </div>
+
+      {/* Printable PDF Report (Off-screen) */}
+      <div 
+        id="mock-interview-pdf-target" 
+        className="absolute left-[-9999px] top-0 w-[800px] p-8 bg-[#09090b] text-slate-100 flex flex-col gap-6"
+        style={{ fontFamily: 'Inter, system-ui, sans-serif' }}
+      >
+        <div className="flex justify-between items-center border-b border-slate-800 pb-5">
+          <div>
+            <h1 className="text-2xl font-black bg-gradient-to-r from-blue-500 via-purple-500 to-teal-400 bg-clip-text text-transparent tracking-tight">
+              SkillSphere AI
+            </h1>
+            <p className="text-xs font-bold text-indigo-400 uppercase tracking-widest mt-1">Mock Interview Performance Report</p>
+          </div>
+          <div className="text-right space-y-1">
+            <p className="text-[10px] text-slate-500 uppercase tracking-wider">Generated on {new Date().toLocaleDateString()}</p>
+            <p className="text-[10px] text-slate-500 uppercase tracking-wider">Session: #{sessionId?.slice(-8).toUpperCase()}</p>
+          </div>
+        </div>
+
+        <div className="flex justify-between items-center bg-slate-900/50 border border-slate-800 rounded-2xl p-6">
+          <div className="space-y-2">
+            <span className="text-[10px] font-bold text-slate-500 uppercase tracking-widest">Topic & Level</span>
+            <div className="flex items-center gap-3">
+              <h2 className="text-xl font-bold uppercase text-white tracking-wide">{results?.topic}</h2>
+              <span className="px-2.5 py-0.5 rounded-full text-xs font-bold bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 capitalize">
+                {results?.difficulty}
+              </span>
+            </div>
+            {results?.duration && (
+              <p className="text-xs text-slate-400">
+                Duration: <strong className="text-slate-300">{results?.duration} seconds</strong>
+              </p>
+            )}
+          </div>
+          <div className="bg-indigo-500/10 border border-indigo-500/20 px-8 py-4 rounded-2xl text-center">
+            <span className="block text-[10px] font-bold text-indigo-400 uppercase tracking-widest mb-1">Overall Score</span>
+            <span className="text-4xl font-extrabold text-white">{overallScore}%</span>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 gap-4">
+          <div className="bg-slate-900/30 border border-slate-800 rounded-xl p-4 text-center">
+            <span className="block text-[10px] font-bold text-slate-500 uppercase tracking-wider mb-1">Technical Skills</span>
+            <span className="text-2xl font-bold text-emerald-400">{avgTechnical}%</span>
+          </div>
+          <div className="bg-slate-900/30 border border-slate-800 rounded-xl p-4 text-center">
+            <span className="block text-[10px] font-bold text-slate-500 uppercase tracking-wider mb-1">Communication</span>
+            <span className="text-2xl font-bold text-indigo-400">{avgCommunication}%</span>
+          </div>
+          <div className="bg-slate-900/30 border border-slate-800 rounded-xl p-4 text-center">
+            <span className="block text-[10px] font-bold text-slate-500 uppercase tracking-wider mb-1">Relevance Score</span>
+            <span className="text-2xl font-bold text-purple-400">{avgRelevance}%</span>
+          </div>
+        </div>
+
+        {results?.weakConcepts?.length > 0 && (
+          <div className="bg-amber-500/5 border border-amber-500/10 rounded-xl p-5">
+            <h3 className="text-xs font-bold text-amber-400 uppercase tracking-wider mb-2">Recommended Concepts to Review</h3>
+            <div className="flex flex-wrap gap-1.5">
+              {results.weakConcepts.map((c, i) => (
+                <span key={i} className="text-xs bg-amber-500/10 text-amber-300 px-2.5 py-0.5 rounded-full border border-amber-500/20">
+                  {c}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <h3 className="text-sm font-bold text-slate-400 uppercase tracking-wider border-b border-slate-800 pb-2">Detailed Questions & Answers</h3>
+          {answers.map((a, idx) => (
+            <div key={idx} className="bg-slate-900/20 border border-slate-800/80 rounded-xl p-5 space-y-3">
+              <div className="flex justify-between items-start">
+                <h4 className="text-sm font-bold text-slate-200 flex-1 pr-6 leading-snug">
+                  Q{idx + 1}. {a.questionText}
+                </h4>
+                <div className="flex flex-col items-end gap-1">
+                  <span className="text-xs font-extrabold text-emerald-400 bg-emerald-500/10 px-2.5 py-0.5 rounded border border-emerald-500/20">
+                    Tech: {a.scores?.technical || 0}%
+                  </span>
+                </div>
+              </div>
+              <div className="text-xs text-slate-300 leading-relaxed bg-[#0c0c0e] p-4 rounded-lg border border-slate-800/50">
+                <span className="block text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-1.5">Your Transcript:</span>
+                {a.transcript || "No answer submitted"}
+              </div>
+              {a.concepts && (a.concepts.detected?.length > 0 || a.concepts.missed?.length > 0) && (
+                <div className="flex flex-wrap gap-2 pt-1">
+                  {a.concepts.detected?.map((c, i) => (
+                    <span key={`det-${i}`} className="text-[10px] font-semibold bg-emerald-500/10 text-emerald-400 border border-emerald-500/10 px-2 py-0.5 rounded">
+                      ✓ {c}
+                    </span>
+                  ))}
+                  {a.concepts.missed?.map((c, i) => (
+                    <span key={`mis-${i}`} className="text-[10px] font-semibold bg-red-500/10 text-red-400 border border-red-500/10 px-2 py-0.5 rounded">
+                      ✗ {c}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="text-center text-[9px] text-slate-600 border-t border-slate-800/60 pt-4 mt-4 uppercase tracking-widest font-semibold">
+          SkillsSphere AI © {new Date().getFullYear()} — Career intelligence ecosystem
+        </div>
       </div>
       </div>
       </main>


### PR DESCRIPTION
## Summary

Adds a comprehensive PDF export capability to the Mock Interview results page (`/mock-interview/:id/results`). This enables students to download and save a professional breakdown of their performance report, category scores, concept recommendations, and transcript logs.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #1538 

## Changes Made

- Imported the `Download` icon and shared `exportToPDF` utility in `client/src/modules/mock-interview/pages/InterviewResults.jsx`.
- Created a `handleExportPDF` helper function to handle filename formatting and trigger the capture logic.
- Built an off-screen, print-optimized container (`#mock-interview-pdf-target`) that templates the student's overall score, delivery attributes, weak concepts list, and detailed question-by-question transcripts.
- Placed the "Export Report (PDF)" button in the bottom actions bar of the dashboard page.

## Validation

- [x] Build passes locally
- [ ] Relevant tests added/updated
- [x] Documentation updated (if needed)
