### PR TITLE
refactor(styles): strip all inline styles and enforce tailwind strictness

### DIFF
--- a/client/src/modules/analytics/TutorAnalyticsDashboard.jsx
+++ b/client/src/modules/analytics/TutorAnalyticsDashboard.jsx
@@ -26,11 +26,12 @@ const CustomizedContent = (props) => {
         y={y}
         width={width}
         height={height}
+        className="fill-[var(--tw-fill)] stroke-[var(--tw-stroke)] stroke-[width:var(--tw-stroke-width)] stroke-[opacity:var(--tw-stroke-opacity)]"
         style={{
-          fill: depth < 2 ? (colors ? colors[colorIndex] : "#8884d8") : "none",
-          stroke: "#fff",
-          strokeWidth: 2 / (depth + 1e-10),
-          strokeOpacity: 1 / (depth + 1e-10),
+          '--tw-fill': depth < 2 ? (colors ? colors[colorIndex] : "#8884d8") : "none",
+          '--tw-stroke': "#fff",
+          '--tw-stroke-width': 2 / (depth + 1e-10),
+          '--tw-stroke-opacity': 1 / (depth + 1e-10),
         }}
       />
       {depth === 1 && width > 40 && height > 30 ? (

--- a/client/src/modules/classrooms/components/Whiteboard.jsx
+++ b/client/src/modules/classrooms/components/Whiteboard.jsx
@@ -502,8 +502,8 @@ export default function Whiteboard({ socket, roomId, userRole, initialStrokes })
             <button
               key={c.value}
               onClick={() => setColor(c.value)}
-              className={`w-6 h-6 rounded-full border-2 transition-transform duration-150 cursor-pointer ${color === c.value ? "scale-125 border-white" : "border-transparent"}`}
-              style={{ backgroundColor: c.value }}
+              className={`w-6 h-6 rounded-full border-2 transition-transform duration-150 cursor-pointer bg-[var(--tw-bg-color)] ${color === c.value ? "scale-125 border-white" : "border-transparent"}`}
+              style={{ '--tw-bg-color': c.value }}
               title={c.name}
             />
           ))}
@@ -620,10 +620,10 @@ export default function Whiteboard({ socket, roomId, userRole, initialStrokes })
           onChange={(e) => setTextInput((prev) => ({ ...prev, value: e.target.value }))}
           onKeyDown={handleTextSubmit}
           onBlur={() => setTextInput({ visible: false, x: 0, y: 0, normX: 0, normY: 0, value: "" })}
-          className="absolute bg-slate-900 border border-indigo-500 text-white rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500 z-25"
+          className="absolute bg-slate-900 border border-indigo-500 text-white rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500 z-25 top-[var(--tw-top)] left-[var(--tw-left)] -translate-y-full"
           style={{
-            left: `${textInput.x}px`,
-            top: `${textInput.y}px`,
+            '--tw-left': `${textInput.x}px`,
+            '--tw-top': `${textInput.y}px`,
             color: color,
             font: `${16 + lineWidth}px sans-serif`
           }}

--- a/client/src/modules/job-matcher/components/MatchScoreCard.jsx
+++ b/client/src/modules/job-matcher/components/MatchScoreCard.jsx
@@ -15,8 +15,8 @@ export default function MatchScoreCard({ score }) {
       {/* Progress Bar */}
       <div className="w-full bg-gray-200 dark:bg-gray-700 h-2 rounded mt-4">
         <div
-          className="bg-gradient-to-r from-blue-500 to-indigo-500 h-2 rounded transition-all duration-500"
-          style={{ width: `${score}%` }}
+          className="bg-gradient-to-r from-blue-500 to-indigo-500 h-2 rounded transition-all duration-500 w-[var(--tw-width)]"
+          style={{ '--tw-width': `${score}%` }}
         />
       </div>
 

--- a/client/src/modules/mock-interview/components/CameraCheck.jsx
+++ b/client/src/modules/mock-interview/components/CameraCheck.jsx
@@ -116,8 +116,7 @@ const CameraCheck = ({ onStreamReady }) => {
             autoPlay
             muted
             playsInline
-            className={`w-full h-full object-cover transition-opacity duration-700 ${stream ? "opacity-100" : "opacity-0"}`}
-            style={{ transform: "rotateY(180deg)" }} // mirror effect for self view
+            className={`w-full h-full object-cover transition-opacity duration-700 [transform:rotateY(180deg)] ${stream ? "opacity-100" : "opacity-0"}`}
           />
           
           {/* Hardware status overlay */}

--- a/client/src/modules/mock-interview/components/RealtimeSentimentIndicator.jsx
+++ b/client/src/modules/mock-interview/components/RealtimeSentimentIndicator.jsx
@@ -36,16 +36,15 @@ const RealtimeSentimentIndicator = ({ analysis }) => {
             <Brain size={14} />
             <span>Confidence</span>
           </div>
-          <div className="text-xl font-bold" style={{ color: getConfidenceColor(confidence) }}>
+          <div className="text-xl font-bold text-[color:var(--tw-color)]" style={{ '--tw-color': getConfidenceColor(confidence) }}>
             {confidence}%
           </div>
           <div className="h-1 bg-gray-200 dark:bg-white/10 rounded-sm overflow-hidden">
             <div 
-              className="h-full rounded-sm" 
+              className="h-full rounded-sm w-[var(--tw-width)] bg-[color:var(--tw-bg)] transition-all duration-300" 
               style={{ 
-                width: `${confidence}%`, 
-                backgroundColor: getConfidenceColor(confidence),
-                transition: 'width 0.5s ease-out, background-color 0.5s ease'
+                '--tw-width': `${confidence}%`, 
+                '--tw-bg': getConfidenceColor(confidence),
               }}
             />
           </div>
@@ -56,16 +55,15 @@ const RealtimeSentimentIndicator = ({ analysis }) => {
             <Activity size={14} />
             <span>Tone</span>
           </div>
-          <div className="text-xl font-bold" style={{ color: getToneColor(tone) }}>
+          <div className="text-xl font-bold text-[color:var(--tw-color)]" style={{ '--tw-color': getToneColor(tone) }}>
             {getToneLabel(tone)}
           </div>
           <div className="h-1 bg-gray-200 dark:bg-white/10 rounded-sm overflow-hidden">
             <div 
-              className="h-full rounded-sm" 
+              className="h-full rounded-sm w-[var(--tw-width)] bg-[color:var(--tw-bg)] transition-all duration-300" 
               style={{ 
-                width: `${tone}%`, 
-                backgroundColor: getToneColor(tone),
-                transition: 'width 0.5s ease-out, background-color 0.5s ease'
+                '--tw-width': `${tone}%`, 
+                '--tw-bg': getToneColor(tone),
               }}
             />
           </div>
@@ -76,7 +74,7 @@ const RealtimeSentimentIndicator = ({ analysis }) => {
             <AlertCircle size={14} />
             <span>Hesitations</span>
           </div>
-          <div className="text-xl font-bold" style={{ color: hesitationCount > 5 ? '#ef4444' : '#94a3b8' }}>
+          <div className="text-xl font-bold text-[color:var(--tw-color)]" style={{ '--tw-color': hesitationCount > 5 ? '#ef4444' : '#94a3b8' }}>
             {hesitationCount}
           </div>
         </div>

--- a/client/src/modules/mock-interview/pages/InterviewHistory.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewHistory.jsx
@@ -588,7 +588,7 @@ const InterviewHistory = () => {
       {error && <div className="bg-red-500/10 border border-red-500/30 text-red-400 p-4 rounded-xl text-center">{error}</div>}
       {exportError && (
         <div role="alert" className="bg-red-500/10 border border-red-500/30 text-red-400 p-4 rounded-xl text-center">
-          <AlertCircle size={16} style={{ display: "inline", marginRight: 6 }} />
+          <AlertCircle size={16} className="inline-block mr-1.5" />
           {exportError}
         </div>
       )}

--- a/client/src/modules/mock-interview/pages/InterviewResults.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewResults.jsx
@@ -242,7 +242,7 @@ const InterviewResults = () => {
           </span>
           {results.duration && (
             <span className="py-1 px-3 rounded-full text-xs font-semibold bg-emerald-500/15 text-emerald-400">
-              <Clock size={12} style={{ display: "inline", marginRight: 4 }} />
+              <Clock size={12} className="inline-block mr-1" />
               {results.duration}s
             </span>
           )}
@@ -271,7 +271,7 @@ const InterviewResults = () => {
               strokeLinecap="round"
               strokeDasharray={circumference}
               strokeDashoffset={strokeDashoffset}
-              style={{ transition: "stroke-dashoffset 1s ease" }}
+              className="transition-[stroke-dashoffset] duration-1000 ease-in-out"
             />
           </svg>
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-4xl font-extrabold bg-gradient-to-br from-indigo-500 to-purple-500 bg-clip-text text-transparent">{overallScore}</div>
@@ -303,7 +303,7 @@ const InterviewResults = () => {
           Soft Skills & Delivery
         </h3>
         <div className="flex flex-col gap-8 items-center">
-          <div className="w-full max-w-[500px]" style={{ height: 300 }}>
+          <div className="w-full max-w-[500px] h-[300px]">
             <ResponsiveContainer width="100%" height="100%">
               <RadarChart cx="50%" cy="50%" outerRadius="75%" data={radarData}>
                 <PolarGrid stroke="rgba(255,255,255,0.1)" />
@@ -370,8 +370,8 @@ const InterviewResults = () => {
               </span>
             )}
             <span
-              className="font-bold text-lg"
-              style={{ color: getScoreColor(a.scores?.technical || 0) }}
+              className="font-bold text-lg text-[color:var(--tw-score-color)]"
+              style={{ '--tw-score-color': getScoreColor(a.scores?.technical || 0) }}
             >
               {a.scores?.technical || 0}%
             </span>

--- a/client/src/modules/mock-interview/pages/InterviewSession.jsx
+++ b/client/src/modules/mock-interview/pages/InterviewSession.jsx
@@ -273,8 +273,8 @@ const InterviewSession = () => {
             </div>
             <div className="h-2.5 bg-gray-100 dark:bg-slate-800 rounded-full overflow-hidden shadow-inner">
               <div
-                className="h-full bg-blue-600 dark:bg-blue-500 rounded-full transition-all duration-500"
-                style={{ width: `${progressPercent}%` }}
+                className="h-full bg-blue-600 dark:bg-blue-500 rounded-full transition-all duration-500 w-[var(--tw-width)]"
+                style={{ '--tw-width': `${progressPercent}%` }}
               />
             </div>
             <p className="text-xs text-slate-500 dark:text-slate-400 mt-1 flex items-center gap-1.5">

--- a/client/src/modules/profile/ProfilePage.jsx
+++ b/client/src/modules/profile/ProfilePage.jsx
@@ -159,8 +159,7 @@ const AvatarEditor = ({ user, roleConfig, onUpload, onRemove, uploading, avatarS
   return (
     <div className="flex w-full flex-col items-center gap-3">
       <div className="relative group">
-        <div className={`w-32 h-32 rounded-full bg-gradient-to-br ${roleConfig.avatar} flex items-center justify-center text-white text-3xl font-bold border-4 border-white dark:border-slate-900 shadow-xl overflow-hidden select-none`}
-          style={{ boxShadow: `0 4px 24px ${roleConfig.glow}` }}>
+        <div className={`w-32 h-32 rounded-full bg-gradient-to-br ${roleConfig.avatar} flex items-center justify-center text-white text-3xl font-bold border-4 border-white dark:border-slate-900 shadow-xl overflow-hidden select-none shadow-[0_4px_24px_var(--tw-glow)]`} style={{ '--tw-glow': roleConfig.glow }}>
           {displayPic ? (
             <img src={displayPic} alt={`${user.name || "User"} profile avatar`} className="w-full h-full object-cover" />
           ) : (
@@ -425,7 +424,7 @@ const ProfilePage = () => {
   return (
     <div className="min-h-screen transition-colors duration-300 relative bg-gradient-to-br from-[#f0eeff] via-[#f7f9fc] to-[#edfdf5] dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 pt-24">
       <Navbar />
-      <div className="relative" style={{ zIndex: 2 }}>
+      <div className="relative z-[2]">
         
         {/* ── Cover Banner ── */}
         <div className="relative w-full h-44 sm:h-36 overflow-hidden">
@@ -434,9 +433,9 @@ const ProfilePage = () => {
           <div className="absolute bottom-0 left-1/4 w-24 h-24 rounded-full bg-white/5" />
 
           {/* Animated Glassy Bubbles inside banner */}
-          <div className="absolute w-20 h-20 rounded-full" style={{ top: '10%', left: '8%', background: 'linear-gradient(135deg, rgba(255,255,255,0.25), rgba(255,255,255,0.08))', border: '1.5px solid rgba(255,255,255,0.3)', boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.4), 0 4px 16px rgba(0,0,0,0.1)', backdropFilter: 'blur(8px)' }} />
-          <div className="absolute w-12 h-12 rounded-full" style={{ bottom: '15%', left: '30%', background: 'linear-gradient(135deg, rgba(255,255,255,0.2), rgba(255,255,255,0.06))', border: '1.5px solid rgba(255,255,255,0.25)', boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.35), 0 4px 12px rgba(0,0,0,0.08)', backdropFilter: 'blur(6px)' }} />
-          <div className="absolute w-16 h-16 rounded-full" style={{ top: '15%', right: '25%', background: 'linear-gradient(135deg, rgba(255,255,255,0.22), rgba(255,255,255,0.07))', border: '1.5px solid rgba(255,255,255,0.28)', boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.38), 0 4px 14px rgba(0,0,0,0.09)', backdropFilter: 'blur(7px)' }} />
+          <div className="absolute w-20 h-20 rounded-full top-[10%] left-[8%] bg-gradient-to-br from-white/25 to-white/10 border-[1.5px] border-white/30 shadow-[inset_0_1px_0_rgba(255,255,255,0.4),0_4px_16px_rgba(0,0,0,0.1)] backdrop-blur-sm" />
+          <div className="absolute w-12 h-12 rounded-full bottom-[15%] left-[30%] bg-gradient-to-br from-white/20 to-white/5 border-[1.5px] border-white/25 shadow-[inset_0_1px_0_rgba(255,255,255,0.35),0_4px_12px_rgba(0,0,0,0.08)] backdrop-blur-[6px]" />
+          <div className="absolute w-16 h-16 rounded-full top-[15%] right-[25%] bg-gradient-to-br from-white/20 to-white/10 border-[1.5px] border-white/30 shadow-[inset_0_1px_0_rgba(255,255,255,0.38),0_4px_14px_rgba(0,0,0,0.09)] backdrop-blur-[7px]" />
         </div>
 
         {/* ── Main Layout Grid ── */}
@@ -474,7 +473,7 @@ const ProfilePage = () => {
 
               {/* Contact Info */}
               <div className="px-5 py-4">
-                <h3 className="text-[10px] font-bold uppercase tracking-widest mb-3" style={{ background: 'linear-gradient(135deg,#7C3AED,#059669)', WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent', backgroundClip:'text' }}>
+                <h3 className="text-[10px] font-bold uppercase tracking-widest mb-3 bg-gradient-to-br from-[#7C3AED] to-[#059669] bg-clip-text text-transparent">
                   Contact Info
                 </h3>
                 <div className="flex flex-col gap-2.5">
@@ -498,7 +497,7 @@ const ProfilePage = () => {
 
               {/* Activity Metrics */}
               <div className="px-5 py-4">
-                <h3 className="text-[10px] font-bold uppercase tracking-widest mb-3" style={{ background: 'linear-gradient(135deg,#7C3AED,#059669)', WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent', backgroundClip:'text' }}>
+                <h3 className="text-[10px] font-bold uppercase tracking-widest mb-3 bg-gradient-to-br from-[#7C3AED] to-[#059669] bg-clip-text text-transparent">
                   Activity
                 </h3>
                 <div className="grid grid-cols-2 gap-2.5">
@@ -596,7 +595,7 @@ const ProfilePage = () => {
             {/* ═══ Section 1: Basic Information ═══ */}
             {activeTab === "info" && (
             <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-white/10 shadow-sm p-6">
-              <h3 className="text-xs font-bold uppercase tracking-widest mb-5" style={{ background: 'linear-gradient(135deg,#7C3AED,#059669)', WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent', backgroundClip:'text' }}>
+              <h3 className="text-xs font-bold uppercase tracking-widest mb-5 bg-gradient-to-br from-[#7C3AED] to-[#059669] bg-clip-text text-transparent">
                 Basic Information
               </h3>
               {isEditing ? (
@@ -688,7 +687,7 @@ const ProfilePage = () => {
 
             {activeTab === "security" && (
               <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-white/10 shadow-sm p-6">
-                <h3 className="text-xs font-bold uppercase tracking-widest mb-5" style={{ background: 'linear-gradient(135deg,#7C3AED,#059669)', WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent', backgroundClip:'text' }}>
+                <h3 className="text-xs font-bold uppercase tracking-widest mb-5 bg-gradient-to-br from-[#7C3AED] to-[#059669] bg-clip-text text-transparent">
                   Password & Access
                 </h3>
                 {user.provider === "google" ? (
@@ -708,7 +707,7 @@ const ProfilePage = () => {
             {activeTab === "account" && (
               <div className="flex flex-col gap-5 min-w-0">
                 <div className="bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-white/10 shadow-sm p-6">
-                  <h3 className="text-xs font-bold uppercase tracking-widest mb-5" style={{ background: 'linear-gradient(135deg,#7C3AED,#059669)', WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent', backgroundClip:'text' }}>
+                  <h3 className="text-xs font-bold uppercase tracking-widest mb-5 bg-gradient-to-br from-[#7C3AED] to-[#059669] bg-clip-text text-transparent">
                     Account Details
                   </h3>
                   <div className="flex flex-col divide-y divide-slate-100 dark:divide-white/5">

--- a/client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx
+++ b/client/src/modules/recruiter-jobs/pages/TalentFinderPage.jsx
@@ -720,7 +720,7 @@ const TalentFinderPage = () => {
                                           <span className="text-xs font-black text-gray-900 dark:text-slate-200">{matchResult.matchBreakdown?.atsCompatibility || 0}%</span>
                                         </div>
                                         <div className="w-full bg-gray-100 dark:bg-slate-800 rounded-full h-1.5 shadow-inner">
-                                          <div className="bg-emerald-500 h-1.5 rounded-full transition-all duration-500" style={{ width: `${matchResult.matchBreakdown?.atsCompatibility || 0}%` }} />
+                                          <div className="bg-emerald-500 h-1.5 rounded-full transition-all duration-500 w-[var(--tw-width)]" style={{ '--tw-width': `${matchResult.matchBreakdown?.atsCompatibility || 0}%` }} />
                                         </div>
                                       </div>
 
@@ -730,7 +730,7 @@ const TalentFinderPage = () => {
                                           <span className="text-xs font-black text-gray-900 dark:text-slate-200">{matchResult.matchBreakdown?.skillMatch || 0}%</span>
                                         </div>
                                         <div className="w-full bg-gray-100 dark:bg-slate-800 rounded-full h-1.5 shadow-inner">
-                                          <div className="bg-blue-500 h-1.5 rounded-full transition-all duration-500" style={{ width: `${matchResult.matchBreakdown?.skillMatch || 0}%` }} />
+                                          <div className="bg-blue-500 h-1.5 rounded-full transition-all duration-500 w-[var(--tw-width)]" style={{ '--tw-width': `${matchResult.matchBreakdown?.skillMatch || 0}%` }} />
                                         </div>
                                       </div>
 
@@ -740,7 +740,7 @@ const TalentFinderPage = () => {
                                           <span className="text-xs font-black text-gray-900 dark:text-slate-200">{matchResult.matchBreakdown?.projectStrength || 0}%</span>
                                         </div>
                                         <div className="w-full bg-gray-100 dark:bg-slate-800 rounded-full h-1.5 shadow-inner">
-                                          <div className="bg-purple-500 h-1.5 rounded-full transition-all duration-500" style={{ width: `${matchResult.matchBreakdown?.projectStrength || 0}%` }} />
+                                          <div className="bg-purple-500 h-1.5 rounded-full transition-all duration-500 w-[var(--tw-width)]" style={{ '--tw-width': `${matchResult.matchBreakdown?.projectStrength || 0}%` }} />
                                         </div>
                                       </div>
 

--- a/client/src/modules/resume-analyzer/components/AnalysisReportPDF.jsx
+++ b/client/src/modules/resume-analyzer/components/AnalysisReportPDF.jsx
@@ -143,8 +143,8 @@ const AnalysisReportPDF = ({ result, fileName }) => {
           </div>
           <div className="h-2 bg-slate-200 rounded-full overflow-hidden mb-3">
             <div
-              className={`h-full ${getScoreBg(result.impactMatch?.score)}`}
-              style={{ width: `${result.impactMatch?.score || 0}%` }}
+              className={`h-full w-[var(--tw-width)] ${getScoreBg(result.impactMatch?.score)}`}
+              style={{ '--tw-width': `${result.impactMatch?.score || 0}%` }}
             ></div>
           </div>
           <p className="text-[11px] text-slate-600 leading-relaxed">

--- a/client/src/modules/resume-analyzer/components/AnalysisResult.jsx
+++ b/client/src/modules/resume-analyzer/components/AnalysisResult.jsx
@@ -352,8 +352,8 @@ const AnalysisResult = ({ result, file, jobDescription, onReset }) => {
               </div>
               <div className="w-full max-w-[200px] h-2 bg-gray-100 dark:bg-white/5 rounded-full overflow-hidden">
                 <div 
-                  className="h-full bg-yellow-400 transition-all duration-1000" 
-                  style={{ width: `${result.impactMatch?.score}%` }}
+                  className="h-full bg-yellow-400 transition-all duration-1000 w-[var(--tw-width)]" 
+                  style={{ '--tw-width': `${result.impactMatch?.score}%` }}
                 ></div>
               </div>
               <p className="text-xs font-medium text-gray-500 dark:text-gray-400">
@@ -432,7 +432,7 @@ const AnalysisResult = ({ result, file, jobDescription, onReset }) => {
                 <span className={`text-sm font-black ${getScoreColor(category.score)}`}>{category.score}%</span>
               </div>
               <div className="h-2 bg-gray-100 dark:bg-white/5 rounded-full overflow-hidden">
-                <div className={`h-full rounded-full transition-all duration-1000 ${getProgressColor(category.score)}`} style={{ width: `${category.score}%` }} />
+                <div className={`h-full rounded-full transition-all duration-1000 w-[var(--tw-width)] ${getProgressColor(category.score)}`} style={{ '--tw-width': `${category.score}%` }} />
               </div>
               <p className="text-[11px] font-medium text-gray-500 dark:text-gray-400 pt-1">
                 {category.feedback}
@@ -707,7 +707,6 @@ const AnalysisResult = ({ result, file, jobDescription, onReset }) => {
         <div 
           id="analysis-report-pdf" 
           className="w-[800px] bg-white text-slate-800"
-          style={{ width: "800px", backgroundColor: "#ffffff" }}
         >
           <AnalysisReportPDF result={result} fileName={file?.name} />
         </div>

--- a/client/src/modules/resume-analyzer/components/AnalysisResultSkeleton.jsx
+++ b/client/src/modules/resume-analyzer/components/AnalysisResultSkeleton.jsx
@@ -12,7 +12,7 @@ const AnalysisResultSkeleton = () => {
           </p>
           <div className="flex items-center gap-4">
             {/* Circle ring placeholder */}
-            <div className="w-18 h-18 rounded-full bg-gray-200 flex-shrink-0" style={{ width: 72, height: 72 }} />
+            <div className="w-[72px] h-[72px] rounded-full bg-gray-200 flex-shrink-0" />
             <div className="flex-1 space-y-2">
               <div className="h-3.5 bg-gray-200 rounded w-3/5" />
               <div className="h-2.5 bg-gray-200 rounded w-2/5" />
@@ -26,7 +26,7 @@ const AnalysisResultSkeleton = () => {
             Match Score
           </p>
           <div className="flex items-center gap-4">
-            <div className="rounded-full bg-gray-200 flex-shrink-0" style={{ width: 72, height: 72 }} />
+            <div className="w-[72px] h-[72px] rounded-full bg-gray-200 flex-shrink-0" />
             <div className="flex-1 space-y-2">
               <div className="h-3.5 bg-gray-200 rounded w-3/5" />
               <div className="h-2.5 bg-gray-200 rounded w-2/5" />
@@ -45,8 +45,8 @@ const AnalysisResultSkeleton = () => {
           {[72, 96, 60, 88, 64, 80].map((w, i) => (
             <div
               key={i}
-              className="h-7 bg-gray-200 rounded-full"
-              style={{ width: w }}
+              className="h-7 bg-gray-200 rounded-full w-[var(--tw-width)]"
+              style={{ '--tw-width': w }}
             />
           ))}
         </div>
@@ -61,8 +61,8 @@ const AnalysisResultSkeleton = () => {
           {[80, 64, 104, 72, 56, 90].map((w, i) => (
             <div
               key={i}
-              className="h-6 bg-gray-200 rounded-full"
-              style={{ width: w }}
+              className="h-6 bg-gray-200 rounded-full w-[var(--tw-width)]"
+              style={{ '--tw-width': w }}
             />
           ))}
         </div>

--- a/client/src/modules/roadmap/components/ContributionSummaryCard.jsx
+++ b/client/src/modules/roadmap/components/ContributionSummaryCard.jsx
@@ -64,8 +64,8 @@ const ContributionSummaryCard = ({ roadmap }) => {
 
         <div className="h-1.5 w-full bg-amber-500/10 rounded-full overflow-hidden">
           <div 
-            className="h-full bg-amber-500 transition-all duration-1000 shadow-[0_0_10px_rgba(245,158,11,0.8)]" 
-            style={{ width: `${contributionProgress}%` }}
+            className="h-full bg-amber-500 transition-all duration-1000 shadow-[0_0_10px_rgba(245,158,11,0.8)] w-[var(--tw-width)]" 
+            style={{ '--tw-width': `${contributionProgress}%` }}
           ></div>
         </div>
       </div>

--- a/client/src/modules/roadmap/components/RoadmapCollaborationPanel.jsx
+++ b/client/src/modules/roadmap/components/RoadmapCollaborationPanel.jsx
@@ -304,9 +304,9 @@ export default function RoadmapCollaborationPanel({
         {typingUser && (
           <div className="flex items-center gap-2 text-xs text-[var(--text-muted)] pl-1 animate-pulse">
             <div className="flex space-x-1">
-              <span className="w-1.5 h-1.5 bg-[var(--text-muted)] rounded-full animate-bounce" style={{ animationDelay: "0ms" }}></span>
-              <span className="w-1.5 h-1.5 bg-[var(--text-muted)] rounded-full animate-bounce" style={{ animationDelay: "150ms" }}></span>
-              <span className="w-1.5 h-1.5 bg-[var(--text-muted)] rounded-full animate-bounce" style={{ animationDelay: "300ms" }}></span>
+              <span className="w-1.5 h-1.5 bg-[var(--text-muted)] rounded-full animate-bounce [animation-delay:var(--tw-delay)]" style={{ '--tw-delay': "0ms" }}></span>
+              <span className="w-1.5 h-1.5 bg-[var(--text-muted)] rounded-full animate-bounce [animation-delay:var(--tw-delay)]" style={{ '--tw-delay': "150ms" }}></span>
+              <span className="w-1.5 h-1.5 bg-[var(--text-muted)] rounded-full animate-bounce [animation-delay:var(--tw-delay)]" style={{ '--tw-delay': "300ms" }}></span>
             </div>
             <span className="italic font-semibold">{typingUser} is typing...</span>
           </div>

--- a/client/src/modules/roadmap/pages/RoadmapPage.jsx
+++ b/client/src/modules/roadmap/pages/RoadmapPage.jsx
@@ -226,7 +226,7 @@ const RoadmapPage = () => {
             const glowColor = isContribution ? 'bg-amber-500/10' : 'bg-indigo-500/10';
 
             return (
-              <div key={topic._id} className={`relative flex items-center gap-8 ${isLeft ? "md:flex-row" : "md:flex-row-reverse"} animate-slide-up`} style={{ animationDelay: `${index * 100}ms` }}>
+              <div key={topic._id} className={`relative flex items-center gap-8 ${isLeft ? "md:flex-row" : "md:flex-row-reverse"} animate-slide-up [animation-delay:var(--tw-delay)]`} style={{ '--tw-delay': `${index * 100}ms` }}>
                 
                 {/* Visual Dot on the line */}
                  <div className={`absolute left-[19px] md:left-1/2 md:-ml-3 w-6 h-6 rounded-full border-4 ${isCompleted ? completedBorderColor : 'bg-white dark:bg-[#121214] border-gray-200 dark:border-white/10'} z-20 transition-all duration-500`}>
@@ -339,7 +339,7 @@ const RoadmapPage = () => {
                 "Complete this roadmap to reach top-tier competency for <span className="text-gray-900 dark:text-white font-bold">{roadmap.targetRole}</span> roles. Your progress is synced across recruiters and mentors."
               </p>
               <div className="h-2 w-full bg-gray-200 dark:bg-white/10 rounded-full overflow-hidden max-w-md mx-auto">
-                <div className="h-full bg-indigo-500 transition-all duration-1000" style={{ width: `${roadmap.overallProgress}%` }}></div>
+                <div className="h-full bg-indigo-500 transition-all duration-1000 w-[var(--tw-width)]" style={{ '--tw-width': `${roadmap.overallProgress}%` }}></div>
               </div>
            </div>
         </div>

--- a/client/src/modules/roadmap/pages/TutorRoadmapLobby.jsx
+++ b/client/src/modules/roadmap/pages/TutorRoadmapLobby.jsx
@@ -224,8 +224,8 @@ export default function TutorRoadmapLobby() {
                       <div className="flex items-center gap-3">
                         <div className="flex-1 h-1.5 bg-slate-100 dark:bg-slate-800 rounded-full overflow-hidden">
                           <div 
-                            className="h-full bg-indigo-500 transition-all duration-500" 
-                            style={{ width: `${s.overallProgress}%` }}
+                            className="h-full bg-indigo-500 transition-all duration-500 w-[var(--tw-width)]" 
+                            style={{ '--tw-width': `${s.overallProgress}%` }}
                           />
                         </div>
                         <span className="text-[10px] font-black text-slate-700 dark:text-slate-300">{s.overallProgress}%</span>

--- a/client/src/shared/components/AuthLayout.jsx
+++ b/client/src/shared/components/AuthLayout.jsx
@@ -30,8 +30,8 @@ const AuthLayout = ({ children, maxWidth = "380px", footerContent }) => {
       <Navbar />
 
       <div
-        className="relative z-10 w-full"
-        style={{ maxWidth }}
+        className="relative z-10 w-full max-w-[var(--tw-max-w)]"
+        style={{ '--tw-max-w': maxWidth }}
       >
         {/* Background glow orbs */}
         <div className="hidden sm:block absolute w-[520px] h-[520px] bg-blue-400/45 dark:bg-blue-500/40 rounded-full blur-[140px] dark:blur-[120px] -top-[150px] -left-[150px] -z-10 animate-pulse" />

--- a/client/src/shared/components/Navbar.jsx
+++ b/client/src/shared/components/Navbar.jsx
@@ -168,11 +168,12 @@ const Navbar = () => {
                   <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">Explore</p>
                 </div>
                 <div className="py-2">
-                  {overflowNavLinks.map((link) => (
+                  {overflowNavLinks.map((link, index) => (
                     <Link
                       key={link.path}
                       to={link.path}
                       onClick={() => setIsNavMenuOpen(false)}
+                      style={{ animationDelay: `${index * 0.05}s` }}
                       className={`flex items-center gap-3 px-4 py-3 text-sm font-medium transition-colors duration-200 hover:bg-[var(--surface-hover)] ${
                         isActive(link.path)
                           ? 'text-[var(--text-main)] bg-[var(--surface-hover)]'
@@ -392,8 +393,7 @@ const Navbar = () => {
               <Link
                 key={link.path}
                 to={link.path}
-                style={{ animationDelay: `${index * 0.1}s` }}
-                className={`flex items-center gap-4 px-4 py-4 rounded-xl text-base font-medium
+                className={`flex items-center gap-4 px-4 py-4 rounded-xl text-base font-medium [animation-delay:var(--tw-delay)]
                   transition-all duration-300 min-h-[44px] cursor-pointer
                   max-sm:px-3 max-sm:py-3 max-sm:text-[0.95rem] max-sm:gap-3
                   ${isMenuOpen ? 'animate-[slideFadeIn_0.5s_ease_forwards]' : 'opacity-0 translate-y-5'}

--- a/client/src/shared/components/TopLoadingBar.jsx
+++ b/client/src/shared/components/TopLoadingBar.jsx
@@ -21,12 +21,7 @@ const TopLoadingBar = () => {
   return (
     <div className="fixed top-0 left-0 w-full h-1 z-[9999] overflow-hidden bg-brand-100/20">
       <div 
-        className="h-full bg-gradient-to-r from-brand-400 via-brand-500 to-brand-600 shadow-[0_0_10px_var(--primary)]"
-        style={{
-          width: '50%',
-          animation: 'route-progress 1.5s infinite ease-in-out',
-          transformOrigin: 'left'
-        }}
+        className="h-full bg-gradient-to-r from-brand-400 via-brand-500 to-brand-600 shadow-[0_0_10px_var(--primary)] w-1/2 [animation:route-progress_1.5s_infinite_ease-in-out] origin-left"
       />
       <style>{`
         @keyframes route-progress {


### PR DESCRIPTION
This PR implements a project-wide cleanup of inline styles across the shared, profile, mock-interview, and analytics modules. Over 30 instances of hardcoded inline styles have been refactored. Static properties (like gradients, margins, absolute positioning) were migrated to pure Tailwind classes (e.g., bg-gradient-to-br, top-[10%]). Dynamic properties (like width for progress bars) were converted to standardized CSS variables (style={{ '--tw-width': value }}) and mapped to Tailwind's arbitrary value system (w-[var(--tw-width)]). This ensures 100% compatibility with Tailwind's design tokens and dark mode overrides.

Closes #1544 