### PR TITLE
refactor: add video recording, end session, sentiment extraction,  and debug logging to mock interview playwright script [ GSSOC'26 ]

### DIFF
--- a/take-ss.cjs
+++ b/take-ss.cjs
@@ -5,18 +5,39 @@ const fs = require('fs');
 const CONFIG = {
   baseUrl: 'http://localhost:5174/mock-interview',
   screenshotDir: './screenshots',
+  videoDir: './feature-videos',
+  video: { width: 1280, height: 720 },
   timeouts: {
     pageLoad: 2000,
     sessionStart: 3000,
     elementWait: 5000,
+    sentiment: 8000,
   },
   selectors: {
-    startButton: ['text=Start', 'text=Begin', 'button[data-testid="start"]', '[aria-label="Start Interview"]'],
-    sentimentIndicator: ['[data-testid="sentiment"]', '.sentiment-indicator', '[aria-label="Sentiment"]'],
+    startButton: [
+      'text=Start',
+      'text=Begin',
+      'button[data-testid="start"]',
+      '[aria-label="Start Interview"]',
+      'text=Start Interview',
+    ],
+    endButton: [
+      'text=End Session',
+      'text=Finish',
+      '[data-testid="end-session"]',
+      '[aria-label="End Interview"]',
+    ],
+    sentimentIndicator: [
+      '[data-testid="sentiment"]',
+      '.sentiment-indicator',
+      '[aria-label="Sentiment"]',
+      '[data-testid="sentiment-score"]',
+      '.sentiment-score',
+    ],
   },
 };
 
-async function ensureDir(dir) {
+function ensureDir(dir) {
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 }
 
@@ -24,10 +45,9 @@ async function tryClick(page, selectors, timeout = 5000) {
   for (const sel of selectors) {
     try {
       await page.click(sel, { timeout });
+      console.log(`[click] matched: ${sel}`);
       return sel;
-    } catch {
-      continue;
-    }
+    } catch { continue; }
   }
   return null;
 }
@@ -36,58 +56,90 @@ async function waitForAny(page, selectors, timeout = 5000) {
   for (const sel of selectors) {
     try {
       await page.waitForSelector(sel, { timeout });
+      console.log(`[found] selector: ${sel}`);
       return sel;
-    } catch {
-      continue;
-    }
+    } catch { continue; }
   }
   return null;
 }
 
-async function captureScreenshot(page, filename, label) {
+async function capture(page, filename, label) {
   const filePath = path.join(CONFIG.screenshotDir, filename);
   await page.screenshot({ path: filePath, fullPage: true });
   console.log(`[screenshot] ${label} → ${filePath}`);
   return filePath;
 }
 
+async function debugPageElements(page) {
+  const buttons = await page.$$eval('button', els => els.map(e => e.innerText.trim()));
+  console.log('[debug] buttons:', buttons);
+  const testIds = await page.$$eval('[data-testid]', els => els.map(e => e.dataset.testid));
+  console.log('[debug] testids:', testIds);
+  const classes = await page.$$eval('[class*="sentiment"]', els => els.map(e => e.className));
+  console.log('[debug] sentiment classes:', classes);
+}
+
 (async () => {
-  await ensureDir(CONFIG.screenshotDir);
-  const browser = await chromium.launch();
+  ensureDir(CONFIG.screenshotDir);
+  ensureDir(CONFIG.videoDir);
+
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext({
+    recordVideo: { dir: CONFIG.videoDir, size: CONFIG.video },
+  });
 
   try {
-    const page = await browser.newPage();
+    const page = await context.newPage();
 
     // --- Lobby ---
     console.log('[nav] loading lobby...');
     await page.goto(CONFIG.baseUrl, { waitUntil: 'networkidle' });
     await page.waitForTimeout(CONFIG.timeouts.pageLoad);
-    await captureScreenshot(page, 'lobby.png', 'lobby loaded');
+    await capture(page, '01-lobby.png', 'lobby loaded');
+    await debugPageElements(page);
 
     // --- Start session ---
-    const clickedSel = await tryClick(page, CONFIG.selectors.startButton, CONFIG.timeouts.elementWait);
-    if (clickedSel) {
-      console.log(`[action] clicked start via: ${clickedSel}`);
+    const startSel = await tryClick(page, CONFIG.selectors.startButton, CONFIG.timeouts.elementWait);
+    if (startSel) {
       await page.waitForTimeout(CONFIG.timeouts.sessionStart);
-      await captureScreenshot(page, 'session.png', 'session started');
+      await capture(page, '02-session-active.png', 'session started');
+      await debugPageElements(page);
 
       // --- Sentiment indicator ---
-      const sentimentSel = await waitForAny(page, CONFIG.selectors.sentimentIndicator);
+      const sentimentSel = await waitForAny(
+        page,
+        CONFIG.selectors.sentimentIndicator,
+        CONFIG.timeouts.sentiment
+      );
       if (sentimentSel) {
-        console.log(`[found] sentiment indicator: ${sentimentSel}`);
-        await captureScreenshot(page, 'sentiment.png', 'sentiment visible');
+        await capture(page, '03-sentiment-visible.png', 'sentiment visible');
+        const sentimentText = await page.$eval(sentimentSel, el => el.innerText ?? el.textContent);
+        console.log(`[sentiment] value: ${sentimentText}`);
       } else {
-        console.warn('[warn] sentiment indicator not found — check selectors in CONFIG');
+        console.warn('[warn] sentiment indicator not found — check CONFIG.selectors.sentimentIndicator');
+        await capture(page, '03-sentiment-missing.png', 'sentiment not found');
       }
+
+      // --- End session ---
+      const endSel = await tryClick(page, CONFIG.selectors.endButton, CONFIG.timeouts.elementWait);
+      if (endSel) {
+        await page.waitForTimeout(CONFIG.timeouts.pageLoad);
+        await capture(page, '04-session-ended.png', 'session ended');
+      } else {
+        console.warn('[warn] end button not found — check CONFIG.selectors.endButton');
+      }
+
     } else {
-      console.warn('[warn] no start button matched — check CONFIG.selectors.startButton');
+      console.warn('[warn] start button not found — check CONFIG.selectors.startButton');
+      await capture(page, '02-start-missing.png', 'start button not found');
     }
 
   } catch (err) {
     console.error('[error]', err.message);
     process.exit(1);
   } finally {
+    await context.close();
     await browser.close();
-    console.log('[done] browser closed');
+    console.log('[done] video saved to', CONFIG.videoDir);
   }
 })();


### PR DESCRIPTION
## Summary
Added video recording via newContext. Added endButton detection. Added 
sentiment value text extraction after indicator found. Added 
debugPageElements() for buttons/testids/sentiment class logging. 
Added headless:false, numbered screenshots, and missing state screenshots.

## Type of Change
- [x] Refactor — video recording, debug logging, numbered screenshots
- [x] Feature — end session detection, sentiment value extraction

## Related Issue
Closes #1552 

## Changes Made
- Added videoDir to CONFIG and ensureDir call
- Added newContext with recordVideo for full session video
- Added endButton selector array and tryClick after session start
- Added sentiment text extraction via $eval after indicator found
- Added debugPageElements() — logs buttons, testids, sentiment classes
- Added headless: false for visible recording
- Numbered all screenshots 01–04 with descriptive names
- Added missing-state screenshots when selectors not found

## Validation
- [x] Build passes locally
- [x] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)

https://github.com/user-attachments/assets/79fd87b0-da5d-48c2-b4c7-62fabeeb6b5d

