### PR TITLE
fix: decouple metric evaluation from power verb presence (#1511)

### DIFF
--- a/ai-ml/evaluators/readabilityEvaluator.js
+++ b/ai-ml/evaluators/readabilityEvaluator.js
@@ -105,18 +105,11 @@ export default function readabilityEvaluator({ resumeText = "" }) {
 
     const hasPowerVerb = allPowerVerbs.some(verb => words.slice(0, 4).includes(verb));
 
+    // 1. STYLE & IMPACT EVALUATION
     if (hasPowerVerb) {
       powerVerbCount++;
       const matchedVerb = allPowerVerbs.find(verb => words.slice(0, 4).includes(verb));
       if (matchedVerb) verbsUsed.push(matchedVerb);
-
-      const complexity = estimateSentenceComplexity(cleanedSentence);
-      if (complexity === "complex") {
-        complexSentences.push({ sentence: cleanedSentence, complexity });
-      }
-
-      const lengthScore = scoreBulletLength(cleanedSentence);
-      bulletLengthIssues[lengthScore]++;
     } else {
       const category = getSentenceCategory(cleanedSentence);
       if (category === "bullet") {
@@ -132,6 +125,17 @@ export default function readabilityEvaluator({ resumeText = "" }) {
           suggestedRewrite: rewrite,
         });
       }
+    }
+
+    // 2. UNIVERSAL STRUCTURAL EVALUATION
+    const complexity = estimateSentenceComplexity(cleanedSentence);
+    if (complexity === "complex") {
+      complexSentences.push({ sentence: cleanedSentence, complexity });
+    }
+
+    const lengthScore = scoreBulletLength(cleanedSentence);
+    if (bulletLengthIssues[lengthScore] !== undefined) {
+      bulletLengthIssues[lengthScore]++;
     }
 
     // Reset lastIndex for global regex before each test


### PR DESCRIPTION
## Summary

Decoupled structural readability metrics (sentence complexity and bullet length tracking) from the power verb conditional check. This ensures that all sentences, including weak bullets, are completely analyzed for structural formatting issues.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #1511

## Changes Made

- Moved `estimateSentenceComplexity` and `scoreBulletLength` logic blocks out of the `if (hasPowerVerb)` branch into a universal execution step inside the `sentences.forEach` loop.
- Added a safety check (`bulletLengthIssues[lengthScore] !== undefined`) to protect against uninitialized properties during length scoring evaluation.

## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)

*N/A (Backend logic fix for metrics calculation backend data pipeline)*