### PR TITLE
fix: match whole text structures in duplicate sentence check to avoid prefix collisions (#1518)

### DIFF
--- a/ai-ml/evaluators/consistencyEvaluator.js
+++ b/ai-ml/evaluators/consistencyEvaluator.js
@@ -50,13 +50,14 @@ function detectOverusedWords(freqMap, threshold) {
   });
 }
 
-// Detect duplicate sentences using simple similarity check
+// Detect duplicate sentences using full-string matching to avoid prefix collision false positives
 function detectDuplicateSentences(sentences) {
   const duplicates = [];
   const seen = new Set();
 
   sentences.forEach(sentence => {
-    const key = sentence.slice(0, 50); // lightweight similarity
+    // Use the entire normalized string as a hash key instead of truncating at 50 characters
+    const key = sentence.trim();
     if (seen.has(key)) {
       duplicates.push(sentence);
     } else {


### PR DESCRIPTION
## Summary

Modified the `detectDuplicateSentences` logic to evaluate entire sentence strings rather than truncating them to an arbitrary 50-character slice. This fixes an algorithmic flaw that caused distinct, metric-driven bullet points utilizing similar professional introductory structures to trigger false duplicate penalties.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #1518

## Changes Made

- Removed the string `.slice(0, 50)` truncation operation from the tracking loop inside `detectDuplicateSentences`.
- Swapped out the partial substring lookup key for the full, trimmed sentence structure (`sentence.trim()`) when managing unique entries in the deduplication lookup `Set`.

## Validation

- [x] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)

*N/A (Algorithmic string dedup processing repair)*