### PR TITLE
fix(interview): stop socket reconnecting every second due to persistBackup/elapsedTime dep chain

### DIFF
--- a/client/src/modules/mock-interview/hooks/useInterviewState.js
+++ b/client/src/modules/mock-interview/hooks/useInterviewState.js
@@ -75,6 +75,7 @@ export const useInterviewState = (sessionId, isObserver) => {
   const [error, setError] = useState(null);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [elapsedTime, setElapsedTime] = useState(0);
+  const elapsedTimeRef = useRef(0);
   const [currentQuestion, setCurrentQuestion] = useState(null);
   const [isLastQuestion, setIsLastQuestion] = useState(false);
   const [lastScores, setLastScores] = useState(null);
@@ -116,7 +117,7 @@ export const useInterviewState = (sessionId, isObserver) => {
         messages: answer
           ? [{ role: "candidate", content: answer, timestamp: Date.now() }]
           : [],
-        elapsedTime,
+        elapsedTime: elapsedTimeRef.current,
         uploadStatus,
         currentQuestion,
         ...overrides,
@@ -126,7 +127,6 @@ export const useInterviewState = (sessionId, isObserver) => {
       answer,
       currentIndex,
       currentQuestion,
-      elapsedTime,
       session,
       sessionId,
       uploadStatus,
@@ -136,7 +136,8 @@ export const useInterviewState = (sessionId, isObserver) => {
   // Timer progression
   useEffect(() => {
     const timer = setInterval(() => {
-      setElapsedTime((prev) => prev + 1);
+      elapsedTimeRef.current += 1;
+      setElapsedTime(elapsedTimeRef.current);
     }, 1000);
     return () => clearInterval(timer);
   }, []);
@@ -177,7 +178,8 @@ export const useInterviewState = (sessionId, isObserver) => {
         const savedSession = loadInterviewSession();
         if (savedSession && savedSession.sessionId === sessionId) {
           idx = Math.min(savedSession.currentIndex, data.answers.length - 1);
-          setElapsedTime(savedSession.elapsedTime || 0);
+          elapsedTimeRef.current = savedSession.elapsedTime || 0;
+          setElapsedTime(elapsedTimeRef.current);
           setUploadStatus(savedSession.uploadStatus || "idle");
           setAnswer(savedSession.answer || savedSession.messages?.at(-1)?.content || "");
           setRecoveryMessage("Recovered saved interview progress.");


### PR DESCRIPTION
## Summary

`useInterviewSocket` was tearing down and recreating the Socket.IO connection once per second for the entire duration of every interview session. Root cause is a dependency chain: `elapsedTime` (updated every second) was in `persistBackup`'s `useCallback` dep array, which gave it a new reference each tick, which triggered `useInterviewSocket`'s `useEffect` (which lists `persistBackup` as a dep) to re-run its cleanup and re-init every second.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #1581

## Changes Made

- Added `elapsedTimeRef` to hold the timer value without making it a reactive dep
- Timer now updates both the ref and the state; display is unchanged
- `persistBackup` reads `elapsedTimeRef.current` instead of `elapsedTime`, removing it from the dep array
- On session rehydration, the ref is synced alongside the state so a restored timer continues from the correct value

## Validation

- [x] Build passes locally
- [x] ESLint clean (`eslint --max-warnings=0`)
- [x] Pre-existing test failures confirmed unrelated (same count on `main` before this change)

## Screenshots (if UI change)

No visual change. Timer display is driven by `elapsedTime` state which still updates every second. The only behavioral change is the socket stays connected instead of reconnecting 60 times/minute.