### PR TITLE
fix(interview): negotiate MediaRecorder MIME type for Safari compatibility

### DIFF
--- a/client/src/modules/mock-interview/hooks/useInterviewAudio.js
+++ b/client/src/modules/mock-interview/hooks/useInterviewAudio.js
@@ -46,6 +46,11 @@ export const useInterviewAudio = ({
     [clearMediaTrackListeners, persistBackup, setMediaWarning, setUploadStatus],
   );
 
+  const getSupportedMimeType = () => {
+    const candidates = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4", "audio/ogg"];
+    return candidates.find((type) => MediaRecorder.isTypeSupported(type)) ?? "";
+  };
+
   const startRecording = useCallback(async () => {
     if (isStartingRef.current) return;
     isStartingRef.current = true;
@@ -55,7 +60,8 @@ export const useInterviewAudio = ({
       setFailedAction(null);
       setUploadStatus("starting");
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      const mediaRecorder = new MediaRecorder(stream, { mimeType: "audio/webm" });
+      const mimeType = getSupportedMimeType();
+      const mediaRecorder = new MediaRecorder(stream, mimeType ? { mimeType } : {});
       mediaRecorderRef.current = mediaRecorder;
       mediaStreamRef.current = stream;
       attachMediaTrackListeners(stream);
@@ -100,8 +106,17 @@ export const useInterviewAudio = ({
       setIsRecording(false);
       setUploadStatus("failed");
       setFailedAction("media");
-      setMediaWarning("Microphone access was denied or unavailable. Check your device and retry.");
-      setError("Microphone access denied or unavailable.");
+      const isCodecError = err.name === "NotSupportedError";
+      setMediaWarning(
+        isCodecError
+          ? "Audio recording is not supported in this browser. Please use Chrome or Firefox."
+          : "Microphone access was denied or unavailable. Check your device and retry.",
+      );
+      setError(
+        isCodecError
+          ? "Audio recording is not supported in this browser."
+          : "Microphone access denied or unavailable.",
+      );
       persistBackup({ uploadStatus: "failed" });
     } finally {
       isStartingRef.current = false;


### PR DESCRIPTION
## Summary

Voice recording was completely broken on Safari. Hardcoded `audio/webm` is unsupported on Safari and throws `NotSupportedError` synchronously before recording starts. The error fell into the generic catch block and showed "Microphone access was denied" — factually wrong and unactionable.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #1582

## Changes Made

- Added `getSupportedMimeType()` that tries `audio/webm;codecs=opus`, `audio/webm`, `audio/mp4`, `audio/ogg` in order and returns the first supported type
- `MediaRecorder` is constructed with the negotiated type; falls back to no `mimeType` option if none match (browser default)
- Catch block now checks `err.name === "NotSupportedError"` to show a browser-compatibility message instead of a false permission denial

## Validation

- [x] Build passes locally
- [x] ESLint clean
- Chrome/Firefox: unchanged behavior, `audio/webm;codecs=opus` is selected
- Safari: `audio/mp4` is selected, recording works
- Server-side Whisper accepts both containers, no backend changes needed

## Screenshots (if UI change)

No visual change on Chrome/Firefox. On Safari the record button now works instead of immediately showing an error banner.