### PR TITLE
fix: notify recruiter when withdrawn application is re-submitted

### DIFF
--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -598,6 +598,17 @@ export const applyToJob = async (jobId, applicantId, options = {}) => {
       existing.coverNote = options.coverNote?.trim() || "";
       existing.statusHistory.push({ status: "pending", comment: "Application re-submitted after withdrawal" });
       await existing.save();
+      await Notification.create({
+  userId: job.recruiter,
+  type: "new_application",
+  title: "Application Re-submitted",
+  message: `A candidate has re-submitted their application for "${job.title}".`,
+  metadata: { jobId: job._id, applicationId: existing._id }
+});
+const io = getIO();
+if (io) {
+  io.to(`user_${job.recruiter}`).emit("new-notification", {});
+}
 
       // Re-evaluate candidate match asynchronously
       recruiterIntelligenceService.evaluateCandidateMatch(existing._id).catch(err => {


### PR DESCRIPTION
Fixes #1429

## Problem
In `server/src/modules/jobs/service.js`, when a student re-applies 
after withdrawing, the application was re-activated but the 
recruiter received no notification.

## Fix
Added notification creation and real-time socket emit when 
a withdrawn application is re-submitted.

## Changes
- `server/src/modules/jobs/service.js` — notification added on re-apply