### PR TITLE
fix: add null check for userId in getNotificationById to prevent crash

### DIFF
--- a/server/src/modules/notifications/service.js
+++ b/server/src/modules/notifications/service.js
@@ -94,7 +94,7 @@ export const getNotificationById = async (notificationId, userId) => {
   }
 
   // Verify ownership
-  if (notification.userId._id.toString() !== userId) {
+  if (!notification.userId || notification.userId._id.toString() !== userId) {
     throw new AppError("Not authorized to access this notification", 403);
   }
 


### PR DESCRIPTION
Fixes #1591

## Problem
In `server/src/modules/notifications/service.js`, `getNotificationById` 
accessed `notification.userId._id` without checking if the populated 
userId was null (which happens if the referenced user was deleted), 
causing an unhandled TypeError instead of a clean error response.

## Fix
Added a null check before accessing _id:

if (!notification.userId || notification.userId._id.toString() !== userId) {
  throw new AppError("Not authorized to access this notification", 403);
}

## Changes
- `server/src/modules/notifications/service.js` — 1 line updated