### PR TITLE
fix: delete replaced resume files

### DIFF
--- a/server/src/modules/resumes/service.js
+++ b/server/src/modules/resumes/service.js
@@ -1,5 +1,6 @@
 import Resume from "../../database/models/Resume.js";
 import SemanticCache from "../../database/models/SemanticCache.js";
+import { safeDeletePhysicalFile } from "../../utils/fileUtils.js";
 
 /**
  * Upsert a resume for a user.
@@ -14,6 +15,10 @@ import SemanticCache from "../../database/models/SemanticCache.js";
 export const upsertResume = async (userId, resumeData, includeText = false) => {
   // If the payload specifies an existing resume ID, we update that document
   if (resumeData._id) {
+    const existingResume = await Resume.findById(resumeData._id).select("file.path");
+    const oldFilePath = existingResume?.file?.path;
+    const newFilePath = resumeData.file?.path;
+
     const query = Resume.findByIdAndUpdate(
       resumeData._id,
       resumeData,
@@ -22,7 +27,13 @@ export const upsertResume = async (userId, resumeData, includeText = false) => {
     if (includeText) {
       query.select("+resumeText");
     }
-    return await query;
+    const updatedResume = await query;
+
+    if (updatedResume && oldFilePath && newFilePath && oldFilePath !== newFilePath) {
+      safeDeletePhysicalFile(oldFilePath);
+    }
+
+    return updatedResume;
   }
 
   // Otherwise, we are uploading a new resume version.


### PR DESCRIPTION
## Summary
- Captures the previous stored resume file path before updating an existing resume
- Deletes the old physical file only after the replacement update succeeds and the file path changes

Fixes #1593

## Testing
- Not run: dependencies are not installed in this workspace; npm test fails before reaching focused tests with missing packages such as winston and mongoose.