### PR TITLE
fix: reopen roadmap topic when verification is removed

### DIFF
--- a/server/src/modules/roadmap/controller.js
+++ b/server/src/modules/roadmap/controller.js
@@ -374,6 +374,8 @@ export const verifyTopic = asyncHandler(async (req, res) => {
   } else {
     topic.verifiedBy = null;
     topic.verifiedAt = null;
+    topic.status = "in_progress";
+    topic.completedAt = null;
   }
 
   // --- Achievement Calculation Logic ---


### PR DESCRIPTION
## Summary
- Clears verification metadata when a tutor removes topic verification
- Reopens the topic and clears completedAt so progress no longer stays completed after verification is revoked

Fixes #1596

## Testing
- Not run: dependencies are not installed in this workspace; npm test fails before reaching focused tests with missing packages such as winston and mongoose.