### PR TITLE
fix: delete old audio file when answer is resubmitted for same question

### DIFF
--- a/server/src/modules/interviews/service.js
+++ b/server/src/modules/interviews/service.js
@@ -1,4 +1,5 @@
 import InterviewSession from "../../database/models/InterviewSession.js";
+import fsPromises from "fs/promises";
 import QuestionBank from "../../database/models/QuestionBank.js";
 import ConceptGraph from "../../database/models/ConceptGraph.js";
 import LearningProgress from "../../database/models/LearningProgress.js";
@@ -214,6 +215,10 @@ export const processAnswerSubmission = async ({
     session.answers[currentIndex].answeredAt = new Date();
 
     if (audioFile) {
+      const oldAudioPath = session.answers[currentIndex].audioPath;
+      if (oldAudioPath && oldAudioPath !== audioFile.path) {
+        await fsPromises.unlink(oldAudioPath).catch(() => {});
+      }
       session.answers[currentIndex].audioPath = audioFile.path || null;
     }
 


### PR DESCRIPTION
Fixes #1594

## Problem
In `server/src/modules/interviews/service.js`, processAnswerSubmission 
overwrote audioPath for a question's answer without deleting the 
previous audio file. Resubmitted answers left orphaned audio 
files accumulating on disk.

## Fix
Delete the old audio file before overwriting with the new one.

## Changes
- `server/src/modules/interviews/service.js` — 5 lines added