### PR TITLE
fix: add limit to interview history analytics query

### DIFF
--- a/server/src/modules/interviews/service.js
+++ b/server/src/modules/interviews/service.js
@@ -375,7 +375,8 @@ export const getUserInterviewHistory = async (userId, page, limit) => {
     InterviewSession.countDocuments({ userId, status: { $ne: "abandoned" } }),
     InterviewSession.find({ userId, status: "completed" })
       .select("topic overallScore weakConcepts completedAt createdAt")
-      .sort({ completedAt: 1, createdAt: 1 })
+      .sort({ completedAt: -1, createdAt: -1 })
+      .limit(100)
       .lean(),
   ]);
 


### PR DESCRIPTION
Fixes #1595

## Problem
In `server/src/modules/interviews/service.js`, getUserInterviewHistory 
fetched ALL of a user's completed interview sessions for analytics 
calculation with no limit, becoming increasingly expensive as 
users accumulate sessions over time.

## Fix
Added .limit(100) to compute analytics over the most recent 100 
completed sessions instead of the entire history.

## Changes
- `server/src/modules/interviews/service.js` — limit added