### PR TITLE
fix: add limit to getBookmarkedQuestions to prevent unbounded query

### DIFF
--- a/server/src/modules/interviews/service.js
+++ b/server/src/modules/interviews/service.js
@@ -511,6 +511,7 @@ export const getBookmarkedQuestions = async (userId) => {
   })
     .select("topic difficulty status overallScore createdAt completedAt answers")
     .sort({ createdAt: -1 })
+    .limit(50)
     .lean();
 
   return sessions.flatMap((session) =>


### PR DESCRIPTION
Fixes #1598

## Problem
In `server/src/modules/interviews/service.js`, getBookmarkedQuestions 
fetched ALL sessions containing bookmarked answers for a user with 
no limit, becoming increasingly expensive as users bookmark more 
questions over time.

## Fix
Added .limit(50) to cap the number of sessions returned.

## Changes
- `server/src/modules/interviews/service.js` — limit added