### PR TITLE
fix : replaced loose equality with strict equality for EMAIL_PORT in emailService

### DIFF
--- a/server/src/utils/emailService.js
+++ b/server/src/utils/emailService.js
@@ -32,7 +32,7 @@ export const sendEmail = async (to, subject, text, html) => {
   const transporter = nodemailer.createTransport({
     host: process.env.EMAIL_HOST,
     port: parseInt(process.env.EMAIL_PORT, 10) || 587,
-    secure: process.env.EMAIL_PORT == 465, // true for 465, false for other ports
+    secure: process.env.EMAIL_PORT === 465, // true for 465, false for other ports
     auth: {
       user: process.env.EMAIL_USER,
       pass: process.env.EMAIL_PASS,


### PR DESCRIPTION
Closes #1617.

Summary of What Has Been Done:
Replaced loose equality (==) with strict equality (===) when checking if the SMTP port requires TLS in server/src/utils/emailService.js. The previous code used process.env.EMAIL_PORT == 465 which could produce unexpected results due to type coercion.

Changes Made:
- server/src/utils/emailService.js: changed == to === on line checking EMAIL_PORT for TLS configuration

Impact it Made:
- Eliminates a JavaScript anti-pattern and potential type coercion bug
- Improves code quality and correctness

Note: Please assign this PR to the `tmdeveloper007` account.