### PR TITLE
fix(parseJD) : use upper bound for years of experience in range patterns

### DIFF
--- a/server/src/utils/parseJD.js
+++ b/server/src/utils/parseJD.js
@@ -40,8 +40,8 @@ export const extractDataFromJD = (jdText) => {
     let match;
     while ((match = pattern.exec(normalizedJD)) !== null) {
       if (match[2]) {
-        // Range case: take the lower bound as required experience
-        maxYears = Math.max(maxYears, parseInt(match[1]));
+        // Range case: take the upper bound as the conservative experience estimate
+        maxYears = Math.max(maxYears, parseInt(match[2]));
       } else {
         maxYears = Math.max(maxYears, parseInt(match[1]));
       }


### PR DESCRIPTION
Closes #1636.

Summary of What Has Been Done:
Fixed the years-of-experience extraction in server/src/utils/parseJD.js. For range patterns like '3-5 years', the code was using the lower bound (match[1]) instead of the upper bound (match[2]), understating the experience requirement. Now uses the upper bound as the conservative estimate of job requirements.

Changes Made:
- server/src/utils/parseJD.js: Changed range case to use match[2] (upper bound) instead of match[1] (lower bound) in the experience extraction logic.

Impact it Made:
- Job recommendation matching will now correctly use upper-bound experience requirements
- Candidates are less likely to be matched to roles where they are underqualified
- The lint error at matching/service.js:167 is pre-existing on main and unrelated to this change

Note: Please assign this PR to the `tmdeveloper007` account.