### PR TITLE
test: add pass/fail counter, bulk IV uniqueness, extended tamper  cases, and decrypt type safety to encryption test [ GSSOC'26 ]

### DIFF
--- a/test_decrypt.cjs
+++ b/test_decrypt.cjs
@@ -2,72 +2,102 @@ const { encrypt, decrypt } = require("./server/src/utils/encryption.js");
 require("dotenv").config({ path: "server/.env" });
 
 // --- Helpers ---
+let passed = 0;
+let failed = 0;
+
 function assert(condition, label) {
-  if (!condition) { console.error(`[FAIL] ${label}`); process.exit(1); }
-  console.log(`[PASS] ${label}`);
+  if (!condition) { console.error(`[FAIL] ${label}`); failed++; }
+  else { console.log(`[PASS] ${label}`); passed++; }
 }
 
 function assertNoPlaintext(ciphertext, plaintext, label) {
   assert(!ciphertext.includes(plaintext), `${label} — plaintext not in ciphertext`);
 }
 
-// --- ENV check ---
+function assertThrows(fn, label) {
+  try { fn(); assert(false, label); }
+  catch { assert(true, label); }
+}
+
+function assertFormat(ciphertext) {
+  assert(typeof ciphertext === "string" && ciphertext.length > 0, "ciphertext is non-empty string");
+  assert(ciphertext.startsWith("v1:gcm:"), "ciphertext has v1:gcm: prefix");
+  const parts = ciphertext.split(":");
+  assert(parts.length >= 5, `ciphertext has >= 5 parts (got ${parts.length})`);
+}
+
+// --- ENV ---
 assert(!!process.env.JWT_SECRET, "JWT_SECRET is set");
 assert(!!process.env.ENCRYPTION_KEY || !!process.env.SECRET_KEY, "encryption key env var is set");
 
-// --- Decrypt known ciphertext ---
+// --- Known ciphertext decrypt ---
 const KNOWN_CIPHERTEXT = "v1:gcm:a02a19ae8a0e138cf430b563:58cf1207bab9460a08737686f7eda382:0:f1b8a514d7c865db2650080fb05fcecb";
-
 try {
   const decrypted = decrypt(KNOWN_CIPHERTEXT);
   assert(typeof decrypted === "string" && decrypted.length > 0, "known ciphertext decrypts to non-empty string");
   console.log("[debug] decrypted length:", decrypted.length, "(value hidden)");
 } catch (err) {
   console.warn(`[warn] known ciphertext decrypt failed: ${err.message}`);
-  console.warn("[warn] key mismatch or ciphertext from different env — expected in CI");
+  console.warn("[warn] key mismatch or different env — expected in CI");
 }
 
-// --- Encrypt/decrypt roundtrip ---
+// --- Roundtrip ---
 const testValues = [
   "alice@example.com",
   "simple",
   "with spaces and symbols !@#$%",
   "unicode: 用户名",
   "a".repeat(500),
+  "123456789",
+  "UPPERCASE@DOMAIN.COM",
+  "  leading trailing spaces  ",
 ];
 
 testValues.forEach((val) => {
   const encrypted = encrypt(val);
   const decrypted = decrypt(encrypted);
   assert(decrypted === val, `roundtrip: "${val.slice(0, 30)}${val.length > 30 ? "..." : ""}"`);
-  assertNoPlaintext(encrypted, val, `plaintext not leaked: "${val.slice(0, 20)}..."`);
+  assertNoPlaintext(encrypted, val.trim().slice(0, 6), `plaintext not leaked: "${val.slice(0, 20)}..."`);
 });
 
-// --- Ciphertext format validation ---
+// --- Format validation ---
 const sample = encrypt("test");
-assert(sample.startsWith("v1:gcm:"), "ciphertext has v1:gcm: prefix");
-const parts = sample.split(":");
-assert(parts.length >= 5, `ciphertext has >= 5 colon-separated parts (got ${parts.length})`);
+assertFormat(sample);
 
-// --- Unique ciphertext per call (random IV) ---
+// --- IV uniqueness ---
 const enc1 = encrypt("same-input");
 const enc2 = encrypt("same-input");
-assert(enc1 !== enc2, "same input produces different ciphertext (random IV)");
+assert(enc1 !== enc2, "same input → different ciphertext (random IV)");
 
-// --- Different inputs produce different ciphertext ---
+// --- Different inputs differ ---
 const encA = encrypt("alice@example.com");
 const encB = encrypt("bob@example.com");
-assert(encA !== encB, "different inputs produce different ciphertext");
+assert(encA !== encB, "different inputs → different ciphertext");
 
-// --- Tampered ciphertext throws ---
-try {
-  decrypt("v1:gcm:tampered:tampered:0:tampered");
-  assert(false, "tampered ciphertext should throw");
-} catch {
-  assert(true, "tampered ciphertext throws correctly");
-}
+// --- High-volume uniqueness (10 calls) ---
+const samples = Array.from({ length: 10 }, () => encrypt("bulk-test"));
+const unique = new Set(samples);
+assert(unique.size === 10, "10 encryptions of same input all unique (random IV)");
 
-// --- Empty string handling ---
+// --- Tamper resistance ---
+const tamperCases = [
+  "v1:gcm:tampered:tampered:0:tampered",
+  "v1:gcm::::",
+  "notvalid",
+  "",
+  "v1:gcm:" + "a".repeat(200),
+];
+tamperCases.forEach((tc, i) => {
+  assertThrows(() => decrypt(tc), `tamper case ${i + 1} throws: "${tc.slice(0, 30)}"`);
+});
+
+// --- Decrypt-only tamper (valid format, wrong auth tag) ---
+assertThrows(
+  () => decrypt("v1:gcm:a02a19ae8a0e138cf430b563:58cf1207bab9460a08737686f7eda382:0:ffffffffffffffffffffffffffffffff"),
+  "wrong auth tag throws"
+);
+
+// --- Empty string ---
 try {
   const encEmpty = encrypt("");
   const decEmpty = decrypt(encEmpty);
@@ -76,19 +106,18 @@ try {
   assert(true, "empty string throws — acceptable");
 }
 
-// --- Null/undefined safe ---
-try {
-  encrypt(null);
-  assert(false, "null should throw");
-} catch {
-  assert(true, "null input throws");
-}
+// --- Type safety ---
+assertThrows(() => encrypt(null), "null throws");
+assertThrows(() => encrypt(undefined), "undefined throws");
+assertThrows(() => encrypt(12345), "number throws");
+assertThrows(() => encrypt({}), "object throws");
+assertThrows(() => encrypt([]), "array throws");
 
-try {
-  encrypt(undefined);
-  assert(false, "undefined should throw");
-} catch {
-  assert(true, "undefined input throws");
-}
+// --- Decrypt type safety ---
+assertThrows(() => decrypt(null), "decrypt null throws");
+assertThrows(() => decrypt(undefined), "decrypt undefined throws");
+assertThrows(() => decrypt(12345), "decrypt number throws");
 
-console.log("\n[done] all encryption tests passed");
+// --- Summary ---
+console.log(`\n[done] ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary
Replaced hard-exit assert with counter-based tracking and summary. 
Added assertThrows() and assertFormat() helpers. Expanded roundtrip 
to 8 values. Added 10-call bulk IV uniqueness, 5 tamper cases, wrong 
auth tag test, and decrypt type safety for null/undefined/number.

## Type of Change
- [x] Feature — bulk uniqueness, extended tamper, decrypt type safety, summary

## Related Issue
Closes #1664 
## Changes Made
- Replaced process.exit(1) in assert with passed/failed counters
- Added assertThrows() helper — deduplicates try/catch pattern
- Added assertFormat() helper — validates prefix + part count
- Expanded roundtrip testValues to 8 (added numbers, uppercase, whitespace)
- Added 10-call bulk IV uniqueness via Set size check
- Added 5 tamper cases covering empty, short, long, malformed inputs
- Added wrong auth tag decrypt test
- Added decrypt type safety: null/undefined/number
- Added [done] X passed, Y failed summary + exit(1) on failure

## Validation
- [x] Build passes locally
- [x] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)
N/A