### PR TITLE
feat: add bulk determinism, domain variation, 50-user collision stress,  and type safety to encrypted email query test [ GSSOC'26 ]

### DIFF
--- a/test_find.cjs
+++ b/test_find.cjs
@@ -11,6 +11,11 @@ function assert(condition, label) {
   else { console.log(`[PASS] ${label}`); passed++; }
 }
 
+function assertThrows(fn, label) {
+  try { fn(); assert(false, label); }
+  catch { assert(true, label); }
+}
+
 function normalizeEmail(email) {
   if (!email || typeof email !== "string") throw new Error("invalid email input");
   return email.toLowerCase().trim();
@@ -36,7 +41,7 @@ async function runTests() {
   const enc3 = encryptDeterministic(normalizeEmail("other@gmail.com"));
   assert(enc1 !== enc3, "deterministic: different input = different ciphertext");
 
-  // 3. Case/whitespace normalization
+  // 3. Case normalization
   const encLower = encryptDeterministic(normalizeEmail("TestAuth4@Gmail.com"));
   assert(encLower === enc1, "normalization: uppercase matches lowercase encrypted");
 
@@ -44,61 +49,63 @@ async function runTests() {
   const encTrimmed = encryptDeterministic(normalizeEmail("  testauth4@gmail.com  "));
   assert(encTrimmed === enc1, "normalization: whitespace trimmed before encrypt");
 
-  // 5. Ciphertext not plaintext
+  // 5. Plaintext not in ciphertext
   assert(!enc1.includes("testauth4@gmail.com"), "plaintext not in ciphertext");
 
-  // 6. Ciphertext is string
+  // 6. Ciphertext is non-empty string
   assert(typeof enc1 === "string" && enc1.length > 0, "ciphertext is non-empty string");
 
-  // 7. Query DB with encrypted email
+  // 7. Bulk determinism — 10 calls same output
+  const bulkResults = Array.from({ length: 10 }, () =>
+    encryptDeterministic(normalizeEmail("testauth4@gmail.com"))
+  );
+  const allSame = bulkResults.every(r => r === enc1);
+  assert(allSame, "bulk determinism: 10 calls all produce same ciphertext");
+
+  // 8. Domain variation — same user different domain = different ciphertext
+  const encGmail = encryptDeterministic(normalizeEmail("testauth4@gmail.com"));
+  const encOutlook = encryptDeterministic(normalizeEmail("testauth4@outlook.com"));
+  assert(encGmail !== encOutlook, "domain variation: same local part different domain differs");
+
+  // 9. Subdomain variation
+  const encSub = encryptDeterministic(normalizeEmail("testauth4@mail.gmail.com"));
+  assert(encSub !== encGmail, "subdomain variation: differs from root domain");
+
+  // 10. Query DB with encrypted email
   const rawUser = await findByEncryptedEmail(users, "testauth4@gmail.com");
   console.log(`[debug] user found in DB: ${!!rawUser}`);
   assert(rawUser !== null, "DB query: user found by encrypted email");
 
-  // 8. Wrong email returns null
+  // 11. Wrong email returns null
   const wrongUser = await findByEncryptedEmail(users, "nonexistent@gmail.com");
   assert(wrongUser === null, "DB query: wrong email returns null");
 
-  // 9. Plaintext email NOT findable
+  // 12. Plaintext NOT findable in DB
   const plainUser = await users.findOne({ email: "testauth4@gmail.com" });
   assert(plainUser === null, "DB at-rest: plaintext email not stored");
 
-  // 10. Multiple users don't collide
+  // 13. Case variant NOT findable with raw query
+  const caseUser = await users.findOne({ email: "TestAuth4@Gmail.com" });
+  assert(caseUser === null, "DB at-rest: mixed-case plaintext not stored");
+
+  // 14. No collision between users
   const encA = encryptDeterministic(normalizeEmail("usera@gmail.com"));
   const encB = encryptDeterministic(normalizeEmail("userb@gmail.com"));
   assert(encA !== encB, "no collision: different users encrypt differently");
 
-  // 11. Empty string throws
-  try {
-    normalizeEmail("");
-    assert(false, "empty email should throw");
-  } catch {
-    assert(true, "empty email throws correctly");
-  }
+  // 15. 50-user no-collision stress test
+  const emails = Array.from({ length: 50 }, (_, i) => `user${i}@gmail.com`);
+  const encryptedEmails = emails.map(e => encryptDeterministic(normalizeEmail(e)));
+  const uniqueCount = new Set(encryptedEmails).size;
+  assert(uniqueCount === 50, `no collision: 50 unique users all encrypt differently (got ${uniqueCount} unique)`);
 
-  // 12. Null throws
-  try {
-    normalizeEmail(null);
-    assert(false, "null email should throw");
-  } catch {
-    assert(true, "null email throws correctly");
-  }
-
-  // 13. Number input throws
-  try {
-    normalizeEmail(12345);
-    assert(false, "number input should throw");
-  } catch {
-    assert(true, "number input throws correctly");
-  }
-
-  // 14. Object input throws
-  try {
-    normalizeEmail({});
-    assert(false, "object input should throw");
-  } catch {
-    assert(true, "object input throws correctly");
-  }
+  // 16-19. Type safety via assertThrows
+  assertThrows(() => normalizeEmail(""), "empty string throws");
+  assertThrows(() => normalizeEmail(null), "null throws");
+  assertThrows(() => normalizeEmail(12345), "number throws");
+  assertThrows(() => normalizeEmail({}), "object throws");
+  assertThrows(() => normalizeEmail([]), "array throws");
+  assertThrows(() => normalizeEmail(undefined), "undefined throws");
 
   await mongoose.disconnect();
 


### PR DESCRIPTION
## Summary
Added assertThrows() helper. Added 10-call bulk determinism, domain 
and subdomain variation assertions, 50-user collision stress via Set 
size, DB case-variant plaintext check, and undefined/array type safety. 
Total assertions expanded from 14 to 21.

## Type of Change
- [x] Feature — bulk determinism, domain variation, stress test, type safety

## Related Issue
Closes #1666 

## Changes Made
- Added assertThrows() helper — deduplicates try/catch pattern
- Added 10-call bulk determinism assertion
- Added domain variation (gmail vs outlook same local part)
- Added subdomain variation assertion
- Added DB case-variant plaintext check
- Added 50-user no-collision stress via Set size
- Added undefined and array type safety via assertThrows
- Total: 21 assertions, all run before exit

## Validation
- [x] Build passes locally
- [x] Relevant tests added/updated
- [ ] Documentation updated (if needed)

## Screenshots (if UI change)
N/A