### PR TITLE
fix: add limit to getTrackedRoadmaps to prevent unbounded query

### DIFF
--- a/server/src/modules/roadmap/controller.js
+++ b/server/src/modules/roadmap/controller.js
@@ -603,6 +603,7 @@ export const optInTutorTracking = asyncHandler(async (req, res) => {
 export const getTrackedRoadmaps = asyncHandler(async (req, res) => {
   const roadmaps = await LearningProgress.find({ recruitersTracking: req.user._id })
     .populate("user", "name email role")
+    .limit(50)
     .lean();
 
   res.status(200).json({


### PR DESCRIPTION
Fixes #1672 

## Problem
getTrackedRoadmaps fetched ALL roadmaps tracked by a recruiter 
with no limit, becoming expensive as tracking grows.

## Fix
Added .limit(50) to cap results.

## Changes
- server/src/modules/roadmap/controller.js — limit added