### PR TITLE
fix: trim title and subject fields when creating classroom session

### DIFF
--- a/server/src/modules/classrooms/service.js
+++ b/server/src/modules/classrooms/service.js
@@ -17,8 +17,8 @@ export const createSession = async (hostId, { title, subject, maxParticipants })
   const roomId = uuidv4();
   const session = await ClassroomSession.create({
     roomId,
-    title,
-    subject,
+    title: title.trim(),
+    subject: subject?.trim() || "",
     maxParticipants,
     host: hostId,
     status: "active",


### PR DESCRIPTION
Fixes #1676 

## Problem
createSession saved title and subject without trimming, allowing 
whitespace-padded values to persist in the database.

## Fix
Trimmed both fields before saving.

## Changes
- server/src/modules/classrooms/service.js — fields trimmed