### PR TITLE
fix: add validation and trimming for title and description in createJ…

### DIFF
--- a/server/src/modules/jobs/controller.js
+++ b/server/src/modules/jobs/controller.js
@@ -78,12 +78,14 @@ export const createJobPosting = asyncHandler(async (req, res) => {
     keywords,
   } = req.body;
 
-
+  if (!title?.trim() || !description?.trim()) {
+    throw new AppError("Title and description are required", 400);
+  }
 
   // Create job posting with recruiter from authenticated user
   const jobPosting = await JobPosting.create({
-    title,
-    description,
+    title: title.trim(),
+    description: description.trim(),
     requirements,
     responsibilities,
     skills,


### PR DESCRIPTION
Fixes #1678 

## Problem
createJobPosting saved fields without validating presence or 
trimming whitespace, allowing empty or whitespace-only job postings.

## Fix
Added validation requiring non-empty title/description, and trim 
both before saving.

## Changes
- server/src/modules/jobs/controller.js — validation added