### PR TITLE
feat: Implement soft deletion for job postings and applications to pr…

### DIFF
--- a/server/src/database/models/JobApplication.js
+++ b/server/src/database/models/JobApplication.js
@@ -24,13 +24,13 @@ const jobApplicationSchema = new mongoose.Schema(
 
     status: {
       type: String,
-      enum: ["pending", "reviewed", "shortlisted", "rejected", "withdrawn"],
+      enum: ["pending", "reviewed", "shortlisted", "rejected", "withdrawn", "archived"],
       default: "pending",
     },
 
     studentStatus: {
       type: String,
-      enum: ["pending", "reviewed", "shortlisted", "rejected", "withdrawn", null],
+      enum: ["pending", "reviewed", "shortlisted", "rejected", "withdrawn", "archived", null],
       default: null,
     },
 
@@ -100,7 +100,7 @@ const jobApplicationSchema = new mongoose.Schema(
       {
         status: {
           type: String,
-          enum: ["pending", "reviewed", "shortlisted", "rejected", "withdrawn"],
+          enum: ["pending", "reviewed", "shortlisted", "rejected", "withdrawn", "archived"],
           required: true,
         },
         comment: {

--- a/server/src/database/models/JobPosting.js
+++ b/server/src/database/models/JobPosting.js
@@ -57,7 +57,7 @@ const jobPostingSchema = new mongoose.Schema(
 
     status: {
       type: String,
-      enum: ["draft", "open", "closed"],
+      enum: ["draft", "open", "closed", "archived"],
       default: "draft",
       required: true,
     },

--- a/server/src/modules/jobs/service.js
+++ b/server/src/modules/jobs/service.js
@@ -234,8 +234,15 @@ export const deleteJob = async (id, recruiterId) => {
       const applications = await JobApplication.find({ job: id }).select("applicant").session(dbSession);
 
       // Delete all associated applications within transaction
-      await JobApplication.deleteMany({ job: id }, { session: dbSession });
-      await JobPosting.findByIdAndDelete(id, { session: dbSession });
+      await JobApplication.updateMany(
+        { job: id },
+        { 
+          $set: { status: "archived", studentStatus: "archived" },
+          $push: { statusHistory: { status: "archived", comment: "Job posting was removed by the recruiter" } }
+        },
+        { session: dbSession }
+      );
+      await JobPosting.findByIdAndUpdate(id, { status: "archived" }, { session: dbSession });
 
       if (applications.length > 0) {
         const notificationsData = applications.map(app => ({
@@ -275,8 +282,14 @@ export const deleteJob = async (id, recruiterId) => {
     }
     
     const applications = await JobApplication.find({ job: id }).select("applicant");
-    await JobApplication.deleteMany({ job: id });
-    await JobPosting.findByIdAndDelete(id);
+    await JobApplication.updateMany(
+      { job: id },
+      { 
+        $set: { status: "archived", studentStatus: "archived" },
+        $push: { statusHistory: { status: "archived", comment: "Job posting was removed by the recruiter" } }
+      }
+    );
+    await JobPosting.findByIdAndUpdate(id, { status: "archived" });
 
     if (applications.length > 0) {
       const notificationsData = applications.map(app => ({
@@ -535,7 +548,7 @@ export const getRecruiterAnalytics = async (recruiterId) => {
     ])
   ]);
 
-  const statusBreakdown = { open: 0, draft: 0, closed: 0 };
+  const statusBreakdown = { open: 0, draft: 0, closed: 0, archived: 0 };
   let totalJobs = 0;
   statusAgg.forEach((stat) => {
     const status = stat._id;


### PR DESCRIPTION
## Summary
This PR transitions the job deletion process from a hard-delete to a soft-delete mechanism. This ensures that when recruiters remove a job posting, candidates do not lose the historical records of their job applications from their dashboards, significantly improving candidate UX.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #1705

## Changes Made

- Added `"archived"` to the `status` enum validation arrays in both the `JobPosting` and `JobApplication` database models.
- Refactored the `deleteJob` method in the jobs service to use `findByIdAndUpdate` and `updateMany` instead of hard deletion (`deleteMany` / `findByIdAndDelete`).
- Configured the deletion process to automatically push an explanatory comment to the `statusHistory` array of all associated job applications when a job is archived.
- Updated the `getRecruiterAnalytics` object payload to safely parse and ignore `"archived"` job statuses without breaking the analytics dashboard.

## Validation

- [x] Build passes locally
- [ ] Relevant tests added/updated
- [ ] Documentation updated (if needed)

