### PR TITLE
fix : removed unnecessary async from generateComparisonInsights

### DIFF
--- a/server/src/utils/aiComparison.js
+++ b/server/src/utils/aiComparison.js
@@ -2,7 +2,7 @@
  * Generates deterministic strategic insights by comparing two resume versions.
  * No LLM/AI required - follows rule-based logic.
  */
-export const generateComparisonInsights = async (v1, v2) => {
+export const generateComparisonInsights = (v1, v2) => {
   const scoreDiff = v2.score - v1.score;
   const oldSkills = new Set(v1.skills || []);
   const newSkills = new Set(v2.skills || []);


### PR DESCRIPTION
Closes #1710.

Summary of What Has Been Done:
Removed the misleading async keyword from generateComparisonInsights in server/src/utils/aiComparison.js. The function never uses await internally and always returns a plain string, so wrapping it in a Promise adds no value and misleads callers.

Changes Made:
- server/src/utils/aiComparison.js: removed async keyword from function declaration (body unchanged)

Impact it Made:
- Cleaner function signature — callers no longer need to await a synchronous result
- No functional change; the existing await in the controller (server/src/modules/resumes/controller.js) still works correctly since await on a non-Promise is a no-op
- No tests broken (function had no test dependency on async behavior)

Note: Please assign this PR to the `tmdeveloper007` account.