### PR TITLE
fix(upload): prevent event loop blocking during resume validation

### DIFF
--- a/server/src/middleware/uploadResume.js
+++ b/server/src/middleware/uploadResume.js
@@ -4,7 +4,7 @@ import fsPromises from "fs/promises";
 import path from "path";
 import AppError from "../utils/AppError.js";
 import { fileURLToPath } from "url";
-import { validateResumeBufferSignatureSync } from "../utils/validateFileSignature.js";
+import { validateResumeBufferSignature } from "../utils/validateFileSignature.js";
 import asyncHandler from "../utils/asyncHandler.js";
 import logger from "../utils/logger.js";
 
@@ -181,8 +181,8 @@ export const validateAndPersistResumeFile = asyncHandler(async (req, res, next) 
     return next();
   }
 
-  // Synchronously validate the magic bytes of the memory buffer
-  const signatureCheck = validateResumeBufferSignatureSync(
+  // Asynchronously validate the magic bytes of the memory buffer
+  const signatureCheck = await validateResumeBufferSignature(
     req.file.buffer,
     req.file.originalname
   );

--- a/server/src/utils/validateFileSignature.js
+++ b/server/src/utils/validateFileSignature.js
@@ -110,6 +110,39 @@ const validateHeaderForExtension = (header, extension) => {
 };
 
 /**
+ * Validate magic bytes from an in-memory buffer asynchronously.
+ * Offloads validation to the next tick to prevent event loop blocking.
+ * @param {Buffer} buffer
+ * @param {string} originalName
+ * @returns {Promise<{ valid: boolean, message?: string }>}
+ */
+export const validateResumeBufferSignature = (buffer, originalName) => {
+  return new Promise((resolve) => {
+    setImmediate(() => {
+      const extension = getExtension(originalName);
+
+      if (!extension) {
+        return resolve({
+          valid: false,
+          message:
+            "Unsupported file type. Only PDF, DOC, DOCX, and TXT files are allowed.",
+        });
+      }
+
+      if (!buffer || !buffer.length) {
+        return resolve({
+          valid: false,
+          message: "The uploaded file is empty.",
+        });
+      }
+
+      resolve(validateHeaderForExtension(sampleHeader(buffer), extension));
+    });
+  });
+};
+
+/**
+ * @deprecated Use validateResumeBufferSignature instead
  * Validate magic bytes from an in-memory buffer (before any disk write).
  * @param {Buffer} buffer
  * @param {string} originalName


### PR DESCRIPTION
## Summary

Refactored resume file signature validation to use an asynchronous implementation, preventing event loop blocking during concurrent file uploads. Updated the upload middleware to await the new async validation method while retaining the legacy synchronous method for backward compatibility.

## Type of Change

* [ ] Feature
* [x] Bug fix
* [ ] Refactor
* [ ] Documentation
* [ ] Chore

## Related Issue

Closes #1728 

## Changes Made

* Added `validateResumeBufferSignature` (async) in `server/src/utils/validateFileSignature.js` that returns a Promise and defers validation using `setImmediate`.
* Marked `validateResumeBufferSignatureSync` as `@deprecated` to maintain backward compatibility.
* Updated `server/src/middleware/uploadResume.js` to use and await the new asynchronous validation method.
* Reduced the risk of Node.js event loop blocking and request latency spikes during high-volume resume uploads.

## Validation

* [x] Build passes locally
* [ ] Relevant tests added/updated
* [ ] Documentation updated (if needed)

## Screenshots (if UI change)

N/A – Backend-only change with no UI impact.
