### PR TITLE
Fix/redis health readiness state

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -220,7 +220,7 @@ app.get("/health", (req, res) => {
   res.json({
     status: "OK",
     db: isConnected ? "connected" : "disconnected",
-    redis: globalThis.__REDIS_READY__ ? "connected" : "disconnected",
+    redis: redisClient?.isReady ? "connected" : "disconnected",
   });
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -181,7 +181,6 @@ app.use("/api", globalLimiter);
 
 // Safe startup: MongoDB/Redis may be temporarily unavailable.
 // Keep server running in degraded mode instead of crashing the process.
-let didConnectRedis = false;
 try {
   await connectDB();
   
@@ -203,7 +202,6 @@ try {
 
 try {
   await connectRedis();
-  didConnectRedis = true;
 } catch (err) {
   logger.error(
     "Redis startup error (degraded mode):",
@@ -211,8 +209,7 @@ try {
   );
 }
 
-// Expose a simple readiness signal for /health without relying on redisClient internals.
-globalThis.__REDIS_READY__ = didConnectRedis;
+
 
 logEvaluatorConfig();
 


### PR DESCRIPTION
## Summary

Resolved the fragile Redis readiness tracking mechanism by removing the startup-time global readiness flag and using the Redis client's live connection state. The `/health` endpoint now reports accurate Redis status during disconnects, reconnects, and failover events.

## Type of Change

* [ ] Feature
* [x] Bug fix
* [ ] Refactor
* [ ] Documentation
* [ ] Chore

## Related Issue

Closes #1730 

## Changes Made

* Updated the `/health` endpoint to query `redisClient?.isReady` directly instead of relying on a global readiness variable.
* Removed the `didConnectRedis` startup tracking logic from `server/index.js`.
* Removed the `globalThis.__REDIS_READY__` assignment and related state management.
* Improved health check accuracy by ensuring Redis status reflects the client's current runtime state.

## Validation

* [x] Build passes locally
* [ ] Relevant tests added/updated
* [ ] Documentation updated (if needed)

## Screenshots (if UI change)

N/A – Backend-only change with no UI impact.
