### PR TITLE
Improve Auth Performance with Redis User Caching and Cache Invalidation Strategy

### DIFF
--- a/server/src/middleware/authMiddleware.js
+++ b/server/src/middleware/authMiddleware.js
@@ -3,6 +3,43 @@ import User from "../database/models/User.js";
 import AppError from "../utils/AppError.js";
 import asyncHandler from "../utils/asyncHandler.js";
 import { isTokenBlacklisted } from "../utils/tokenBlacklist.js";
+import redisClient from "../config/redis.js";
+
+export const invalidateUserCache = async (userId) => {
+  if (redisClient && redisClient.isReady) {
+    try {
+      await redisClient.del(`user_cache:${userId}`);
+    } catch (err) {}
+  }
+};
+
+const getCachedUser = async (userId) => {
+  const cacheKey = `user_cache:${userId}`;
+  let currentUser = null;
+
+  if (redisClient && redisClient.isReady) {
+    try {
+      const cached = await redisClient.get(cacheKey);
+      if (cached) {
+        currentUser = JSON.parse(cached);
+        if (currentUser.passwordChangedAt) {
+          currentUser.passwordChangedAt = new Date(currentUser.passwordChangedAt);
+        }
+      }
+    } catch (err) {}
+  }
+
+  if (!currentUser) {
+    currentUser = await User.findById(userId).select("-password");
+    if (currentUser && redisClient && redisClient.isReady) {
+      try {
+        await redisClient.setEx(cacheKey, 3600, JSON.stringify(currentUser));
+      } catch (err) {}
+    }
+  }
+
+  return currentUser;
+};
 
 /**
  * Middleware to protect routes - checks if user is logged in
@@ -35,7 +72,7 @@ export const protect = asyncHandler(async (req, res, next) => {
     }
 
     // 4) Check if user still exists
-    const currentUser = await User.findById(decoded.userId).select("-password");
+    const currentUser = await getCachedUser(decoded.userId);
     if (!currentUser) {
       return next(
         new AppError("The user belonging to this token no longer exists.", 401)
@@ -116,7 +153,7 @@ export const verifySocketToken = async (token) => {
     throw new Error("Token has been revoked");
   }
 
-  const user = await User.findById(decoded.userId).select("-password");
+  const user = await getCachedUser(decoded.userId);
   if (!user) {
     throw new Error("User not found");
   }

--- a/server/src/modules/users/controller.js
+++ b/server/src/modules/users/controller.js
@@ -12,6 +12,7 @@ import fsPromises from "fs/promises";
 import AppError from "../../utils/AppError.js";
 import asyncHandler from "../../utils/asyncHandler.js";
 import { cascadeDeleteUser } from "../../utils/cascadeDelete.js";
+import { invalidateUserCache } from "../../middleware/authMiddleware.js";
 
 import { safeDeleteAvatarByUrl } from "../../utils/fileUtils.js";
 import { deleteCloudinaryAsset, uploadAvatarBuffer } from "../../config/cloudinary.js";
@@ -202,6 +203,8 @@ export const updatePreferences = asyncHandler(async (req, res, next) => {
   user.preferences = preferences;
   await user.save({ validateModifiedOnly: true });
 
+  await invalidateUserCache(req.user._id);
+
   res.status(200).json({
     success: true,
     message: "Preferences updated successfully",
@@ -237,6 +240,8 @@ export const onboardUser = asyncHandler(async (req, res, next) => {
   if (!updatedUser) {
     return next(new AppError("User not found", 404));
   }
+
+  await invalidateUserCache(req.user._id);
 
   res.status(200).json({
     success: true,
@@ -319,6 +324,8 @@ const updatedUser = await User.findByIdAndUpdate(
         { new: true, runValidators: true }
       ).select("-password -__v");
 
+      await invalidateUserCache(req.user._id);
+
       return res.status(200).json({
         success: true,
         message: "Profile updated successfully",
@@ -326,6 +333,8 @@ const updatedUser = await User.findByIdAndUpdate(
       });
     }
   }
+
+  await invalidateUserCache(req.user._id);
 
   res.status(200).json({
     success: true,
@@ -373,6 +382,8 @@ export const uploadAvatar = asyncHandler(async (req, res, next) => {
       return next(new AppError("User not found", 404));
     }
 
+    await invalidateUserCache(req.user._id);
+
     if (previousPublicId) {
       await deleteCloudinaryAsset(previousPublicId).catch((error) => {
         logger.error("[uploadAvatar] Failed to delete previous Cloudinary avatar:", error.message);
@@ -417,6 +428,8 @@ export const removeAvatar = asyncHandler(async (req, res, next) => {
     safeDeleteAvatarByUrl(previousProfilePic);
   }
 
+  await invalidateUserCache(req.user._id);
+
   res.status(200).json({
     success: true,
     message: "Profile photo removed",
@@ -438,6 +451,7 @@ export const deleteProfile = asyncHandler(async (req, res, next) => {
   }
 
   await cascadeDeleteUser(userId);
+  await invalidateUserCache(userId);
 
   res.status(200).json({
     success: true,


### PR DESCRIPTION
## Summary

Introduced Redis-based caching for authenticated user data to reduce repeated MongoDB queries in authentication middleware. The `protect` and `verifySocketToken` middlewares now use a shared `getCachedUser` helper that reads from Redis first and falls back to MongoDB on cache miss, with automatic cache population and TTL handling.

Cache invalidation was also implemented to ensure consistency when user data changes.

---

## Type of Change

* [ ] Feature
* [x] Bug fix
* [x] Refactor
* [ ] Documentation
* [ ] Chore

---

## Related Issue

Closes #1732 

---

## Changes Made

* Refactored `protect` middleware to use `getCachedUser` for Redis-first user retrieval.
* Updated `verifySocketToken` middleware to use the same caching logic for consistency.
* Implemented Redis-first lookup with MongoDB fallback and automatic cache population (1-hour TTL).
* Added `invalidateUserCache` utility to remove stale user cache entries.
* Integrated cache invalidation into user controllers (profile updates, preferences, avatar changes) to ensure data consistency.
* Reduced redundant MongoDB queries during authentication flows.

---

## Validation

* [x] Build passes locally
* [ ] Relevant tests added/updated
* [ ] Documentation updated (if needed)

---

## Screenshots (if UI change)

N/A – Backend-only change with no UI impact.
