### PR TITLE
fix : added EMAIL_PORT type comparison fix in emailService

### DIFF
--- a/server/src/utils/emailService.js
+++ b/server/src/utils/emailService.js
@@ -32,7 +32,7 @@ export const sendEmail = async (to, subject, text, html) => {
   const transporter = nodemailer.createTransport({
     host: process.env.EMAIL_HOST,
     port: parseInt(process.env.EMAIL_PORT, 10) || 587,
-    secure: process.env.EMAIL_PORT === 465, // true for 465, false for other ports
+    secure: parseInt(process.env.EMAIL_PORT || "587", 10) === 465, // true for 465, false for other ports
     auth: {
       user: process.env.EMAIL_USER,
       pass: process.env.EMAIL_PASS,


### PR DESCRIPTION
Closes #1740.

Summary of What Has Been Done:
Fixed the nodemailer transport configuration in emailService.js where the secure option compared the EMAIL_PORT environment variable (a string) directly to the integer 465, always evaluating to false. Changed to parse the port as an integer before comparing.

Changes Made:
- server/src/utils/emailService.js: Changed secure option from `process.env.EMAIL_PORT === 465` to `parseInt(process.env.EMAIL_PORT || "587", 10) === 465`

Impact it Made:
- SMTP connections on port 465 will now correctly use TLS/SSL
- Verified: node --check passes, eslint passes with zero warnings

Note: Please assign this PR to the `tmdeveloper007` account.