### PR TITLE
test : added unit tests for useDocumentTitle hook

### DIFF
--- a/client/src/hooks/__tests__/useDocumentTitle.test.tsx
+++ b/client/src/hooks/__tests__/useDocumentTitle.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDocumentTitle } from "../useDocumentTitle";
+
+describe("useDocumentTitle", () => {
+  const originalTitle = document.title;
+
+  afterEach(() => {
+    document.title = originalTitle;
+  });
+
+  it("sets document title to title plus suffix on mount", () => {
+    const { result } = renderHook(() => useDocumentTitle("Dashboard"));
+    expect(document.title).toBe("Dashboard | SkillSphere AI");
+  });
+
+  it("sets document title to default when title prop is empty string", () => {
+    const { result } = renderHook(() => useDocumentTitle(""));
+    expect(document.title).toBe("SkillSphere AI");
+  });
+
+  it("restores original document title on unmount", () => {
+    document.title = "Original Title";
+    const { unmount } = renderHook(() => useDocumentTitle("Temp Title"));
+    expect(document.title).toBe("Temp Title | SkillSphere AI");
+    unmount();
+    expect(document.title).toBe("Original Title");
+  });
+
+  it("updates document title when title prop changes", () => {
+    const { result, rerender } = renderHook(
+      ({ title }) => useDocumentTitle(title),
+      { initialProps: { title: "Page One" } },
+    );
+    expect(document.title).toBe("Page One | SkillSphere AI");
+
+    rerender({ title: "Page Two" });
+    expect(document.title).toBe("Page Two | SkillSphere AI");
+  });
+
+  it("handles null-like title gracefully", () => {
+    // @ts-expect-error intentionally passing invalid prop
+    const { result } = renderHook(() => useDocumentTitle(null));
+    expect(document.title).toBe("SkillSphere AI");
+  });
+});


### PR DESCRIPTION
Closes #1745.

Summary of What Has Been Done:
Added 5 unit tests for the useDocumentTitle React hook covering title formatting with the platform suffix, default fallback, unmount restoration, title prop change reactivity, and null handling.

Changes Made:
- client/src/hooks/__tests__/useDocumentTitle.test.tsx: New test file with 5 test cases

Impact it Made:
- useDocumentTitle hook now has test coverage
- All 5 tests pass locally via Vitest

Note: Please assign this PR to the `tmdeveloper007` account.