### PR TITLE
fix(backend): Move mongodb-memory-server to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4191,6 +4191,7 @@
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -4309,6 +4310,7 @@
     },
     "node_modules/bare-events": {
       "version": "2.8.3",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -4321,6 +4323,7 @@
     },
     "node_modules/bare-fs": {
       "version": "4.7.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -4343,6 +4346,7 @@
     },
     "node_modules/bare-os": {
       "version": "3.9.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -4350,6 +4354,7 @@
     },
     "node_modules/bare-path": {
       "version": "3.0.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-os": "^3.0.1"
@@ -4357,6 +4362,7 @@
     },
     "node_modules/bare-stream": {
       "version": "2.13.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "streamx": "^2.25.0",
@@ -4381,6 +4387,7 @@
     },
     "node_modules/bare-url": {
       "version": "2.4.3",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -4669,6 +4676,7 @@
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -4771,6 +4779,7 @@
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5146,6 +5155,7 @@
     },
     "node_modules/commondir": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/compressible": {
@@ -7292,6 +7302,7 @@
     },
     "node_modules/events-universal": {
       "version": "1.0.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
@@ -7430,6 +7441,7 @@
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -7598,6 +7610,7 @@
     },
     "node_modules/find-cache-dir": {
       "version": "3.3.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "commondir": "^1.0.1",
@@ -7613,6 +7626,7 @@
     },
     "node_modules/find-cache-dir/node_modules/find-up": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -7624,6 +7638,7 @@
     },
     "node_modules/find-cache-dir/node_modules/locate-path": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -7634,6 +7649,7 @@
     },
     "node_modules/find-cache-dir/node_modules/p-limit": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -7647,6 +7663,7 @@
     },
     "node_modules/find-cache-dir/node_modules/p-locate": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -7657,6 +7674,7 @@
     },
     "node_modules/find-cache-dir/node_modules/pkg-dir": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
@@ -10188,6 +10206,7 @@
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
@@ -11186,6 +11205,7 @@
     },
     "node_modules/mongodb-memory-server": {
       "version": "11.2.0",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -11198,6 +11218,7 @@
     },
     "node_modules/mongodb-memory-server-core": {
       "version": "11.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "async-mutex": "^0.5.0",
@@ -11219,6 +11240,7 @@
     },
     "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
       "version": "7.2.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.3.0",
@@ -11263,6 +11285,7 @@
     },
     "node_modules/mongodb-memory-server-core/node_modules/semver": {
       "version": "7.8.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11434,6 +11457,7 @@
     },
     "node_modules/new-find-package-json": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
@@ -12003,6 +12027,7 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12185,6 +12210,7 @@
     },
     "node_modules/pend": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/perfect-freehand": {
@@ -13576,6 +13602,7 @@
     },
     "node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -14072,6 +14099,7 @@
     },
     "node_modules/streamx": {
       "version": "2.26.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -14444,6 +14472,7 @@
     },
     "node_modules/tar-stream": {
       "version": "3.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
@@ -14454,6 +14483,7 @@
     },
     "node_modules/tar-stream/node_modules/b4a": {
       "version": "1.8.1",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -14473,6 +14503,7 @@
     },
     "node_modules/teex": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "streamx": "^2.12.5"
@@ -14480,6 +14511,7 @@
     },
     "node_modules/text-decoder": {
       "version": "1.2.7",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -14487,6 +14519,7 @@
     },
     "node_modules/text-decoder/node_modules/b4a": {
       "version": "1.8.1",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -16142,6 +16175,7 @@
     },
     "node_modules/yauzl": {
       "version": "3.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
@@ -16268,7 +16302,6 @@
         "jsonwebtoken": "^9.0.3",
         "mammoth": "^1.12.0",
         "mongodb": "^7.2.0",
-        "mongodb-memory-server": "^11.2.0",
         "mongoose": "^9.6.3",
         "multer": "^2.1.1",
         "nodemailer": "^8.0.5",
@@ -16290,6 +16323,7 @@
       "devDependencies": {
         "dependency-cruiser": "^16.10.1",
         "eslint": "^8.57.1",
+        "mongodb-memory-server": "^11.2.0",
         "nodemon": "^3.1.14",
         "socket.io-client": "^4.8.3"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,6 @@
     "jsonwebtoken": "^9.0.3",
     "mammoth": "^1.12.0",
     "mongodb": "^7.2.0",
-    "mongodb-memory-server": "^11.2.0",
     "mongoose": "^9.6.3",
     "multer": "^2.1.1",
     "nodemailer": "^8.0.5",
@@ -50,6 +49,7 @@
   },
   "devDependencies": {
     "dependency-cruiser": "^16.10.1",
+    "mongodb-memory-server": "^11.2.0",
     "eslint": "^8.57.1",
     "nodemon": "^3.1.14",
     "socket.io-client": "^4.8.3"


### PR DESCRIPTION
This PR fixes a severe configuration issue in the backend's package.json where mongodb-memory-server was listed as a production dependency. By moving it to devDependencies, we ensure that production builds will no longer download the unnecessary MongoDB binary. This fix dramatically reduces the production container/deployment size, drastically speeds up the backend build times in CI/CD, and prevents fatal installation crashes in restricted cloud deployment environments that block unauthorized binary executions.

Closes #1773 