### PR TITLE
fix : added sanitizeValue guard on req.ip in requestLogger middleware

### DIFF
--- a/server/src/__tests__/requestLogger.test.js
+++ b/server/src/__tests__/requestLogger.test.js
@@ -1,0 +1,166 @@
+import { describe, test, mock, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverRoot = path.resolve(__dirname, "../..");
+
+// Track what logData is passed to logger
+let loggedData = null;
+const mockLogger = {
+  info: mock.fn((msg, data) => { loggedData = data; }),
+  warn: mock.fn((msg, data) => { loggedData = data; }),
+  error: mock.fn((msg, data) => { loggedData = data; }),
+  debug: mock.fn(),
+};
+
+// Mock logger before importing the module under test
+await mock.module(`file://${serverRoot}/src/utils/logger.js`, {
+  namedExports: {},
+  defaultExport: mockLogger,
+});
+
+const { requestLogger } = await import("../middleware/requestLogger.js");
+
+describe("requestLogger middleware", () => {
+  beforeEach(() => {
+    loggedData = null;
+  });
+
+  test("generates a unique request id via uuid", () => {
+    const next = mock.fn();
+    const req = {
+      method: "GET",
+      originalUrl: "/test",
+      ip: "127.0.0.1",
+      get: () => "test-agent",
+    };
+    const res = { on: () => {}, statusCode: 200 };
+
+    requestLogger(req, res, next);
+
+    assert.ok(req.id, "req.id should be set");
+    assert.equal(typeof req.id, "string");
+    assert.notEqual(req.id.length, 0);
+  });
+
+  test("calls next() immediately", () => {
+    const next = mock.fn();
+    const req = {
+      method: "GET",
+      originalUrl: "/test",
+      ip: "127.0.0.1",
+      get: () => "test-agent",
+    };
+    const res = { on: () => {}, statusCode: 200 };
+
+    requestLogger(req, res, next);
+
+    assert.equal(next.mock.calls.length, 1);
+  });
+
+  test("registers a finish listener on res", () => {
+    const onMock = mock.fn();
+    const req = {
+      method: "GET",
+      originalUrl: "/test",
+      ip: "127.0.0.1",
+      get: () => "test-agent",
+    };
+    const res = { on: onMock, statusCode: 200 };
+
+    requestLogger(req, res, () => {});
+
+    assert.equal(onMock.mock.calls.length, 1);
+    const [event] = onMock.mock.calls[0].arguments;
+    assert.equal(event, "finish");
+  });
+
+  test("ip field goes through sanitizeValue to prevent log injection", async () => {
+    // Craft a request with newline injection in the IP
+    const req = {
+      method: "GET",
+      originalUrl: "/test",
+      ip: "127.0.0.1\n[INJECTED] fake log entry",
+      get: () => "test-agent",
+    };
+    const finishCallbacks = [];
+    const res = {
+      on: (event, cb) => { if (event === "finish") finishCallbacks.push(cb); },
+      statusCode: 200,
+    };
+
+    requestLogger(req, res, () => {});
+    finishCallbacks[0]();
+    await new Promise(resolve => setImmediate(resolve));
+
+    // Verify the ip in loggedData does NOT contain newline (proving sanitizeValue was applied)
+    assert.ok(loggedData, "logger should have been called");
+    assert.ok(
+      !loggedData.ip.includes("\n"),
+      `logData.ip should not contain newline after sanitizeValue. Got: ${JSON.stringify(loggedData.ip)}`
+    );
+  });
+
+  test("url and userAgent also go through sanitizeValue", async () => {
+    const req = {
+      method: "POST",
+      originalUrl: "/api/users?email=user@example.com",
+      ip: "10.0.0.1",
+      get: () => "Mozilla/5.0",
+    };
+    const finishCallbacks = [];
+    const res = {
+      on: (event, cb) => { if (event === "finish") finishCallbacks.push(cb); },
+      statusCode: 200,
+    };
+
+    requestLogger(req, res, () => {});
+    finishCallbacks[0]();
+    await new Promise(resolve => setImmediate(resolve));
+
+    // Verify url in logData was sanitized (email masked)
+    assert.ok(loggedData.url.includes("/api/users"), "url should be logged");
+    // Verify ip was sanitized
+    assert.ok(loggedData.ip.includes("10.0.0.1"), "ip should be logged");
+    // Verify userAgent was sanitized
+    assert.ok(loggedData.userAgent.includes("Mozilla"), "userAgent should be logged");
+  });
+
+  test("logs warning for 4xx status codes without throwing", () => {
+    const next = mock.fn();
+    const req = {
+      method: "POST",
+      originalUrl: "/api/bad",
+      ip: "10.0.0.1",
+      get: () => "test-agent",
+    };
+    const finishCallbacks = [];
+    const res = {
+      on: (event, cb) => { if (event === "finish") finishCallbacks.push(cb); },
+      statusCode: 404,
+    };
+
+    requestLogger(req, res, next);
+    assert.doesNotThrow(() => finishCallbacks[0]());
+  });
+
+  test("logs error for 5xx status codes without throwing", () => {
+    const next = mock.fn();
+    const req = {
+      method: "GET",
+      originalUrl: "/api/crash",
+      ip: "10.0.0.1",
+      get: () => "test-agent",
+    };
+    const finishCallbacks = [];
+    const res = {
+      on: (event, cb) => { if (event === "finish") finishCallbacks.push(cb); },
+      statusCode: 500,
+    };
+
+    requestLogger(req, res, next);
+    assert.doesNotThrow(() => finishCallbacks[0]());
+  });
+});

--- a/server/src/middleware/requestLogger.js
+++ b/server/src/middleware/requestLogger.js
@@ -14,7 +14,7 @@ export const requestLogger = (req, res, next) => {
       url: sanitizeValue(req.originalUrl),
       status: res.statusCode,
       duration: `${duration}ms`,
-      ip: req.ip,
+      ip: sanitizeValue(req.ip),
       userAgent: sanitizeValue(req.get('user-agent'))
     };
 

--- a/server/src/utils/logSanitizer.js
+++ b/server/src/utils/logSanitizer.js
@@ -26,6 +26,10 @@ const PHONE_REGEX = /(?:\+?\d{1,4}[-.\s]?)?(?:\(?\d{2,4}\)?[-.\s]?)?\d{3,4}[-.\s
 export const sanitizeString = (str) => {
   if (typeof str !== "string") return str;
   let sanitized = str;
+  // Strip log-injection characters before masking PII to prevent
+  // crafted values (e.g., newlines in X-Forwarded-For) from injecting
+  // extra entries into structured log files.
+  sanitized = sanitized.replace(/[\n\r]+/g, "");
   sanitized = sanitized.replace(EMAIL_REGEX, "[MASKED_EMAIL]");
   sanitized = sanitized.replace(PHONE_REGEX, "[MASKED_PHONE]");
   return sanitized;


### PR DESCRIPTION
Closes #1787.

Summary of What Has Been Done:
Fixed the requestLogger middleware to pass the req.ip field through sanitizeValue before including it in log output. The fix also enhances sanitizeString to strip newline and carriage-return characters to prevent log-injection attacks via crafted X-Forwarded-For headers.

Changes Made:
- server/src/middleware/requestLogger.js: changed ip: req.ip to ip: sanitizeValue(req.ip)
- server/src/utils/logSanitizer.js: sanitizeString now strips log-injection characters (newlines, CR) before PII masking
- server/src/__tests__/requestLogger.test.js: 7 new tests covering the fix

Impact it Made:
- Closes log-injection vector where a crafted X-Forwarded-For header could inject fake log entries
- Makes ip field consistent with url and userAgent sanitization
- All 7 new tests pass; no regression in existing test suite

Note: Please assign this PR to the `tmdeveloper007` account.