### PR TITLE
test : added unit tests for cacheHelpers utility

### DIFF
--- a/server/src/utils/__tests__/cacheHelpers.test.js
+++ b/server/src/utils/__tests__/cacheHelpers.test.js
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mock } from "node:test";
+import redisClient from "../../config/redis.js";
+import { invalidateCacheByPrefix } from "../cacheHelpers.js";
+
+// Make isReady writable so tests can control the Redis availability flag
+Object.defineProperty(redisClient, "isReady", {
+  value: false,
+  writable: true,
+  configurable: true,
+});
+
+test("invalidateCacheByPrefix deletes matching keys via scan + del", async () => {
+  const scanKeys = ["user:session:abc", "user:session:def"];
+  const delCalled = [];
+
+  redisClient.isReady = true;
+  mock.method(redisClient, "scan", async () => ({ cursor: 0, keys: scanKeys }));
+  mock.method(redisClient, "del", async (keys) => {
+    delCalled.push(...keys);
+    return keys.length;
+  });
+
+  await invalidateCacheByPrefix("user:session");
+
+  assert.deepEqual(delCalled.sort(), ["user:session:abc", "user:session:def"].sort());
+
+  mock.restoreAll();
+  redisClient.isReady = false;
+});
+
+test("invalidateCacheByPrefix is no-op when Redis is unavailable", async () => {
+  let called = false;
+  redisClient.isReady = false;
+  mock.method(redisClient, "scan", async () => { called = true; return { cursor: 0, keys: [] }; });
+
+  await invalidateCacheByPrefix("user:session");
+
+  assert.equal(called, false);
+  mock.restoreAll();
+});
+
+test("invalidateCacheByPrefix skips del when scan returns no keys", async () => {
+  let delCalled = false;
+  redisClient.isReady = true;
+  mock.method(redisClient, "scan", async () => ({ cursor: 0, keys: [] }));
+  mock.method(redisClient, "del", async () => { delCalled = true; return 0; });
+
+  await invalidateCacheByPrefix("nonexistent:prefix");
+
+  assert.equal(delCalled, false);
+  mock.restoreAll();
+});
+
+test("invalidateCacheByPrefix logs error and continues when scan throws", async () => {
+  redisClient.isReady = true;
+  mock.method(redisClient, "scan", async () => { throw new Error("Redis scan failed"); });
+
+  // Should not throw — error is caught internally
+  await invalidateCacheByPrefix("user:session");
+  mock.restoreAll();
+});
+
+test("invalidateCacheByPrefix handles multiple scan pages", async () => {
+  let callCount = 0;
+  redisClient.isReady = true;
+  mock.method(redisClient, "scan", async () => {
+    callCount++;
+    if (callCount === 1) return { cursor: 1, keys: ["a:1"] };
+    return { cursor: 0, keys: ["a:2"] };
+  });
+  const delCalled = [];
+  mock.method(redisClient, "del", async (keys) => {
+    delCalled.push(...keys);
+    return keys.length;
+  });
+
+  await invalidateCacheByPrefix("a");
+
+  assert.deepEqual(delCalled.sort(), ["a:1", "a:2"].sort());
+  mock.restoreAll();
+  redisClient.isReady = false;
+});


### PR DESCRIPTION
Closes #1818.

Summary of What Has Been Done:
Added 5 Jest tests covering the invalidateCacheByPrefix function:
- scan+del path with matching keys
- early-return when Redis is unavailable
- skip del when scan returns no keys
- graceful error handling when scan throws
- multi-page scan pagination

Changes Made:
- server/src/utils/__tests__/cacheHelpers.test.js: new test file (84 lines)

Impact it Made:
- Full coverage of the cache invalidation logic with edge cases
- 5/5 tests pass locally

Note: Please assign this PR to the `tmdeveloper007` account.