### PR TITLE
fix(tests): Update JobService mocks from delete to update

### DIFF
--- a/server/src/modules/jobs/__tests__/service.test.js
+++ b/server/src/modules/jobs/__tests__/service.test.js
@@ -98,23 +98,23 @@ describe("Job Service", () => {
       mock.method(JobApplication, "find", () => ({
         select: async () => [{ applicant: "applicant123" }]
       }));
-      mock.method(JobApplication, "deleteMany", () => ({ deletedCount: 5 }));
+      mock.method(JobApplication, "updateMany", () => ({ modifiedCount: 5 }));
       const mockQuery = {
         select: mock.fn(() => mockQuery),
         then: function(resolve) { resolve([{ applicant: new mongoose.Types.ObjectId().toString() }]); }
       };
       mock.method(JobApplication, "find", () => mockQuery);
-      mock.method(JobPosting, "findByIdAndDelete", () => mockExistingJob);
+      mock.method(JobPosting, "findByIdAndUpdate", () => mockExistingJob);
       mock.method(Notification, "insertMany", async () => ([{}]));
 
       await jobService.deleteJob(mockJobId, mockRecruiterId);
 
       assert.equal(JobPosting.findById.mock.calls.length, 1);
       assert.equal(JobPosting.findById.mock.calls[0].arguments[0], mockJobId);
-      assert.equal(JobApplication.deleteMany.mock.calls.length, 1);
-      assert.deepEqual(JobApplication.deleteMany.mock.calls[0].arguments, [{ job: mockJobId }]);
-      assert.equal(JobPosting.findByIdAndDelete.mock.calls.length, 1);
-      assert.equal(JobPosting.findByIdAndDelete.mock.calls[0].arguments[0], mockJobId);
+      assert.equal(JobApplication.updateMany.mock.calls.length, 1);
+      assert.deepEqual(JobApplication.updateMany.mock.calls[0].arguments[0], { job: mockJobId });
+      assert.equal(JobPosting.findByIdAndUpdate.mock.calls.length, 1);
+      assert.equal(JobPosting.findByIdAndUpdate.mock.calls[0].arguments[0], mockJobId);
     });
 
     it("should throw AppError(404) if job not found for deletion", async () => {


### PR DESCRIPTION
This PR resolves a major blocker in the backend continuous integration suite where job service tests hung and ultimately failed with a 10000ms timeout error from Mongoose. The root cause was identified as a mismatch in database operation mocking: the implementation leverages JobApplication.updateMany() and JobPosting.findByIdAndUpdate() to archive data when a job is deleted, but the tests were mistakenly asserting against deleteMany() and findByIdAndDelete(). By updating the mocked methods to reflect the actual archival logic—specifically moving from deleteMany to updateMany and findByIdAndDelete to findByIdAndUpdate—this commit ensures that the database calls are intercepted properly. The result is a lightning-fast, 100% passing test execution. This branch was created directly from the pristine main branch to guarantee zero merge conflicts with parallel pull requests.

Closes #1838 