### PR TITLE
fix(security): enforce payload limits and fix authorization bypass in whiteboard handler

### DIFF
--- a/server/src/modules/classrooms/socketHandlers/__tests__/whiteboardHandler.test.js
+++ b/server/src/modules/classrooms/socketHandlers/__tests__/whiteboardHandler.test.js
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import registerWhiteboardHandler, {
   WHITEBOARD_ERROR_CODES,
-  validateWhiteboardStrokePayload,
+  validateExcalidrawElements,
 } from "../whiteboardHandler.js";
 import {
   clearRoomState,
@@ -20,15 +20,10 @@ const restoreEnvValue = (key, value) => {
 };
 
 const validStroke = (overrides = {}) => ({
-  type: "freehand",
+  type: "freedraw",
   x: 0.5,
   y: 0.5,
-  prevX: 0.4,
-  prevY: 0.4,
-  color: "#38bdf8",
-  width: 4,
-  isEraser: false,
-  actionId: "action-1",
+  points: [[0, 0], [1, 1]],
   ...overrides,
 });
 
@@ -99,30 +94,27 @@ describe("whiteboardHandler security", () => {
   it("broadcasts valid drawing events only to the socket classroom room", () => {
     const { handlers, broadcastEmits } = createSocketHarness({ roomId: "room-a" });
 
-    handlers.get("draw-stroke")({
+    handlers.get("excalidraw-update")({
       roomId: "room-a",
-      strokeData: validStroke(),
+      elements: [validStroke()],
     });
 
     assert.equal(broadcastEmits.length, 1);
     assert.equal(broadcastEmits[0].roomId, "room-a");
-    assert.equal(broadcastEmits[0].event, "draw-stroke");
+    assert.equal(broadcastEmits[0].event, "excalidraw-update");
     assert.equal(getRoomState("room-a").whiteboard.length, 1);
     assert.equal(getRoomState("room-b"), undefined);
   });
 
   it("blocks forged room IDs from modifying another classroom whiteboard", () => {
-    getOrCreateRoomState("room-b").whiteboard.push({
-      strokeData: validStroke({ actionId: "existing" }),
-      sender: { id: "other-user" },
-    });
+    getOrCreateRoomState("room-b").whiteboard = [validStroke({ actionId: "existing" })];
     const { handlers, socketEmits, broadcastEmits } = createSocketHarness({
       roomId: "room-a",
     });
 
-    handlers.get("draw-stroke")({
+    handlers.get("excalidraw-update")({
       roomId: "room-b",
-      strokeData: validStroke({ actionId: "forged" }),
+      elements: [validStroke({ actionId: "forged" })],
     });
 
     assert.equal(socketEmits.length, 1);
@@ -133,12 +125,12 @@ describe("whiteboardHandler security", () => {
   });
 
   it("rejects oversized stroke payloads without broadcasting", () => {
-    process.env.MAX_WHITEBOARD_PAYLOAD_BYTES = "80";
+    process.env.MAX_WHITEBOARD_PAYLOAD_BYTES = "10";
     const { handlers, socketEmits, broadcastEmits } = createSocketHarness();
 
-    handlers.get("draw-stroke")({
+    handlers.get("excalidraw-update")({
       roomId: "room-a",
-      strokeData: validStroke({ actionId: "x".repeat(200) }),
+      elements: [{ text: "this text is longer than 10 bytes easily" }],
     });
 
     assert.equal(broadcastEmits.length, 0);
@@ -154,21 +146,18 @@ describe("whiteboardHandler security", () => {
   it("rejects malformed stroke data without broadcasting", () => {
     const malformedStrokes = [
       null,
-      [],
-      { type: "freehand", x: "0.5", y: 0.5 },
-      { type: "freehand", points: [{ x: 0.1 }] },
-      { type: "shape", shape: "polygon", startX: 0, startY: 0, endX: 1, endY: 1 },
-      { type: "text", text: "", x: 0.5, y: 0.5 },
-      { type: "freehand", x: 0.5, y: 0.5, unexpected: "field" },
+      "not an array",
+      123,
+      {},
     ];
 
-    for (const strokeData of malformedStrokes) {
+    for (const elements of malformedStrokes) {
       clearRoomState("room-a");
       const { handlers, socketEmits, broadcastEmits } = createSocketHarness();
 
-      handlers.get("draw-stroke")({
+      handlers.get("excalidraw-update")({
         roomId: "room-a",
-        strokeData,
+        elements,
       });
 
       assert.equal(broadcastEmits.length, 0);
@@ -181,26 +170,39 @@ describe("whiteboardHandler security", () => {
     }
   });
 
-  it("rejects excessive point count and deeply nested payloads", () => {
+  it("blocks non-tutors from clearing canvas via empty excalidraw-update elements array", () => {
+    getOrCreateRoomState("room-a").whiteboard = [validStroke()];
+    const { handlers, socketEmits, broadcastEmits } = createSocketHarness({
+      role: "student"
+    });
+
+    handlers.get("excalidraw-update")({
+      roomId: "room-a",
+      elements: [],
+    });
+
+    assert.equal(broadcastEmits.length, 0);
+    assert.equal(getRoomState("room-a").whiteboard.length, 1);
+    assert.equal(socketEmits.length, 1);
+    assert.equal(socketEmits[0].event, "whiteboard-error");
+    assert.equal(
+      socketEmits[0].payload.errorCode,
+      WHITEBOARD_ERROR_CODES.CLEAR_CANVAS_FORBIDDEN,
+    );
+  });
+
+  it("rejects excessive element count and deeply nested payloads", () => {
     process.env.MAX_WHITEBOARD_POINTS = "2";
     process.env.MAX_WHITEBOARD_PAYLOAD_DEPTH = "3";
 
-    const pointValidation = validateWhiteboardStrokePayload({
-      type: "freehand",
-      points: [
-        { x: 0.1, y: 0.1 },
-        { x: 0.2, y: 0.2 },
-        { x: 0.3, y: 0.3 },
-      ],
-      color: "#38bdf8",
-      width: 4,
-    });
-    const depthValidation = validateWhiteboardStrokePayload({
-      type: "freehand",
-      x: 0.1,
-      y: 0.1,
-      metadata: { a: { b: { c: 1 } } },
-    });
+    const pointValidation = validateExcalidrawElements([
+      { x: 0.1, y: 0.1 },
+      { x: 0.2, y: 0.2 },
+      { x: 0.3, y: 0.3 },
+    ]);
+    const depthValidation = validateExcalidrawElements([{
+      metadata: { a: { b: { c: 1 } } }
+    }]);
 
     assert.equal(pointValidation.isValid, false);
     assert.equal(
@@ -215,10 +217,7 @@ describe("whiteboardHandler security", () => {
   });
 
   it("allows authorized users to clear the canvas", () => {
-    getOrCreateRoomState("room-a").whiteboard.push({
-      strokeData: validStroke(),
-      sender: { id: "user-1" },
-    });
+    getOrCreateRoomState("room-a").whiteboard = [validStroke()];
     const { handlers, broadcastEmits, socketEmits } = createSocketHarness({
       roomId: "room-a",
       role: "tutor",
@@ -234,10 +233,7 @@ describe("whiteboardHandler security", () => {
   });
 
   it("blocks unauthorized users from clearing the canvas", () => {
-    getOrCreateRoomState("room-a").whiteboard.push({
-      strokeData: validStroke(),
-      sender: { id: "user-1" },
-    });
+    getOrCreateRoomState("room-a").whiteboard = [validStroke()];
     const { handlers, broadcastEmits, socketEmits } = createSocketHarness({
       roomId: "room-a",
       role: "student",
@@ -256,10 +252,7 @@ describe("whiteboardHandler security", () => {
   });
 
   it("blocks forged room IDs from clearing another classroom canvas", () => {
-    getOrCreateRoomState("room-b").whiteboard.push({
-      strokeData: validStroke(),
-      sender: { id: "user-2" },
-    });
+    getOrCreateRoomState("room-b").whiteboard = [validStroke()];
     const { handlers, socketEmits, broadcastEmits } = createSocketHarness({
       roomId: "room-a",
       role: "tutor",

--- a/server/src/modules/classrooms/socketHandlers/whiteboardHandler.js
+++ b/server/src/modules/classrooms/socketHandlers/whiteboardHandler.js
@@ -9,10 +9,6 @@ export const WHITEBOARD_ERROR_CODES = {
 const DEFAULT_MAX_WHITEBOARD_PAYLOAD_BYTES = 16 * 1024;
 const DEFAULT_MAX_WHITEBOARD_POINTS = 1_000;
 const DEFAULT_MAX_WHITEBOARD_DEPTH = 6;
-const MAX_TEXT_LENGTH = 500;
-const MAX_STRING_LENGTH = 1_000;
-const ALLOWED_STROKE_TYPES = new Set(["freehand", "shape", "text"]);
-const ALLOWED_SHAPES = new Set(["line", "rect", "circle", "arrow"]);
 const CLEAR_CANVAS_ROLES = new Set(["admin", "tutor"]);
 
 const getPositiveIntEnv = (key, fallback) => {
@@ -57,190 +53,50 @@ const getNestedDepth = (value, seen = new WeakSet()) => {
   return 1 + Math.max(...childValues.map((child) => getNestedDepth(child, seen)));
 };
 
-const isFiniteCoordinate = (value) =>
-  typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
-
-const isSafeString = (value, maxLength = MAX_STRING_LENGTH) =>
-  typeof value === "string" && value.length > 0 && value.length <= maxLength;
-
-const isSafeColor = (value) =>
-  typeof value === "string" && /^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/.test(value);
-
-const isSafeWidth = (value) =>
-  typeof value === "number" && Number.isFinite(value) && value >= 1 && value <= 100;
-
-const isPoint = (value) =>
-  value &&
-  typeof value === "object" &&
-  !Array.isArray(value) &&
-  isFiniteCoordinate(value.x) &&
-  isFiniteCoordinate(value.y);
-
-const hasOnlyAllowedKeys = (value, allowedKeys) =>
-  Object.keys(value).every((key) => allowedKeys.has(key));
-
-const validateFreehandStroke = (strokeData, limits) => {
-  const allowedKeys = new Set([
-    "type",
-    "x",
-    "y",
-    "prevX",
-    "prevY",
-    "points",
-    "color",
-    "width",
-    "isEraser",
-    "actionId",
-  ]);
-
-  if (!hasOnlyAllowedKeys(strokeData, allowedKeys)) return false;
-  if (strokeData.color !== undefined && !isSafeColor(strokeData.color)) return false;
-  if (strokeData.width !== undefined && !isSafeWidth(strokeData.width)) return false;
-  if (strokeData.isEraser !== undefined && typeof strokeData.isEraser !== "boolean") return false;
-  if (strokeData.actionId !== undefined && !isSafeString(strokeData.actionId, 128)) return false;
-
-  if (strokeData.points !== undefined) {
-    return (
-      Array.isArray(strokeData.points) &&
-      strokeData.points.length > 0 &&
-      strokeData.points.length <= limits.maxPoints &&
-      strokeData.points.every(isPoint)
-    );
-  }
-
-  return (
-    isFiniteCoordinate(strokeData.x) &&
-    isFiniteCoordinate(strokeData.y) &&
-    (strokeData.prevX === undefined || isFiniteCoordinate(strokeData.prevX)) &&
-    (strokeData.prevY === undefined || isFiniteCoordinate(strokeData.prevY))
-  );
-};
-
-const validateShapeStroke = (strokeData) => {
-  const allowedKeys = new Set([
-    "type",
-    "shape",
-    "startX",
-    "startY",
-    "endX",
-    "endY",
-    "color",
-    "width",
-    "actionId",
-  ]);
-
-  return (
-    hasOnlyAllowedKeys(strokeData, allowedKeys) &&
-    ALLOWED_SHAPES.has(strokeData.shape) &&
-    isFiniteCoordinate(strokeData.startX) &&
-    isFiniteCoordinate(strokeData.startY) &&
-    isFiniteCoordinate(strokeData.endX) &&
-    isFiniteCoordinate(strokeData.endY) &&
-    (strokeData.color === undefined || isSafeColor(strokeData.color)) &&
-    (strokeData.width === undefined || isSafeWidth(strokeData.width)) &&
-    (strokeData.actionId === undefined || isSafeString(strokeData.actionId, 128))
-  );
-};
-
-const validateTextStroke = (strokeData) => {
-  const allowedKeys = new Set(["type", "text", "x", "y", "color", "size", "actionId"]);
-
-  return (
-    hasOnlyAllowedKeys(strokeData, allowedKeys) &&
-    isSafeString(strokeData.text, MAX_TEXT_LENGTH) &&
-    isFiniteCoordinate(strokeData.x) &&
-    isFiniteCoordinate(strokeData.y) &&
-    (strokeData.color === undefined || isSafeColor(strokeData.color)) &&
-    (strokeData.size === undefined || isSafeWidth(strokeData.size)) &&
-    (strokeData.actionId === undefined || isSafeString(strokeData.actionId, 128))
-  );
-};
-
-export const validateWhiteboardStrokePayload = (strokeData) => {
+export const validateExcalidrawElements = (elements) => {
   const limits = getWhiteboardLimits();
 
-  if (!strokeData || typeof strokeData !== "object" || Array.isArray(strokeData)) {
+  if (!Array.isArray(elements)) {
     return {
       isValid: false,
       error: safeError(
         WHITEBOARD_ERROR_CODES.INVALID_STROKE_PAYLOAD,
-        "Invalid whiteboard stroke payload.",
+        "Invalid whiteboard payload.",
       ),
     };
   }
 
-  if (getPayloadSizeBytes(strokeData) > limits.maxPayloadBytes) {
+  if (getPayloadSizeBytes(elements) > limits.maxPayloadBytes) {
     return {
       isValid: false,
       error: safeError(
         WHITEBOARD_ERROR_CODES.WHITEBOARD_PAYLOAD_TOO_LARGE,
-        "Whiteboard stroke payload is too large.",
+        "Whiteboard payload is too large.",
       ),
     };
   }
 
-  if (getNestedDepth(strokeData) > limits.maxDepth) {
+  if (getNestedDepth(elements) > limits.maxDepth) {
     return {
       isValid: false,
       error: safeError(
         WHITEBOARD_ERROR_CODES.INVALID_STROKE_PAYLOAD,
-        "Invalid whiteboard stroke payload.",
+        "Invalid whiteboard payload.",
       ),
     };
   }
 
-  if (!ALLOWED_STROKE_TYPES.has(strokeData.type)) {
+  if (elements.length > limits.maxPoints) {
     return {
       isValid: false,
       error: safeError(
         WHITEBOARD_ERROR_CODES.INVALID_STROKE_PAYLOAD,
-        "Invalid whiteboard stroke payload.",
+        "Invalid whiteboard payload.",
       ),
     };
   }
 
-  const isValid =
-    (strokeData.type === "freehand" && validateFreehandStroke(strokeData, limits)) ||
-    (strokeData.type === "shape" && validateShapeStroke(strokeData)) ||
-    (strokeData.type === "text" && validateTextStroke(strokeData));
-
-  if (!isValid) {
-    return {
-      isValid: false,
-      error: safeError(
-        WHITEBOARD_ERROR_CODES.INVALID_STROKE_PAYLOAD,
-        "Invalid whiteboard stroke payload.",
-      ),
-    };
-  }
-
-  return { isValid: true, strokeData };
-};
-
-const optimizeStrokePoints = (points) => {
-  if (!Array.isArray(points) || points.length < 3) return points;
-  const optimized = [points[0]];
-  for (let i = 1; i < points.length - 1; i += 1) {
-    const current = points[i];
-    const last = optimized[optimized.length - 1];
-    if (
-      current &&
-      last &&
-      typeof current.x === "number" &&
-      typeof current.y === "number" &&
-      typeof last.x === "number" &&
-      typeof last.y === "number"
-    ) {
-      const dx = current.x - last.x;
-      const dy = current.y - last.y;
-      const distSq = dx * dx + dy * dy;
-      if (distSq > 0.000025) { // 0.005 squared distance
-        optimized.push(current);
-      }
-    }
-  }
-  optimized.push(points[points.length - 1]);
-  return optimized;
+  return { isValid: true, elements };
 };
 
 export const canClearWhiteboard = (socket) =>
@@ -256,8 +112,18 @@ export default function registerWhiteboardHandler(io, socket) {
       return;
     }
 
-    if (!Array.isArray(elements)) {
-      emitWhiteboardError(socket, WHITEBOARD_ERROR_CODES.INVALID_STROKE_PAYLOAD, "Elements must be an array");
+    const validation = validateExcalidrawElements(elements);
+    if (!validation.isValid) {
+      emitWhiteboardError(socket, validation.error.errorCode, validation.error.message);
+      return;
+    }
+
+    if (elements.length === 0 && !canClearWhiteboard(socket)) {
+      emitWhiteboardError(
+        socket,
+        WHITEBOARD_ERROR_CODES.CLEAR_CANVAS_FORBIDDEN,
+        "You are not allowed to clear this whiteboard.",
+      );
       return;
     }
 


### PR DESCRIPTION
This PR resolves two major security vulnerabilities in the live classroom whiteboard functionality. We identified that the excalidraw-update socket listener was blindly accepting incoming payload arrays without applying byte size, element count, or recursion depth limits—exposing the Node.js process to trivial DoS attacks. Additionally, the event allowed malicious users to overwrite the entire board state with an empty array, bypassing the canClearWhiteboard role verification. This commit purges the dead legacy validation code and introduces validateExcalidrawElements, which rigorously checks all incoming payloads against getWhiteboardLimits(). It also explicitly prevents non-tutor users from dispatching empty state arrays. The unit test suite (whiteboardHandler.test.js) has been updated correspondingly to assert these new security guardrails, achieving 100% test passing.

Closes #1842 