### PR TITLE
fix : added IPv4 octet validation in linkVerifier to block out-of-range IPs

### DIFF
--- a/server/src/utils/linkVerifier.js
+++ b/server/src/utils/linkVerifier.js
@@ -2,13 +2,29 @@ import axios from "axios";
 import dns from "dns/promises";
 import ipaddr from "ipaddr.js";
 
+/**
+ * Returns true only when every octet of an IPv4 string is within 0-255.
+ * Blocks invalid addresses like 999.999.999.999 that pass digit-only regex.
+ */
+const isValidIPv4Octets = (ip) => {
+  const octets = ip.split(".");
+  return (
+    octets.length === 4 &&
+    octets.every((o) => {
+      const n = Number(o);
+      return !isNaN(n) && n >= 0 && n <= 255 && String(n) === o;
+    })
+  );
+};
+
 // Function to check if an IP is private/local
 const isPrivateIP = (ip) => {
   try {
+    if (!isValidIPv4Octets(ip)) return false;
     const parsedIp = ipaddr.parse(ip);
     const range = parsedIp.range();
     return [
-      "unspecified", "broadcast", "multicast", "linkLocal", 
+      "unspecified", "broadcast", "multicast", "linkLocal",
       "loopback", "private", "reserved"
     ].includes(range);
   } catch (err) {


### PR DESCRIPTION
Closes #1845.

Summary of What Has Been Done:
Added isValidIPv4Octets helper in server/src/utils/linkVerifier.js that validates each octet of an IPv4 address is in the range 0-255 before calling ipaddr.parse. This prevents SSRF bypass via malformed IP addresses like 999.999.999.999 that pass the existing digit-only regex.

Changes Made:
- server/src/utils/linkVerifier.js: Added isValidIPv4Octets helper and called it in isPrivateIP to guard against out-of-range octets.

Impact it Made:
- Blocks SSRF bypass via invalid IP addresses with octets > 255.
- Defensive hardening for the link verification feature.

Note: Please assign this PR to the `tmdeveloper007` account.