### PR TITLE
fix(frontend): resolve stale closure in fetchApplications hook on My Applications page

### DIFF
--- a/client/src/modules/student-jobs/pages/MyApplicationsPage.tsx
+++ b/client/src/modules/student-jobs/pages/MyApplicationsPage.tsx
@@ -1,5 +1,5 @@
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { useSelector } from "react-redux";
 import { useNavigate, Link } from "react-router-dom";
 import {
@@ -69,7 +69,7 @@ const MyApplicationsPage = () => {
   // For Drag and Drop visual feedback
   const [activeDragCol, setActiveDragCol] = useState(null);
 
-  const fetchApplications = async (page = 1, currentView = viewMode) => {
+  const fetchApplications = useCallback(async (page = 1, currentView = viewMode) => {
     setLoading(true);
     setError(null);
     const limit = currentView === "board" ? 100 : 3;
@@ -92,11 +92,11 @@ const MyApplicationsPage = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [token, viewMode, toast]);
 
   useEffect(() => {
     fetchApplications(viewMode === "list" ? currentPage : 1, viewMode);
-  }, [token, viewMode, currentPage]);
+  }, [fetchApplications, viewMode, currentPage]);
 
   const handlePageChange = (newPage) => {
     if (newPage >= 1 && newPage <= totalPages) {


### PR DESCRIPTION
This PR fixes a critical React Hooks bug in MyApplicationsPage.tsx that caused inconsistent data loading. The fetchApplications function has been properly wrapped in a useCallback hook with its exact dependencies (token, viewMode, and toast) correctly mapped. Consequently, it has been safely added to the useEffect array that watches for page layout shifts. This strictly enforces React's exhaustive-deps rules, preventing stale closures during rapid view mode toggles or pagination, guaranteeing students always see their most up-to-date job application statuses. All frontend linters now pass seamlessly with zero warnings.

Closes #1857 