### PR TITLE
fix(frontend): resolve inconsistent filter state closure in Job Filters component

### DIFF
--- a/client/src/modules/student-jobs/components/JobFilters.tsx
+++ b/client/src/modules/student-jobs/components/JobFilters.tsx
@@ -33,10 +33,12 @@ const JobFilters = ({ onFilterChange }) => {
     if(salaryError) return;
 
     onFilterChange({
-      ...filters,
+      minSalary: filters.minSalary,
+      maxSalary: filters.maxSalary,
+      postedWithin: filters.postedWithin,
       designation: debouncedDesignation,
     });
-  }, [ debouncedDesignation,filters.minSalary,filters.maxSalary, filters.postedWithin, salaryError,]);
+  }, [debouncedDesignation, filters.minSalary, filters.maxSalary, filters.postedWithin, salaryError, onFilterChange]);
 
 
   

--- a/client/src/modules/student-jobs/pages/JobBoardPage.tsx
+++ b/client/src/modules/student-jobs/pages/JobBoardPage.tsx
@@ -67,9 +67,9 @@ const JobBoardPage = () => {
     }
   };
 
-  const handleFilterChange = (newFilters) => {
+  const handleFilterChange = useCallback((newFilters) => {
     setFilters(newFilters);
-  };
+  }, []);
 
   const handleApply = (job) => {
     setApplyModalJob(job);


### PR DESCRIPTION
This PR fixes a frustrating UI bug where the Job Board filters (designation, salary bounds, date) would occasionally fail to synchronize accurately due to stale closures. The JobFilters component was updated to explicitly unpack filter properties rather than blindly spreading a stale state object, perfectly aligning with React's exhaustive-deps rules without breaking the built-in 500ms designation debounce timer. Additionally, the parent JobBoardPage's handleFilterChange was securely memoized using useCallback, ensuring that including onFilterChange in the child's dependency array doesn't accidentally trigger infinite re-renders. All frontend linter warnings associated with this hook have been successfully resolved.

Closes #1859