### PR TITLE
test : added unit tests for uploadPaths resolveUploadPath utility

### DIFF
--- a/server/src/utils/__tests__/uploadPaths.test.js
+++ b/server/src/utils/__tests__/uploadPaths.test.js
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveUploadPath, buildAvatarFileUrl, buildResumeFileUrl } from "../uploadPaths.js";
+
+test("resolveUploadPath rejects null and empty filenames", () => {
+  assert.equal(resolveUploadPath("resumes", null), null);
+  assert.equal(resolveUploadPath("avatars", null), null);
+  assert.equal(resolveUploadPath("resumes", ""), null);
+  assert.equal(resolveUploadPath("avatars", ""), null);
+});
+
+test("resolveUploadPath rejects non-string filenames", () => {
+  assert.equal(resolveUploadPath("resumes", 123), null);
+  assert.equal(resolveUploadPath("avatars", undefined), null);
+  assert.equal(resolveUploadPath("resumes", {}), null);
+});
+
+test("resolveUploadPath blocks path traversal with ..", () => {
+  assert.equal(resolveUploadPath("resumes", "../etc/passwd"), null);
+  assert.equal(resolveUploadPath("avatars", "avatars/../../secret.png"), null);
+  assert.equal(resolveUploadPath("resumes", "..\\windows\\system32\\config"), null);
+});
+
+test("resolveUploadPath blocks filenames with path separators", () => {
+  assert.equal(resolveUploadPath("resumes", "myfile/../../../etc/passwd"), null);
+  assert.equal(resolveUploadPath("avatars", "path\\to\\file.png"), null);
+});
+
+test("resolveUploadPath accepts valid filenames", () => {
+  const result = resolveUploadPath("resumes", "resume.pdf");
+  assert.notEqual(result, null);
+  assert.equal(typeof result, "object");
+  assert.equal(result.safeName, "resume.pdf");
+  assert.ok(result.absolutePath.endsWith("resume.pdf"));
+});
+
+test("resolveUploadPath uses avatars directory for avatars subdir", () => {
+  const result = resolveUploadPath("avatars", "avatar.png");
+  assert.notEqual(result, null);
+  assert.ok(result.absolutePath.includes("avatars"));
+});
+
+test("resolveUploadPath uses resumes directory for non-avatars subdir", () => {
+  const result = resolveUploadPath("resumes", "cv.pdf");
+  assert.notEqual(result, null);
+  assert.ok(result.absolutePath.includes("uploads"));
+});
+
+test("resolveUploadPath resolves parent-path traversal attempt to null", () => {
+  // Even though safeName would be '..', the full resolved path escapes uploads dir
+  const result = resolveUploadPath("resumes", "..");
+  assert.equal(result, null);
+});
+
+test("buildAvatarFileUrl returns correct avatar URL", () => {
+  const url = buildAvatarFileUrl("avatar.png");
+  assert.equal(url, "/api/files/avatars/avatar.png");
+});
+
+test("buildResumeFileUrl returns correct resume URL", () => {
+  const url = buildResumeFileUrl("resume.pdf");
+  assert.equal(url, "/api/files/resumes/resume.pdf");
+});


### PR DESCRIPTION
Closes #1861.

Summary of What Has Been Done:
Added 10 unit tests for the resolveUploadPath helper in server/src/utils/uploadPaths.js. Tests cover null/empty input rejection, non-string type rejection, path traversal attack blocking (with '..' and path separators), valid filename resolution to the correct subdirectory, and URL builder functions.

Changes Made:
- server/src/utils/__tests__/uploadPaths.test.js (new file, 10 tests)

Impact it Made:
- Guards against path traversal vulnerabilities in file upload paths
- Improves test coverage for a security-critical utility
- All 10 tests pass locally

Note: Please assign this PR to the `tmdeveloper007` account.