### PR TITLE
test : added unit tests for client authToken utility

### DIFF
--- a/client/src/utils/__tests__/authToken.test.ts
+++ b/client/src/utils/__tests__/authToken.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { getToken, TOKEN_KEY } from "../authToken";
+
+describe("authToken", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("TOKEN_KEY is defined", () => {
+    expect(TOKEN_KEY).toBe("skillssphere.auth.token");
+  });
+
+  it("getToken returns token from localStorage", () => {
+    localStorage.setItem(TOKEN_KEY, "local-storage-token");
+    expect(getToken()).toBe("local-storage-token");
+  });
+
+  it("getToken prefers localStorage over sessionStorage", () => {
+    localStorage.setItem(TOKEN_KEY, "local-token");
+    sessionStorage.setItem(TOKEN_KEY, "session-token");
+    expect(getToken()).toBe("local-token");
+  });
+
+  it("getToken falls back to sessionStorage when localStorage is empty", () => {
+    sessionStorage.setItem(TOKEN_KEY, "session-token");
+    expect(getToken()).toBe("session-token");
+  });
+
+  it("getToken returns null when both storages are empty", () => {
+    expect(getToken()).toBeNull();
+  });
+
+  it("getToken returns null when storage contains empty string", () => {
+    localStorage.setItem(TOKEN_KEY, "");
+    sessionStorage.setItem(TOKEN_KEY, "");
+    expect(getToken()).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1875.

Summary of What Has Been Done:
Added unit tests for the authToken utility in client/src/utils/__tests__/authToken.test.ts. The module exports TOKEN_KEY and getToken() which checks localStorage first, then sessionStorage.

Changes Made:
- Created client/src/utils/__tests__/authToken.test.ts
- 6 test cases covering TOKEN_KEY constant, localStorage priority, sessionStorage fallback, null on empty storage

Impact it Made:
- Test coverage for a small but critical client utility used throughout the app
- Guards against accidental TOKEN_KEY changes breaking token retrieval

Note: Please assign this PR to the `tmdeveloper007` account.