### PR TITLE
fix : added SSR guard to authToken.ts getToken utility

### DIFF
--- a/client/src/utils/authToken.ts
+++ b/client/src/utils/authToken.ts
@@ -1,4 +1,6 @@
 export const TOKEN_KEY = "skillssphere.auth.token";
 
-export const getToken = () =>
-  localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY) || null;
+export const getToken = () => {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(TOKEN_KEY) || sessionStorage.getItem(TOKEN_KEY) || null;
+};


### PR DESCRIPTION
Closes #1881.

Summary of What Has Been Done:
Added a typeof window !== 'undefined' guard in the getToken() function of authToken.ts to prevent ReferenceError when the module is imported in SSR (Server-Side Rendering) contexts. This aligns the file with the established pattern used throughout the codebase.

Changes Made:
- client/src/utils/authToken.ts: Wrapped localStorage/sessionStorage access in SSR guard, returning null when window is not available.

Impact it Made:
- Prevents SSR crashes in components and services that use getToken
- Fixes inconsistency with the rest of the codebase (authSlice, interviewSessionStorage, logger, errorReporter all use typeof guards)

Note: Please assign this PR to the `tmdeveloper007` account.