### PR TITLE
fix(client): support multi-word filler phrases in sentiment logic

### DIFF
--- a/client/src/modules/mock-interview/utils/sentiment.ts
+++ b/client/src/modules/mock-interview/utils/sentiment.ts
@@ -66,14 +66,16 @@ export const analyzeText = (text) => {
 
   // Hesitation Analysis
   const lowerText = text.toLowerCase();
+  const cleanText = lowerText.replace(/[.,!?]/g, '');
   const words = lowerText.split(/\s+/);
   let hesitationCount = 0;
   
-  words.forEach(word => {
-    // Remove punctuation
-    const cleanWord = word.replace(/[.,!?]/g, '');
-    if (FILLER_WORDS.includes(cleanWord)) {
-      hesitationCount++;
+  FILLER_WORDS.forEach(filler => {
+    // Match whole words/phrases to handle both single and multi-word fillers
+    const regex = new RegExp(`\\b${filler}\\b`, 'g');
+    const matches = cleanText.match(regex);
+    if (matches) {
+      hesitationCount += matches.length;
     }
   });
 


### PR DESCRIPTION
This PR resolves a logical bug in the mock interview's hesitation analysis engine (sentiment.ts) where multi-word filler phrases were systematically ignored. The previous implementation split the transcript into an array of individual words before checking against the FILLER_WORDS array, preventing multi-word strings like "you know" or "sort of" from ever matching. The logic has been rewritten to iterate through the FILLER_WORDS array and apply a word-boundary regex (\b${filler}\b) against the entire cleaned transcript string. This ensures that both single-word and multi-word filler phrases are accurately captured and counted towards the user's hesitation score, restoring the intended strictness and accuracy of the interview confidence evaluator.

Closes #1893 