### PR TITLE
fix(server): use word boundary matching in mock evaluator

### DIFF
--- a/server/src/integrations/aiInterviewService.js
+++ b/server/src/integrations/aiInterviewService.js
@@ -131,16 +131,21 @@ const mockEvaluate = (transcript, expectedAnswer, expectedConcepts) => {
 
   // Simple keyword overlap for technical score
   const expectedWords = expectedLower.split(/\s+/).filter((w) => w.length > 3);
-  const matchedWords = expectedWords.filter((w) => transcriptLower.includes(w));
+  const matchedWords = expectedWords.filter((w) => {
+    const regex = new RegExp(`\\b${w}\\b`, "i");
+    return regex.test(transcriptLower);
+  });
   const technical = Math.min(
     100,
     Math.round((matchedWords.length / Math.max(expectedWords.length, 1)) * 100)
   );
 
   // Concept detection via keyword matching
-  const detected = expectedConcepts.filter((c) =>
-    transcriptLower.includes(c.replace(/-/g, " ").toLowerCase())
-  );
+  const detected = expectedConcepts.filter((c) => {
+    const conceptStr = c.replace(/-/g, " ").toLowerCase();
+    const regex = new RegExp(`\\b${conceptStr}\\b`, "i");
+    return regex.test(transcriptLower);
+  });
   const missed = expectedConcepts.filter((c) => !detected.includes(c));
   const relevance = Math.round(
     (detected.length / Math.max(expectedConcepts.length, 1)) * 100


### PR DESCRIPTION
This PR resolves a major scoring logic flaw within the fallback mockEvaluate function used by the AI Interview module. Previously, the evaluator incorrectly utilized String.prototype.includes() to verify the presence of expected technical keywords and concepts within the user's transcribed answer. This permissive substring matching resulted in artificially inflated scores due to false positives (e.g., matching "net" inside "network"). This PR updates the logic to construct a dynamic Regular Expression (new RegExp('\\b' + w + '\\b', 'i')) that relies on strict word boundaries (\b), ensuring that the mock evaluator only awards points for exact token matches, thereby preserving the integrity of the interview scoring system.

Closes #1895 