### PR TITLE
fix: add Zod input validation schemas for interview module endpoints

### DIFF
--- a/server/src/modules/interviews/controller.js
+++ b/server/src/modules/interviews/controller.js
@@ -26,10 +26,6 @@ import { safeDeletePhysicalFile } from "../../utils/fileUtils.js";
 export const startInterview = asyncHandler(async (req, res) => {
   const { topic, difficulty, persona } = req.body;
 
-  if (!topic) {
-    throw new AppError("Topic is required to start an interview", 400);
-  }
-
   const session = await createSession({
     userId: req.user._id,
     topic,
@@ -161,13 +157,6 @@ export const getSessionResults = asyncHandler(async (req, res) => {
  * @access  Private
  */
 export const bookmarkQuestion = asyncHandler(async (req, res) => {
-  if (
-    req.body?.bookmarked !== undefined &&
-    typeof req.body.bookmarked !== "boolean"
-  ) {
-    throw new AppError("bookmarked must be a boolean", 400);
-  }
-
   const bookmark = await updateQuestionBookmark({
     sessionId: req.params.id,
     questionId: req.params.questionId,

--- a/server/src/modules/interviews/routes.js
+++ b/server/src/modules/interviews/routes.js
@@ -2,9 +2,16 @@ import express from "express";
 import multer from "multer";
 import path from "path";
 import { authorizeRoles, protect } from "../../middleware/authMiddleware.js";
+import { validateBody } from "../../middleware/validation.js";
 import cacheMiddleware from "../../middleware/cacheMiddleware.js";
 import { aiActionLimiter } from "../../middleware/rateLimiter.js";
 import AppError from "../../utils/AppError.js";
+import {
+  startInterviewSchema,
+  submitAnswerSchema,
+  submitTutorFeedbackSchema,
+  bookmarkQuestionSchema,
+} from "../../validations/interviews.validation.js";
 import {
   completeInterview,
   bookmarkQuestion,
@@ -189,7 +196,7 @@ router.get("/ai-status", getAIServiceStatus);
  *       201:
  *         description: Session started
  */
-router.post("/start", aiActionLimiter, startInterview);
+router.post("/start", aiActionLimiter, validateBody(startInterviewSchema), startInterview);
 
 /**
  * @openapi
@@ -286,6 +293,7 @@ router.get("/tutor/sessions/:id", authorizeRoles("tutor"), getTutorSession);
 router.post(
   "/tutor/sessions/:id/feedback",
   authorizeRoles("tutor"),
+  validateBody(submitTutorFeedbackSchema),
   submitTutorFeedback,
 );
 
@@ -358,6 +366,7 @@ router.post(
   aiActionLimiter,
   handleAudioUpload,
   validateUploadedAudioFile,
+  validateBody(submitAnswerSchema),
   submitAnswer,
 );
 
@@ -404,7 +413,7 @@ router.post("/:id/complete", completeInterview);
  *       200:
  *         description: Question bookmarked
  */
-router.patch("/:id/questions/:questionId/bookmark", bookmarkQuestion);
+router.patch("/:id/questions/:questionId/bookmark", validateBody(bookmarkQuestionSchema), bookmarkQuestion);
 
 /**
  * @openapi

--- a/server/src/validations/interviews.validation.js
+++ b/server/src/validations/interviews.validation.js
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+/**
+ * Zod validation schemas for interview module endpoints.
+ *
+ * These mirror the constraints defined in the InterviewSession Mongoose model
+ * (`server/src/database/models/InterviewSession.js`) to enforce validation at
+ * the HTTP boundary — before any DB operations run.
+ */
+
+// --- Start Interview ---
+
+export const startInterviewSchema = z.object({
+  topic: z
+    .string({ required_error: "Topic is required to start an interview" })
+    .trim()
+    .min(1, "Topic must not be empty")
+    .max(100, "Topic must be 100 characters or fewer"),
+  difficulty: z
+    .enum(["easy", "medium", "hard"], {
+      errorMap: () => ({ message: "Difficulty must be one of: easy, medium, hard" }),
+    })
+    .optional(),
+  persona: z
+    .string()
+    .trim()
+    .max(50, "Persona must be 50 characters or fewer")
+    .optional(),
+});
+
+// --- Submit Answer ---
+
+export const submitAnswerSchema = z.object({
+  transcript: z
+    .string()
+    .max(50000, "Transcript must be 50,000 characters or fewer")
+    .optional(),
+});
+
+// --- Tutor Feedback ---
+
+const tutorScoresSchema = z
+  .object({
+    technical: z.number().min(0).max(100).optional(),
+    communication: z.number().min(0).max(100).optional(),
+    relevance: z.number().min(0).max(100).optional(),
+  })
+  .strict()
+  .optional();
+
+const answerFeedbackItemSchema = z.object({
+  questionId: z.string({ required_error: "questionId is required" }).min(1),
+  tutorScores: tutorScoresSchema,
+  tutorFeedback: z
+    .string()
+    .max(2000, "Per-answer tutor feedback must be 2,000 characters or fewer")
+    .optional(),
+});
+
+export const submitTutorFeedbackSchema = z.object({
+  tutorOverallScore: z
+    .number({ invalid_type_error: "tutorOverallScore must be a number" })
+    .min(0, "Score must be at least 0")
+    .max(100, "Score must be at most 100")
+    .optional(),
+  tutorOverallFeedback: z
+    .string()
+    .max(5000, "Overall tutor feedback must be 5,000 characters or fewer")
+    .optional(),
+  answersFeedback: z
+    .array(answerFeedbackItemSchema)
+    .max(20, "answersFeedback may contain at most 20 items")
+    .optional(),
+});
+
+// --- Bookmark Question ---
+
+export const bookmarkQuestionSchema = z.object({
+  bookmarked: z.boolean({ invalid_type_error: "bookmarked must be a boolean" }).optional(),
+});


### PR DESCRIPTION
## Overview

Adds Zod-based request validation to the interview module, bringing it in line with the validation approach used across other backend modules.

Previously, several interview endpoints accepted unvalidated request bodies, allowing invalid types, out-of-range values, oversized payloads, and malformed request structures to reach the controller layer.

---

## Related Issue

Closes #1899 

---

## Type of Change

* [x] Bug Fix

## Changes Made

### Validation Schemas

**New File**

```text
server/src/validations/interviews.validation.js
```

Added Zod schemas for:

* Start Interview
* Submit Answer
* Submit Tutor Feedback
* Bookmark Question

### Route Validation

Updated:

```text
server/src/modules/interviews/routes.js
```

Changes:

* Integrated `validateBody()` middleware into the interview routes.
* Applied request validation before controller execution.

### Controller Cleanup

Updated:

```text
server/src/modules/interviews/controller.js
```

Changes:

* Removed redundant manual validation checks now handled by Zod.

### Validation Rules

#### `startInterviewSchema`

* `topic` → Required string, trimmed, 1–100 characters
* `difficulty` → Optional enum (`easy`, `medium`, `hard`)
* `persona` → Optional string, trimmed, maximum 50 characters

#### `submitAnswerSchema`

* `transcript` → Optional string, maximum 50,000 characters

#### `submitTutorFeedbackSchema`

* `tutorOverallScore` → Optional number (0–100)
* `tutorOverallFeedback` → Optional string (max 5,000 characters)
* `answersFeedback` → Optional array (max 20 items)
* `answersFeedback[].questionId` → Required string
* `answersFeedback[].tutorScores` → Optional object (`technical`, `communication`, `relevance`, each 0–100)
* `answersFeedback[].tutorFeedback` → Optional string (max 2,000 characters)

#### `bookmarkQuestionSchema`

* `bookmarked` → Optional boolean

---

## Files Updated

```text
server/src/validations/interviews.validation.js
server/src/modules/interviews/routes.js
server/src/modules/interviews/controller.js
```

---

## Result

The interview module now uses centralized Zod validation, preventing invalid request payloads from reaching the controller layer while maintaining consistency with the validation architecture used throughout the rest of the backend.
