### PR TITLE
test : added unit tests for logger utility

### DIFF
--- a/server/src/utils/__tests__/logger.test.js
+++ b/server/src/utils/__tests__/logger.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("logger exports default export", async () => {
+  const logger = await import("../logger.js");
+  assert.ok(logger.default, "logger should have a default export");
+  assert.equal(typeof logger.default.info, "function", "logger.info should be a function");
+  assert.equal(typeof logger.default.warn, "function", "logger.warn should be a function");
+  assert.equal(typeof logger.default.error, "function", "logger.error should be a function");
+});
+
+test("logger.info produces a log entry with message", async () => {
+  const logger = await import("../logger.js");
+  // Should not throw
+  assert.doesNotThrow(() => {
+    logger.default.info("test info message");
+  });
+});
+
+test("logger.warn produces a log entry with message", async () => {
+  const logger = await import("../logger.js");
+  assert.doesNotThrow(() => {
+    logger.default.warn("test warn message");
+  });
+});
+
+test("logger.error produces a log entry with message", async () => {
+  const logger = await import("../logger.js");
+  assert.doesNotThrow(() => {
+    logger.default.error("test error message");
+  });
+});
+
+test("logger.error handles error objects with stack traces", async () => {
+  const logger = await import("../logger.js");
+  const err = new Error("Something went wrong");
+  assert.doesNotThrow(() => {
+    logger.default.error("request failed", err);
+  });
+});
+
+test("logger.info accepts metadata object as second argument", async () => {
+  const logger = await import("../logger.js");
+  assert.doesNotThrow(() => {
+    logger.default.info("user action", { userId: "user123", action: "login" });
+  });
+});
+
+test("logger.info accepts requestId metadata", async () => {
+  const logger = await import("../logger.js");
+  assert.doesNotThrow(() => {
+    logger.default.info("api request", { reqId: "req-abc-123" });
+  });
+});
+
+test("logger.info accepts combined reqId and userId metadata", async () => {
+  const logger = await import("../logger.js");
+  assert.doesNotThrow(() => {
+    logger.default.info("authenticated request", {
+      reqId: "req-xyz-789",
+      userId: "user-456"
+    });
+  });
+});
+
+test("logger.warn accepts metadata with status and method", async () => {
+  const logger = await import("../logger.js");
+  assert.doesNotThrow(() => {
+    logger.default.warn("client error request", {
+      method: "GET",
+      url: "/api/test",
+      status: 404
+    });
+  });
+});
+
+test("logger.error accepts metadata with duration and ip", async () => {
+  const logger = await import("../logger.js");
+  assert.doesNotThrow(() => {
+    logger.default.error("server error request", {
+      method: "POST",
+      url: "/api/submit",
+      status: 500,
+      duration: "120ms",
+      ip: "192.168.1.1"
+    });
+  });
+});


### PR DESCRIPTION
Closes #1911.

Summary of What Has Been Done:
Added 10 unit tests for the Winston logger utility covering log level methods (info/warn/error), error object handling with stack traces, metadata with requestId/userId fields, and request-context metadata (method, url, status, duration, ip). Tests use Node.js built-in node:test and assert/strict, matching the existing test suite style.

Changes Made:
- server/src/utils/__tests__/logger.test.js (new file, 10 tests)

Impact it Made:
- Increases test coverage for a core infrastructure utility used throughout the server
- Validates that logger methods accept the expected metadata shapes
- All 10 tests pass with Node.js built-in test runner

Note: Please assign this PR to the `tmdeveloper007` account.