### PR TITLE
feat : added x-error-code header to global error handler responses

### DIFF
--- a/server/src/middleware/errorMiddleware.js
+++ b/server/src/middleware/errorMiddleware.js
@@ -272,7 +272,18 @@ const globalErrorHandler = (err, req, res, next) => {
   error.statusCode = error.statusCode ?? err.statusCode ?? 500;
   error.status = error.status ?? err.status ?? "error";
 
+  // Determine a machine-readable error code for the x-error-code header.
+  // Strings are used as-is; numeric codes (e.g. Mongoose 11000) are stringified.
+  const rawCode = error.code;
+  let errorCodeString = "INTERNAL_ERROR";
+  if (typeof rawCode === "string" && rawCode.trim().length > 0) {
+    errorCodeString = rawCode.trim();
+  } else if (typeof rawCode === "number" && Number.isFinite(rawCode)) {
+    errorCodeString = String(rawCode);
+  }
+
   if (process.env.NODE_ENV === "development") {
+    res.setHeader("x-error-code", errorCodeString);
     res.status(error.statusCode).json({
       success: false,
       status: error.status,
@@ -283,6 +294,7 @@ const globalErrorHandler = (err, req, res, next) => {
   } else {
     // Production
     if (error.isOperational) {
+      res.setHeader("x-error-code", errorCodeString);
       res.status(error.statusCode).json({
         success: false,
         status: error.status,
@@ -297,6 +309,7 @@ const globalErrorHandler = (err, req, res, next) => {
       // Frontend may expect `errors` and `statusCode` consistently.
       const statusCode = 500;
 
+      res.setHeader("x-error-code", "INTERNAL_ERROR");
       res.status(statusCode).json({
         success: false,
         status: "error",


### PR DESCRIPTION
Closes #1915.

Summary of What Has Been Done:
Extended the globalErrorHandler in server/src/middleware/errorMiddleware.js to include an x-error-code response header on all error responses. The header carries a machine-readable error code: string codes (e.g. RATE_LIMIT_EXCEEDED) are passed through as-is, numeric codes (e.g. Mongoose 11000) are stringified, and the default is INTERNAL_ERROR for non-operational errors. The header is set before every res.status() call in both development and production branches.

Changes Made:
- server/src/middleware/errorMiddleware.js (added x-error-code header in 3 places)

Impact it Made:
- Provides a stable machine-readable error identifier for frontend error handling
- Enables programmatic error categorization without parsing message text
- Minimal, isolated change that does not affect existing error message structure

Note: Please assign this PR to the `tmdeveloper007` account.