### PR TITLE
feat : added parseSignedUrlExpiry utility to signedFileUrl.js

### DIFF
--- a/server/src/utils/__tests__/signedFileUrl.test.js
+++ b/server/src/utils/__tests__/signedFileUrl.test.js
@@ -5,6 +5,7 @@ import {
   buildSignedFileUrl,
   normalizeProtectedFilePath,
   verifySignedFileUrl,
+  parseSignedUrlExpiry,
 } from "../signedFileUrl.js";
 
 process.env.FILE_URL_SIGNING_SECRET = "test-signing-secret-that-is-long-enough-for-hmac";
@@ -97,4 +98,42 @@ test("buildSignedFileUrl throws when FILE_URL_SIGNING_SECRET is too short", () =
   );
 
   process.env.FILE_URL_SIGNING_SECRET = original;
+});
+
+test("parseSignedUrlExpiry returns expiry for valid future timestamp", () => {
+  const futureExp = Math.floor(Date.now() / 1000) + 3600;
+  const result = parseSignedUrlExpiry(`/api/files/avatars/x.png?exp=${futureExp}&sig=abc`);
+  assert.equal(result, futureExp);
+});
+
+test("parseSignedUrlExpiry returns null for expired timestamp", () => {
+  const pastExp = Math.floor(Date.now() / 1000) - 10;
+  const result = parseSignedUrlExpiry(`/api/files/avatars/x.png?exp=${pastExp}&sig=abc`);
+  assert.equal(result, null);
+});
+
+test("parseSignedUrlExpiry returns null when exp parameter is missing", () => {
+  assert.equal(parseSignedUrlExpiry("/api/files/avatars/x.png?sig=abc"), null);
+  assert.equal(parseSignedUrlExpiry("/api/files/avatars/x.png"), null);
+});
+
+test("parseSignedUrlExpiry returns null for non-numeric exp value", () => {
+  assert.equal(parseSignedUrlExpiry("/api/files/avatars/x.png?exp=not-a-number"), null);
+  assert.equal(parseSignedUrlExpiry("/api/files/avatars/x.png?exp="), null);
+  assert.equal(parseSignedUrlExpiry("/api/files/avatars/x.png?exp=0"), null);
+  assert.equal(parseSignedUrlExpiry("/api/files/avatars/x.png?exp=-10"), null);
+});
+
+test("parseSignedUrlExpiry returns null for null/undefined/empty input", () => {
+  assert.equal(parseSignedUrlExpiry(null), null);
+  assert.equal(parseSignedUrlExpiry(undefined), null);
+  assert.equal(parseSignedUrlExpiry(""), null);
+});
+
+test("parseSignedUrlExpiry handles full URLs with query strings", () => {
+  const futureExp = Math.floor(Date.now() / 1000) + 3600;
+  const result = parseSignedUrlExpiry(
+    `https://example.com/api/files/avatars/x.png?exp=${futureExp}&sig=abc&uid=user1`
+  );
+  assert.equal(result, futureExp);
 });

--- a/server/src/utils/signedFileUrl.js
+++ b/server/src/utils/signedFileUrl.js
@@ -82,3 +82,34 @@ export const verifySignedFileUrl = (path, expiresAt, sig, extra = "") => {
 
   return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(sig));
 };
+
+/**
+ * Extracts and validates the expiry timestamp from a signed URL query string.
+ *
+ * @param {string} url - Full URL or path+query string containing an 'exp' parameter.
+ * @returns {number|null} Numeric expiry timestamp in seconds, or null if missing,
+ *                        invalid, or already expired.
+ */
+export const parseSignedUrlExpiry = (url) => {
+  if (!url || typeof url !== "string") return null;
+
+  let queryString = "";
+
+  if (url.includes("?")) {
+    const parts = url.split("?", 2);
+    queryString = parts[1] || "";
+  }
+
+  const params = new URLSearchParams(queryString);
+  const expValue = params.get("exp");
+
+  if (!expValue) return null;
+
+  const exp = Number(expValue);
+  if (!Number.isFinite(exp) || exp <= 0) return null;
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (exp < nowSeconds) return null;
+
+  return exp;
+};


### PR DESCRIPTION
Closes #1925.

Summary of What Has Been Done:
Added parseSignedUrlExpiry(url) helper to server/src/utils/signedFileUrl.js that extracts and validates the 'exp' query parameter from a signed URL. Returns the numeric expiry timestamp if valid and not expired, null otherwise. Also added 6 unit tests covering valid timestamps, expired timestamps, missing params, non-numeric values, null/undefined/empty input, and full URLs.

Changes Made:
- server/src/utils/signedFileUrl.js: Added parseSignedUrlExpiry function
- server/src/utils/__tests__/signedFileUrl.test.js: Added 6 new tests (14 total, all passing)

Impact it Made:
- Enables lightweight expiry checking without full signature verification
- Reduces code duplication across file authorization checks
- 14/14 tests pass locally, lint clean

Note: Please assign this PR to the `tmdeveloper007` account.