### PR TITLE
fix(backend): resolve whiteboard runtime crash and remove duplicate validation

### DIFF
--- a/server/src/modules/classrooms/socketHandlers/whiteboardHandler.js
+++ b/server/src/modules/classrooms/socketHandlers/whiteboardHandler.js
@@ -99,6 +99,19 @@ export const validateExcalidrawElements = (elements) => {
   return { isValid: true, elements };
 };
 
+export const validateWhiteboardStrokePayload = (element) => {
+  if (!element || typeof element !== "object" || Array.isArray(element)) {
+    return {
+      isValid: false,
+      error: safeError(
+        WHITEBOARD_ERROR_CODES.INVALID_STROKE_PAYLOAD,
+        "Invalid whiteboard element payload."
+      ),
+    };
+  }
+  return { isValid: true, element };
+};
+
 export const canClearWhiteboard = (socket) =>
   CLEAR_CANVAS_ROLES.has(socket.data?.user?.role);
 
@@ -124,11 +137,6 @@ export default function registerWhiteboardHandler(io, socket) {
         WHITEBOARD_ERROR_CODES.CLEAR_CANVAS_FORBIDDEN,
         "You are not allowed to clear this whiteboard.",
       );
-      return;
-    }
-
-    if (elements.length === 0 && !canClearWhiteboard(socket)) {
-      emitWhiteboardError(socket, WHITEBOARD_ERROR_CODES.CLEAR_CANVAS_FORBIDDEN, "You are not allowed to clear this whiteboard.");
       return;
     }
 


### PR DESCRIPTION
This PR fixes a critical bug in the whiteboard socket handler that causes a runtime crash during synchronization. It introduces the missing validateWhiteboardStrokePayload function to properly validate individual Excalidraw payload elements, preventing ReferenceError crashes on the excalidraw-update event. Furthermore, this update cleans up the socket handler by removing redundant duplicate authorization checks for canvas clearing, enhancing overall code maintainability and reliability.

Closes #1931 