### PR TITLE
fix: prevent path traversal in safeDeletePhysicalFile (#1924)

### DIFF
--- a/server/src/utils/fileUtils.js
+++ b/server/src/utils/fileUtils.js
@@ -7,6 +7,8 @@ import logger from "./logger.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const UPLOADS_ROOT = path.join(__dirname, "..", "uploads");
+
 /**
  * Safely deletes a file from the local disk given its relative or absolute path.
  * Suppresses errors if the file doesn't exist or deletion fails.
@@ -18,9 +20,17 @@ export const safeDeletePhysicalFile = (filePath) => {
   if (!filePath) return false;
 
   try {
-    const absolutePath = path.isAbsolute(filePath)
-      ? filePath
-      : path.join(__dirname, "..", "..", filePath);
+    let absolutePath = filePath;
+    
+    if (!path.isAbsolute(filePath)) {
+      absolutePath = path.resolve(UPLOADS_ROOT, filePath);
+    }
+    
+    // Path traversal check: Ensure the resolved path is within UPLOADS_ROOT
+    if (!absolutePath.startsWith(UPLOADS_ROOT + path.sep) && absolutePath !== UPLOADS_ROOT) {
+      logger.warn(`[safeDeletePhysicalFile] Attempted path traversal to delete outside uploads: ${filePath}`);
+      return false;
+    }
     
     if (fs.existsSync(absolutePath)) {
       fs.unlinkSync(absolutePath);


### PR DESCRIPTION
## PR Description

### Description
This PR addresses **Issue #1924** by fixing a potential path traversal vulnerability in `safeDeletePhysicalFile`.

When dealing with relative paths, the function now properly resolves them against the intended `UPLOADS_ROOT` directory instead of blindly traversing upwards with `__dirname` and `..`. Additionally, it implements a security boundary check to ensure that even after path resolution, the final target directory strictly resides within `UPLOADS_ROOT`. Any attempts to resolve files outside this boundary will be instantly blocked and a warning will be logged.

### Changes Made
- Introduced a `UPLOADS_ROOT` constant in `server/src/utils/fileUtils.js`.
- Refactored `safeDeletePhysicalFile` to resolve relative paths against `UPLOADS_ROOT`.
- Added a strict bounds check (`absolutePath.startsWith(UPLOADS_ROOT)`) to prevent directory traversal outside of uploads.
- The function will now cleanly return `false` and log a warning (`logger.warn`) instead of attempting to delete critical system or application files.

### Testing/Verification
- Verified that passing traversal strings (like `../../secret.jpg`) gets blocked safely.
- Verified that valid files are still successfully deleted.

### Related Issue
Closes #1924 

---
*Note: I am a GSSoC (GirlScript Summer of Code) contributor.*
