### PR TITLE
fix: correct import of clearRoomState in classroom service

### DIFF
--- a/server/src/modules/classrooms/service.js
+++ b/server/src/modules/classrooms/service.js
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import ClassroomSession from "../../database/models/ClassroomSession.js";
 import AppError from "../../utils/AppError.js";
-import { clearRoomState, getRoomState } from "./socket.js";
+import { clearRoomState, getRoomState } from "./roomStateManager.js";
 
 /**
  * Create a new live classroom session


### PR DESCRIPTION
Closes #1955

This PR fixes an ESM module resolution crash in the backend tests where `clearRoomState` and `getRoomState` were imported from the wrong module file in the classrooms module. 
## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore
## Related Issue
Closes #1955
## Changes Made
- Updated `server/src/modules/classrooms/service.js` to import `clearRoomState` and `getRoomState` from `./roomStateManager.js` instead of `./socket.js` (since they are not exported from `./socket.js`).
## Verification
- Running `npm run test` inside the `server` workspace successfully resolves the module loading checks and passes the classroom service tests.