### PR TITLE
feat: implement local queueing and flushing for audio chunks on socke…

### DIFF
--- a/client/src/modules/mock-interview/hooks/useInterviewAudio.tsx
+++ b/client/src/modules/mock-interview/hooks/useInterviewAudio.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import logger from "../../../utils/logger";
 
 export const useInterviewAudio = ({
@@ -17,6 +17,7 @@ export const useInterviewAudio = ({
   const mediaStreamRef = useRef(null);
   const mediaTrackCleanupRef = useRef([]);
   const isStartingRef = useRef(false);
+  const audioChunkQueue = useRef([]);
 
   const clearMediaTrackListeners = useCallback(() => {
     mediaTrackCleanupRef.current.forEach((cleanup) => cleanup());
@@ -72,12 +73,22 @@ export const useInterviewAudio = ({
 
       mediaRecorder.ondataavailable = (event) => {
         try {
-          if (event.data.size > 0 && socket && socketStatus === "connected") {
-            setUploadStatus("uploading");
-            socket.emit("audio-chunk", { sessionId, chunk: event.data });
-          } else if (event.data.size > 0) {
-            setUploadStatus("queued");
-            setRecoveryMessage("Audio upload paused until the connection recovers.");
+          if (event.data.size > 0) {
+            if (socket && socketStatus === "connected") {
+              if (audioChunkQueue.current.length > 0) {
+                logger.info(`[InterviewSessionAudio] Flushing ${audioChunkQueue.current.length} queued audio chunks.`);
+                audioChunkQueue.current.forEach((chunk) => {
+                  socket.emit("audio-chunk", { sessionId, chunk });
+                });
+                audioChunkQueue.current = [];
+              }
+              setUploadStatus("uploading");
+              socket.emit("audio-chunk", { sessionId, chunk: event.data });
+            } else {
+              audioChunkQueue.current.push(event.data);
+              setUploadStatus("queued");
+              setRecoveryMessage("Audio upload paused. Chunks are being saved locally.");
+            }
           }
         } catch (err: any) {
           setUploadStatus("failed");
@@ -151,6 +162,21 @@ export const useInterviewAudio = ({
       socket.emit("end-audio-stream", { sessionId });
     }
   }, [clearMediaTrackListeners, sessionId, socket, socketStatus]);
+
+  useEffect(() => {
+    if (isRecording && socket && socketStatus === "connected") {
+      logger.info("[InterviewSessionAudio] Reconnected during active recording. Restarting audio stream.");
+      socket.emit("start-audio-stream", { sessionId });
+      
+      if (audioChunkQueue.current.length > 0) {
+        logger.info(`[InterviewSessionAudio] Flushing ${audioChunkQueue.current.length} queued audio chunks on reconnection.`);
+        audioChunkQueue.current.forEach((chunk) => {
+          socket.emit("audio-chunk", { sessionId, chunk });
+        });
+        audioChunkQueue.current = [];
+      }
+    }
+  }, [socket, socketStatus, isRecording, sessionId]);
 
   return {
     isRecording,


### PR DESCRIPTION
Closes #1958
## Summary
This PR implements a client-side connection recovery flow for real-time audio streaming in the Mock Interview module. Previously, if the socket connection dropped during active audio recording, all recorded audio chunks were discarded. We now cache these chunks locally and flush them in chronological order once the connection is restored.

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue
Closes  #1958

## Changes Made
- Introduced an `audioChunkQueue` ref buffer inside `useInterviewAudio.tsx` to cache recorded chunks during disconnections.
- Updated the `MediaRecorder.ondataavailable` listener to queue chunks locally when `socketStatus !== "connected"`.
- Added a `useEffect` hook that triggers when the socket reconnects (`connected`) during an active recording. It emits `"start-audio-stream"` to establish a new backend WebSocket session and flushes the cached chunks in sequence.

## Verification
- Verified code builds and compiles correctly.