### PR TITLE
fix: implement garbage collection for websocket rate limiter

### DIFF
--- a/server/src/modules/classrooms/socketHandlers/codeEditorHandler.js
+++ b/server/src/modules/classrooms/socketHandlers/codeEditorHandler.js
@@ -9,6 +9,16 @@ const DEFAULT_EXECUTION_RATE_LIMIT_MAX = 5;
 const DEFAULT_EXECUTION_RATE_LIMIT_WINDOW_MS = 60_000;
 const executionAttempts = new Map();
 
+// Periodic cleanup of expired rate limit entries to prevent memory leaks
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, attempt] of executionAttempts.entries()) {
+    if (now >= attempt.resetAt) {
+      executionAttempts.delete(key);
+    }
+  }
+}, 5 * 60 * 1000); // Run every 5 minutes
+
 const getRateLimitConfig = () => {
   const maxAttempts = Number(process.env.CODE_EXECUTION_RATE_LIMIT_MAX);
   const windowMs = Number(process.env.CODE_EXECUTION_RATE_LIMIT_WINDOW_MS);


### PR DESCRIPTION
This PR resolves a critical memory leak in server/src/modules/classrooms/socketHandlers/codeEditorHandler.js. The executionAttempts Map previously grew indefinitely as it stored rate-limiting data without a TTL. A lightweight setInterval cleanup function has been added to run every 5 minutes. This function iterates through the Map and safely deletes entries where the expiration timestamp (resetAt) has passed, ensuring the application's memory footprint remains stable over time.

You can push the newly created branch fix/websocket-rate-limiter-memory-leak to your remote repository and open the PR! Let me know if you want to tackle the next issue.

Closes #1962 