### PR TITLE
fix(frontend): correctly parse hesitations and accurately calculate word counts in sentiment analyzer

### DIFF
--- a/client/src/modules/mock-interview/utils/sentiment.ts
+++ b/client/src/modules/mock-interview/utils/sentiment.ts
@@ -66,7 +66,7 @@ export const analyzeText = (text) => {
 
   // Hesitation Analysis
   const lowerText = text.toLowerCase();
-  const cleanText = lowerText.replace(/[.,!?]/g, '');
+  const cleanText = lowerText.replace(/[.,!?]/g, ' ');
   const words = lowerText.split(/\s+/);
   let hesitationCount = 0;
   

--- a/client/src/modules/mock-interview/utils/sentiment.ts
+++ b/client/src/modules/mock-interview/utils/sentiment.ts
@@ -66,8 +66,8 @@ export const analyzeText = (text) => {
 
   // Hesitation Analysis
   const lowerText = text.toLowerCase();
-  const cleanText = lowerText.replace(/[.,!?]/g, '');
-  const words = lowerText.split(/\s+/);
+  const cleanText = lowerText.replace(/[.,!?]/g, ' ');
+  const words = cleanText.trim().split(/\s+/).filter(Boolean);
   let hesitationCount = 0;
   
   FILLER_WORDS.forEach(filler => {


### PR DESCRIPTION
This PR resolves two critical flaws in the mock interview sentiment analyzer (client/src/modules/mock-interview/utils/sentiment.ts).

Replaced the punctuation stripper (/[.,!?]/g, '') with a space replacer (/[.,!?]/g, ' '). This ensures word boundaries are preserved for concatenated tokens like "um,like" -> "um like", allowing the regex to accurately catch hesitation fillers.
Updated the words array generation to use the spaced cleanText instead of the raw lowerText, and appended .filter(Boolean) to drop empty strings. This guarantees that words.length accurately reflects the true spoken word count, fixing the skewed hesitationRatio math that was artificially destroying candidate confidence scores.

Closes #1965