### PR TITLE
feat: add strict schema validations and unit tests for job postings

### DIFF
--- a/server/src/validations/__tests__/jobsValidation.test.js
+++ b/server/src/validations/__tests__/jobsValidation.test.js
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { jobPostingSchema, updateJobSchema } from "../jobs.validation.js";
+
+const validJobPayload = {
+  title: "Senior Full Stack Engineer",
+  description: "We are looking for a senior full stack developer with experience in React and Node.js to join our core team.",
+  location: {
+    city: "Mumbai",
+    state: "Maharashtra",
+    country: "India",
+    remote: true,
+  },
+  salary: {
+    min: 800000,
+    max: 1500000,
+    currency: "INR",
+    isNegotiable: true,
+  },
+  skills: ["React", "Node.js", "Express", "MongoDB"],
+  experienceRequired: 5,
+  jobLevel: "Mid-Senior Level",
+  status: "open",
+};
+
+test("jobPostingSchema accepts a valid payload", () => {
+  const result = jobPostingSchema.safeParse(validJobPayload);
+  assert.equal(result.success, true);
+  assert.equal(result.data.title, "Senior Full Stack Engineer");
+  assert.equal(result.data.skills[0], "react"); // lowercased
+});
+
+test("jobPostingSchema trims and enforces length constraints on title", () => {
+  // Too short
+  const shortResult = jobPostingSchema.safeParse({
+    ...validJobPayload,
+    title: "  QA  ",
+  });
+  assert.equal(shortResult.success, false);
+  assert.equal(shortResult.error.issues[0].path.join("."), "title");
+  assert.equal(shortResult.error.issues[0].message, "Job title must be at least 5 characters");
+
+  // Too long
+  const longResult = jobPostingSchema.safeParse({
+    ...validJobPayload,
+    title: "a".repeat(101),
+  });
+  assert.equal(longResult.success, false);
+  assert.equal(longResult.error.issues[0].path.join("."), "title");
+  assert.equal(longResult.error.issues[0].message, "Job title cannot exceed 100 characters");
+});
+
+test("jobPostingSchema sanitizes HTML and checks length on description", () => {
+  // Sanitizes and checks length (should fail if length falls below 20 after sanitizing)
+  const htmlPayload = {
+    ...validJobPayload,
+    description: "<script>alert('xss')</script><b>Short</b>",
+  };
+  const result = jobPostingSchema.safeParse(htmlPayload);
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "description");
+  assert.equal(result.error.issues[0].message, "Description must be at least 20 characters");
+
+  // Valid length after sanitization
+  const validHtmlPayload = {
+    ...validJobPayload,
+    description: "<div>This is a very long description that contains some HTML divs but remains long enough.</div>",
+  };
+  const validResult = jobPostingSchema.safeParse(validHtmlPayload);
+  assert.equal(validResult.success, true);
+  assert.equal(validResult.data.description, "This is a very long description that contains some HTML divs but remains long enough.");
+});
+
+test("jobPostingSchema enforces non-negative salary and max >= min", () => {
+  // Negative min
+  const negMin = jobPostingSchema.safeParse({
+    ...validJobPayload,
+    salary: { min: -10, max: 100 },
+  });
+  assert.equal(negMin.success, false);
+  assert.equal(negMin.error.issues[0].path.join("."), "salary.min");
+
+  // max < min
+  const invalidRange = jobPostingSchema.safeParse({
+    ...validJobPayload,
+    salary: { min: 500, max: 400 },
+  });
+  assert.equal(invalidRange.success, false);
+  assert.equal(invalidRange.error.issues[0].path.join("."), "salary.max");
+  assert.equal(invalidRange.error.issues[0].message, "Maximum salary must be greater than or equal to minimum salary");
+});
+
+test("jobPostingSchema requires city and state", () => {
+  const missingCity = jobPostingSchema.safeParse({
+    ...validJobPayload,
+    location: { state: "Maharashtra" },
+  });
+  assert.equal(missingCity.success, false);
+  assert.equal(missingCity.error.issues[0].path.join("."), "location.city");
+});
+
+test("jobPostingSchema normalizes skills to lowercase and trims them", () => {
+  const result = jobPostingSchema.safeParse({
+    ...validJobPayload,
+    skills: ["  React JS  ", "NodeJS", ""],
+  });
+  assert.equal(result.success, true);
+  assert.deepEqual(result.data.skills, ["react js", "nodejs"]);
+});
+
+test("updateJobSchema allows partial updates", () => {
+  const result = updateJobSchema.safeParse({
+    title: "New Title",
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.data.title, "New Title");
+  assert.equal(result.data.description, undefined);
+});

--- a/server/src/validations/jobs.validation.js
+++ b/server/src/validations/jobs.validation.js
@@ -1,12 +1,19 @@
 import { z } from 'zod';
 
 export const jobPostingSchema = z.object({
-  title: z.string().min(3, 'Job title must be at least 3 characters'),
-  description: z.string().min(10, 'Description must be at least 10 characters'),
+  title: z.string()
+    .trim()
+    .min(5, 'Job title must be at least 5 characters')
+    .max(100, 'Job title cannot exceed 100 characters'),
+  description: z.string()
+    .trim()
+    .transform(val => val.replace(/\0/g, "").replace(/<[^>]*>/g, ""))
+    .refine(val => val.length >= 20, { message: 'Description must be at least 20 characters' })
+    .refine(val => val.length <= 5000, { message: 'Description cannot exceed 5000 characters' }),
   location: z.object({
-    city: z.string().min(1, 'City is required'),
-    state: z.string().min(1, 'State is required'),
-    country: z.string().optional(),
+    city: z.string().trim().min(1, 'City is required'),
+    state: z.string().trim().min(1, 'State is required'),
+    country: z.string().trim().optional(),
     remote: z.boolean().optional(),
   }),
   salary: z.object({
@@ -14,8 +21,13 @@ export const jobPostingSchema = z.object({
     max: z.number().min(0, 'Maximum salary cannot be negative'),
     currency: z.string().optional(),
     isNegotiable: z.boolean().optional(),
+  }).refine(data => data.max >= data.min, {
+    message: "Maximum salary must be greater than or equal to minimum salary",
+    path: ["max"]
   }),
-  skills: z.array(z.string()).min(1, 'At least one skill is required'),
+  skills: z.array(z.string().trim())
+    .min(1, 'At least one skill is required')
+    .transform(arr => arr.map(s => s.toLowerCase()).filter(Boolean)),
   experienceRequired: z.number().optional(),
   jobLevel: z.string().optional(),
   requirements: z.array(z.string()).optional(),


### PR DESCRIPTION
Closes #1961

## Summary

This PR implements strict input validation and sanitization rules for creating and updating job postings in the backend using Zod, preventing invalid salary ranges, empty skill lists, or HTML injection.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Related Issue

Closes #1961

## Changes Made

- Updated `server/src/validations/jobs.validation.js` to strictly validate `title` and `description` lengths, strip HTML tags, and normalize skills to lowercase.
- Added a refinement rule in Zod ensuring `max >= min` on the `salary` sub-object.
- Created `server/src/validations/__tests__/jobsValidation.test.js` with comprehensive unit tests for all validation boundaries.

## Validation

- [x] Build passes locally
- [x] Relevant tests added/updated
- [ ] Documentation updated (if needed)


*No UI changes.*